### PR TITLE
Update build.scala for organization and Maven build.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ name := "reach"
 
 version := "1.0"
 
+organization := "edu.arizona.sista"
+
 scalaVersion := "2.11.6"
 
 scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation")
@@ -17,6 +19,51 @@ connectInput in run := true
 
 // don't show output prefix
 outputStrategy := Some(StdoutOutput)
+
+//
+// publishing settings
+//
+
+// publish to a maven repo
+publishMavenStyle := true
+
+// the standard maven repository
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases" at nexus + "service/local/staging/deploy/maven2")
+}
+
+// let’s remove any repositories for optional dependencies in our artifact
+pomIncludeRepository := { _ => false }
+
+// mandatory stuff to add to the pom for publishing
+pomExtra := (
+  <url>https://github.com/clulab/reach</url>
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>https://github.com/clulab/reach</url>
+    <connection>https://github.com/clulab/reach</connection>
+  </scm>
+  <developers>
+    <developer>
+      <id>mihai.surdeanu</id>
+      <name>Mihai Surdeanu</name>
+      <email>mihai@surdeanu.info</email>
+    </developer>
+  </developers>)
+
+//
+// end publishing settings
+//
 
 resolvers ++= Seq(
   "BioPAX Releases" at "http://biopax.sourceforge.net/m2repo/releases",


### PR DESCRIPTION
Hey Mihai,

I'm refactoring my web app's library dependencies so that the web app build system gets them from a local Maven repository. So, I need to be able to publish to my local Maven repository. I copied over the sbt code which (I think) makes this possible in the Processors library to REACH.

I'm requesting this as a pull because I am not sure what other ramifications there might be and would appreciate it if you could review the changes to build.scala. Thanks,
    -t
