### PR TITLE
Test refactor

### DIFF
--- a/src/test/scala/edu/arizona/sista/reach/HypothesisTests.scala
+++ b/src/test/scala/edu/arizona/sista/reach/HypothesisTests.scala
@@ -14,7 +14,7 @@ class HypothesisTests extends FlatSpec with Matchers{
     val sen1 = "RAS suggests the phosphorylation of MEK"
 
     sen1 should "contain a mention with a hyphothesis modification" in {
-      val mentions = parseSentence(sen1).filter(_ matches "Event")
+      val mentions = getBioMentions(sen1).filter(_ matches "Event")
 
       val phospho = mentions filter (_ matches "Phosphorylation")
       getHyphoteses(phospho.head) should have size (1)
@@ -23,7 +23,7 @@ class HypothesisTests extends FlatSpec with Matchers{
     val sen2 = "After extensive experimentation, the process hints that RAS phosphorylates MEK"
 
     sen2 should "contain a mention with a hyphothesis modification" in {
-      val mentions = parseSentence(sen2).filter(_ matches "Event")
+      val mentions = getBioMentions(sen2).filter(_ matches "Event")
 
       val phospho = mentions filter (_ matches "Phosphorylation")
       getHyphoteses(phospho.head) should have size (1)
@@ -32,7 +32,7 @@ class HypothesisTests extends FlatSpec with Matchers{
     val sen3 = "Now, we hypothesize that RAS phosphorylates MEK"
 
     sen3 should "contain a mention with a hyphothesis modification" in {
-      val mentions = parseSentence(sen3).filter(_ matches "Event")
+      val mentions = getBioMentions(sen3).filter(_ matches "Event")
 
       val phospho = mentions filter (_ matches "Phosphorylation")
       getHyphoteses(phospho.head) should have size (1)
@@ -41,7 +41,7 @@ class HypothesisTests extends FlatSpec with Matchers{
     val sen4 = "The presence of p53 indicates the phosphorylation of MEK"
 
     sen4 should "contain a mention with a hyphothesis modification" in {
-      val mentions = parseSentence(sen3).filter(_ matches "Event")
+      val mentions = getBioMentions(sen3).filter(_ matches "Event")
 
       val phospho = mentions filter (_ matches "Phosphorylation")
       getHyphoteses(phospho.head) should have size (1)

--- a/src/test/scala/edu/arizona/sista/reach/NegationTests.scala
+++ b/src/test/scala/edu/arizona/sista/reach/NegationTests.scala
@@ -15,7 +15,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen1 = "RAS does not phosphorylate MEK"
 
     sen1 should "contain a mention with a negation modification" in {
-      val mentions = parseSentence(sen1)
+      val mentions = getBioMentions(sen1)
 
       mentions filter (_ matches "Event") should have size (2)
 
@@ -32,7 +32,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen2 = "RAS doesn't phosphorylate MEK"
 
     sen2 should "contain a mention with a negation modification" in {
-      val mentions = parseSentence(sen2)
+      val mentions = getBioMentions(sen2)
 
       mentions filter (_ matches "Event") should have size (2)
 
@@ -49,7 +49,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen3 = "RAS is not phosphorylating MEK"
 
     sen3 should "contain a mention with a negation modification" in {
-      val mentions = parseSentence(sen3)
+      val mentions = getBioMentions(sen3)
 
       mentions filter (_ matches "Event") should have size (2)
 
@@ -66,7 +66,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen4 = "RAS isn't phosphorylating MEK"
 
     sen4 should "contain a mention with a negation modification" in {
-      val mentions = parseSentence(sen4)
+      val mentions = getBioMentions(sen4)
 
       mentions filter (_ matches "Event") should have size (2)
 
@@ -83,7 +83,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen5 = "RAS wasn't phosphorylated"
 
     sen5 should "contain a mention with a negation modification" in {
-      val mentions = parseSentence(sen5)
+      val mentions = getBioMentions(sen5)
 
       mentions filter (_ matches "Event") should have size (1)
 
@@ -95,7 +95,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen6 = "RAS fails to phosphorylate MEK"
 
     sen6 should "contain a mention with a negation modification" in {
-      val mentions = parseSentence(sen6)
+      val mentions = getBioMentions(sen6)
 
       mentions filter (_ matches "Event") should have size (2)
 
@@ -111,7 +111,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen7 = "RAS fails phosphorylating MEK"
 
     sen7 should "contain a mention with a negation modification" in {
-      val mentions = parseSentence(sen7)
+      val mentions = getBioMentions(sen7)
 
       mentions filter (_ matches "Event") should have size (2)
 
@@ -127,7 +127,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen8 = "RAS plays no role in the phosphorylation of MEK"
 
     sen8 should "contain a mention with a negation modification" in {
-      val mentions = parseSentence(sen8)
+      val mentions = getBioMentions(sen8)
 
       mentions filter (_ matches "Event") should have size (2)
 
@@ -143,7 +143,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen9 = "RAS plays little role in the phosphorylation of MEK"
 
     sen9 should "contain a mention with a negation modification" in {
-      val mentions = parseSentence(sen9)
+      val mentions = getBioMentions(sen9)
 
       mentions filter (_ matches "Event") should have size (2)
 
@@ -161,7 +161,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen10 = "RAS phosphorylates MEK"
 
     sen10 should "not contain a mention with a negation modification" in {
-      val mentions = parseSentence(sen10)
+      val mentions = getBioMentions(sen10)
 
       mentions filter (_ matches "Event") should have size (2)
 
@@ -178,7 +178,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen11 = "RAS doesn't fail to phosphorylate MEK"
 
     sen11 should "not contain any negation mentions" in {
-      val mentions = parseSentence(sen11)
+      val mentions = getBioMentions(sen11)
 
       mentions filter (_ matches "Event") should have size (2)
 
@@ -194,7 +194,7 @@ class NegationTests extends FlatSpec with Matchers{
     val sen12 = "RAS fails not to phosphorylate MEK"
 
     sen12 should "not contain any negation mentions" in {
-      val mentions = parseSentence(sen12)
+      val mentions = getBioMentions(sen12)
 
       mentions filter (_ matches "Event") should have size (2)
 

--- a/src/test/scala/edu/arizona/sista/reach/TestActivationEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestActivationEvents.scala
@@ -16,42 +16,42 @@ class TestActivationEvents extends FlatSpec with Matchers {
   val sent1d = "Addition of Ras inhibits PI3KC2Beta."
   val sent1e = "Increase of Ras dose inhibits PI3KC2Beta."
   sent1 should "contain negative activation patterns" in {
-    var mentions = parseSentence(sent1)
+    var mentions = getBioMentions(sent1)
     mentions.filter(_.label == "Negative_activation") should have size (1)
 
-    mentions = parseSentence(sent1b)
+    mentions = getBioMentions(sent1b)
     mentions.filter(_.label == "Negative_activation") should have size (1)
 
-    mentions = parseSentence(sent1c)
+    mentions = getBioMentions(sent1c)
     mentions.filter(_.label == "Negative_activation") should have size (1)
 
-    mentions = parseSentence(sent1d)
+    mentions = getBioMentions(sent1d)
     mentions.filter(_.label == "Negative_activation") should have size (1)
 
-    mentions = parseSentence(sent1e)
+    mentions = getBioMentions(sent1e)
     mentions.filter(_.label == "Negative_activation") should have size (1)
   }
 
   val sent2 = "Ubiquitinated Ras activates Raf and PI3K."
   val sent2b = "Ubiquitinated Ras increases Raf and PI3K activity."
   sent2 should "contain multiple different positive activations" in {
-    var mentions = parseSentence(sent2)
+    var mentions = getBioMentions(sent2)
     mentions.filter(_.label == "Positive_activation") should have size (2)
 
-    mentions = parseSentence(sent2)
+    mentions = getBioMentions(sent2)
     mentions.filter(_.label == "Positive_activation") should have size (2)
   }
 
   val sent3 = "the phosphorylation of Ras promotes the ubiquitination of MEK"
   sent3 should "contain NO activation events, and a single positive regulation" in {
-    val mentions = parseSentence(sent3)
+    val mentions = getBioMentions(sent3)
     mentions.filter(_.label == "Positive_activation") should have size (0)
     mentions.filter(_.label == "Positive_regulation") should have size (1)
   }
 
   val sent4 = "We observed increased ERBB3 binding to PI3K following MEK inhibition (Figure 1D), and accordingly, MEK inhibition substantially increased tyrosine phosphorylated ERBB3 levels (Figure 1A)."
   sent4 should "contain 1 negative activation and NO positive activation events" in {
-    val mentions = parseSentence(sent4)
+    val mentions = getBioMentions(sent4)
     hasNegativeActivation("MEK", "ERBB3", mentions) should be(true)
     hasPositiveActivation("MEK", "ERBB3", mentions) should be(false)
     mentions.filter(_.label.contains("Positive_regulation")) should have size (0)
@@ -61,7 +61,7 @@ class TestActivationEvents extends FlatSpec with Matchers {
 
   val sent5 = "the suppression of ASPP1 decreases ASPP2."
   sent5 should "contain 1 positive activation and NO negative activation or regulation events" in {
-    val mentions = parseSentence(sent5)
+    val mentions = getBioMentions(sent5)
     hasNegativeActivation("ASPP1", "ASPP2", mentions) should be(false)
     hasPositiveActivation("ASPP1", "ASPP2", mentions) should be(true)
     mentions.filter(_.label.contains("regulation")) should have size (0)
@@ -69,7 +69,7 @@ class TestActivationEvents extends FlatSpec with Matchers {
 
   val sent6 = "ASPP1 is an activator of ASPP2"
   sent6 should "contain 1 positive activation event" in {
-    val mentions = parseSentence(sent6)
+    val mentions = getBioMentions(sent6)
     hasNegativeActivation("ASPP1", "ASPP2", mentions) should be(false)
     hasPositiveActivation("ASPP1", "ASPP2", mentions) should be(true)
     mentions.filter(_.label.contains("regulation")) should have size (0)
@@ -77,7 +77,7 @@ class TestActivationEvents extends FlatSpec with Matchers {
 
   val sent7 = "ASPP1 is an inhibitor of ASPP2"
   sent7 should "contain 1 negative activation event" in {
-    val mentions = parseSentence(sent7)
+    val mentions = getBioMentions(sent7)
     hasNegativeActivation("ASPP1", "ASPP2", mentions) should be(true)
     hasPositiveActivation("ASPP1", "ASPP2", mentions) should be(false)
     mentions.filter(_.label.contains("regulation")) should have size (0)
@@ -85,7 +85,7 @@ class TestActivationEvents extends FlatSpec with Matchers {
 
   val sent8 = "The ASPP2-binding activity of CREB is, in most cases, constitutive."
   sent8 should "contain a binding but not an activation or regulation event" in {
-    val mentions = parseSentence(sent8)
+    val mentions = getBioMentions(sent8)
     mentions.filter(_.label.contains("activation")) should have size (0)
     mentions.filter(_.label.contains("regulation")) should have size (0)
     hasEventWithArguments("Binding", List("ASPP2", "CREB"), mentions) should be(true)
@@ -93,14 +93,14 @@ class TestActivationEvents extends FlatSpec with Matchers {
 
   /*  val sent9 = "HOXB7 overexpression induced a decrease of c-FOS"
   sent9 should "contain 1 negative activation and 0 positive ones" in {
-    val mentions = parseSentence(sent9)
+    val mentions = getBioMentions(sent9)
     mentions.filter(_.label.contains("Transcription")) should have size (1)
     mentions.filter(_.label.contains("Negative_activation")) should have size (1)
   }*/
 
   val sent10 = "The suppression of ASPP1 increases the inhibition of ASPP2."
   sent10 should "contain 1 positive activation and 0 negative ones" in {
-    val mentions = parseSentence(sent10)
+    val mentions = getBioMentions(sent10)
     mentions.filter(_.label.contains("Positive_activation")) should have size (1)
     mentions.filter(_.label.contains("Negative_activation")) should have size (0)
   }
@@ -108,68 +108,68 @@ class TestActivationEvents extends FlatSpec with Matchers {
   // Controller and Controlled cannot be the same entity
   val sent11 = "MEK activates MEK."
   sent11 should "not contain a positive activation" in {
-    val mentions = parseSentence(sent11)
+    val mentions = getBioMentions(sent11)
     mentions.filter(_.label.contains("Positive_activation")) should have size (0)
   }
 
   val sent12 = "mTOR inhibitor Rapamycin"
   sent12 should "contain a negative activation" in {
-    val mentions = parseSentence(sent12)
+    val mentions = getBioMentions(sent12)
     hasNegativeActivation("Rapamycin", "mTOR", mentions) should be(true)
   }
 
   val sent13 = "mTOR activator Rapamycin"
   sent13 should "contain a positive activation" in {
-    val mentions = parseSentence(sent13)
+    val mentions = getBioMentions(sent13)
     hasPositiveActivation("Rapamycin", "mTOR", mentions) should be(true)
   }
 
   val sent14 = "Rapamycin, an inhibitor of the mTOR kinase,"
   sent14 should "contain a negative activation" in {
-    val mentions = parseSentence(sent14)
+    val mentions = getBioMentions(sent14)
     hasNegativeActivation("Rapamycin", "mTOR", mentions) should be(true)
   }
 
   val sent15 = "Rapamycin, an activator of the mTOR kinase,"
   sent15 should "contain a positive activation" in {
-    val mentions = parseSentence(sent15)
+    val mentions = getBioMentions(sent15)
     hasPositiveActivation("Rapamycin", "mTOR", mentions) should be(true)
   }
 
   val sent16 = "Inhibition of mTOR by rapamycin has been standard treatment"
   sent16 should "contain a negative activation (MARCO)" in {
-    val mentions = parseSentence(sent16)
+    val mentions = getBioMentions(sent16)
     // TODO: this works when the text is "Inhibition of mTOR by rapamycin" but not for the full text
     hasNegativeActivation("rapamycin", "mTOR", mentions) should be(true)
   }
 
   val sent17 = "XRCC1 stimulates DNA-PK enzymatic activity"
   sent17 should "contain 1 activation" in {
-    val mentions = parseSentence(sent17)
+    val mentions = getBioMentions(sent17)
     hasPositiveActivation("XRCC1", "DNA-PK", mentions) should be(true)
   }
 
   val sent18 = "Reciprocally, XRCC1 stimulates the kinase activity of DNA-PK on serine 15 of p53 in vitro"
   sent18 should "contain 1 activation" in {
-    val mentions = parseSentence(sent18)
+    val mentions = getBioMentions(sent18)
     hasPositiveActivation("XRCC1", "DNA-PK", mentions) should be(true)
   }
 
   val sent19 = "XRCC1 stimulates DNA-PK catalytic activity in vitro"
   sent19 should "contain 1 activation" in {
-    val mentions = parseSentence(sent19)
+    val mentions = getBioMentions(sent19)
     hasPositiveActivation("XRCC1", "DNA-PK", mentions) should be(true)
   }
 
   val sent20 = "Taken together, these data indicate that XRCC1 strongly stimulates DNA-PK activity and that this stimulatory effect is weakened in the mutant S371D that mimics a phosphorylated status of the BRCT1 domain."
   sent20 should "contain 1 activation" in {
-    val mentions = parseSentence(sent20)
+    val mentions = getBioMentions(sent20)
     hasPositiveActivation("XRCC1", "DNA-PK", mentions) should be(true)
   }
 
   val sent21 = "The phosphorylation of MEK activates K-Ras."
   sent21 should "contain 1 activation with a phosphorylation event as its controller" in {
-    val mentions = parseSentence(sent21)
+    val mentions = getBioMentions(sent21)
     val activations = mentions.filter(_ matches "Positive_activation")
     activations should have size (1)
     val mods = activations.head.arguments("controller").head.toBioMention.modifications.map(_.label)
@@ -178,7 +178,7 @@ class TestActivationEvents extends FlatSpec with Matchers {
 
   val sent22 = "The phosphorylation of MEK deactivates K-Ras."
   sent22 should "contain 1 Negative Activation with a phosphorylation event as its controller" in {
-    val mentions = parseSentence(sent22)
+    val mentions = getBioMentions(sent22)
     val negActs = mentions.filter(_ matches "Negative_activation")
     negActs.length should be (1)
     val mods = negActs.head.arguments("controller").head.toBioMention.modifications.map(_.label)
@@ -190,7 +190,7 @@ class TestActivationEvents extends FlatSpec with Matchers {
   // Relies on COREF
   /*val sent23 = "ASPP1 is common, as is its inhibition by ASPP2."
   sent23 should "contain 1 activation" in {
-    val mentions = parseSentence(sent23)
+    val mentions = getBioMentions(sent23)
     // Two entities and one event
     mentions should have size (3)
     mentions.filter(_ matches "ActivationEvent") should have size (1)
@@ -199,14 +199,14 @@ class TestActivationEvents extends FlatSpec with Matchers {
 
   val sent24 = "Ubiquitinated Ras activates Raf and PI3K more than non-ubiquitinated Ras"
   sent24 should "contain 2 activations" in {
-    val mentions = parseSentence(sent24)
+    val mentions = getBioMentions(sent24)
     hasPositiveActivation("Ras", "Raf", mentions) should be(true)
     hasPositiveActivation("Ras", "PI3K", mentions) should be(true)
   }
 
   val sent25 = "Figure 2 shows that only the K650M and K650E ASPP1 mutants activated STAT1 in 293T and RCS cells."
   sent25 should "contain 2 activations (GUS)" in {
-    val mentions = parseSentence(sent25)
+    val mentions = getBioMentions(sent25)
     // TODO: this fails because we do not capture the 2 mutations for the controller
     mentions.filter(_ matches "ActivationEvent") should have size (2)
     hasPositiveActivation("ASPP1", "STAT1", mentions) should be(true)
@@ -215,14 +215,14 @@ class TestActivationEvents extends FlatSpec with Matchers {
   // test missing controller argument
   val sent26 = "ERK phosphorylation in lysates from A375 expressing indicated ORFs following shRNA mediated C-RAF depletion (shCRAF)."
   sent26 should "not contain a positive activation" in {
-    val mentions = parseSentence(sent26)
+    val mentions = getBioMentions(sent26)
     mentions.filter(_.label.contains("Positive_activation")) should have size (0)
   }
 
   // test normal controller argument
   val sent27 = "Interacting proteins that facilitate FGFR3 mediated STAT1 activation could exist in cells."
   sent27 should "contain 1 activation with a controller" in {
-    val mentions = parseSentence(sent27)
+    val mentions = getBioMentions(sent27)
     val activations = mentions.filter(_ matches "Positive_activation")
     activations should have size (1)
     activations.head.arguments("controller") should have size (1)
@@ -231,7 +231,7 @@ class TestActivationEvents extends FlatSpec with Matchers {
   // tests that controller/controlled don't have overlapping syntactic paths
   val sent28 = "The basal levels of EGFR downstream signaling, shown by the levels of activation specific phosphorylation of Akt, ERK, and STAT3, were not consistently associated with the HER family expression levels or EGFR sequence coding status in a positive or negative manner among the cell lines."
   sent28 should "not contain regulations or activations" in {
-    val mentions = parseSentence(sent28)
+    val mentions = getBioMentions(sent28)
     val regulations = mentions.filter(_ matches "Regulation")
     val activations = mentions.filter(_ matches "ActivationEvent")
     regulations should be ('empty)

--- a/src/test/scala/edu/arizona/sista/reach/TestBindingEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestBindingEvents.scala
@@ -14,7 +14,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
 
   val sent1 = "The ubiquitinated Ras binds AKT and ASPP2."
   sent1 should "contain only binary bindings" in {
-    val mentions = parseSentence(sent1)
+    val mentions = getBioMentions(sent1)
 
     // this MUST produce Binding(Ras, AKT) and Binding(Ras, ASPP2)
 
@@ -29,7 +29,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
 
   val sent2 = "The ubiquitinated Ras protein binds AKT."
   sent2 should "contain a binding when an entity modifies \"protein\"" in {
-    val mentions = parseSentence(sent2)
+    val mentions = getBioMentions(sent2)
 
     // this MUST produce Binding(Ras, AKT)
     val bindings = mentions.filter(_ matches "Binding")
@@ -43,7 +43,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
 
   val sent3 = "AKT binds AKT."
   sent3 should "not contain a binding between two mentions of the same protein" in {
-    val mentions = parseSentence(sent3)
+    val mentions = getBioMentions(sent3)
 
     // this MUST produce no bindings!
     val binds = mentions.find(_ matches "Binding")
@@ -52,7 +52,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
 
   val sent3b = "binding to the L858R EGFR"
   sent3b should "not contain a binding between two mentions of the same protein" in {
-    val mentions = parseSentence(sent3b)
+    val mentions = getBioMentions(sent3b)
 
     // this MUST produce no bindings!
     // something fishy because of PwS (GUS)
@@ -63,7 +63,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
 
   val sent4 = "The AKT binding was successful."
   sent4 should "not contain unary bindings" in {
-    val mentions = parseSentence(sent4)
+    val mentions = getBioMentions(sent4)
     val bindings = mentions.find(_ matches "Binding")
     bindings.isDefined should be (false)
   }
@@ -71,7 +71,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
   val sent5 = "Figure 3. Raf and PI3K bind to ubiquitinated Ras."
   val sent5b = "Figure 3. Raf and PI3K bind more to ubiquitinated Ras than to non-ubiquitinated Ras."
   it should "extract correct bindings with theme and theme2" in {
-    var mentions = parseSentence(sent5)
+    var mentions = getBioMentions(sent5)
     var bs = mentions.filter(_ matches "Binding")
     bs should have size (2)
     for (b <- bs) {
@@ -79,7 +79,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
       b.arguments.get("theme").get.exists(_.text == "Ras") should be (true) // Ras is a theme in all these
     }
 
-    mentions = parseSentence(sent5b)
+    mentions = getBioMentions(sent5b)
     bs = mentions.filter(_ matches "Binding")
     bs should have size (2)
     for (b <- bs) {
@@ -115,7 +115,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
 
   val sent9 = "Mechanistically ASPP1 and ASPP2 bind RAS-GTP and potentiates RAS signalling to enhance p53 mediated apoptosis"
   sent9 should "contain 2 binding events" in {
-    val mentions = parseSentence(sent9)
+    val mentions = getBioMentions(sent9)
     hasEntity("RAS-GTP", mentions) should be (true)
     hasEntity("RAS", mentions) should be (true)
     hasEntity("p53", mentions) should be (true)
@@ -127,21 +127,21 @@ class TestBindingEvents extends FlatSpec with Matchers {
 
   val sent10 = "Moreover, the RAS-ASPP interaction enhances the transcription function of p53 in cancer cells."
   sent10 should "contain 1 binding event" in {
-    val mentions = parseSentence(sent10)
+    val mentions = getBioMentions(sent10)
     // TODO: this requires the splitting of the complex, so it's probably Ok to miss for now
     hasEventWithArguments("Binding", List("RAS", "ASPP"), mentions)
   }
 
   val sent11 = "As expected based on previous studies, wild- type K-Ras bound primarily 32P-GDP, while G12V-Ras bound 32P-GTP (Fig.2, A and B)."
   sent11 should "contain 2 binding events" in {
-    val mentions = parseSentence(sent11)
+    val mentions = getBioMentions(sent11)
     hasEventWithArguments("Binding", List("K-Ras", "32P-GDP"), mentions) should be (true)
     hasEventWithArguments("Binding", List("G12V-Ras", "32P-GTP"), mentions) should be (true)
   }
 
   val sent12 = "GTP loaded Ras induces multiple signaling pathways by binding to its numerous effectors such as Raf and PI3K."
   sent12 should "contain 2 binding events" in {
-    val mentions = parseSentence(sent12)
+    val mentions = getBioMentions(sent12)
     val b = mentions.filter(_ matches "Binding")
     b should have size (2)
     hasEventWithArguments("Binding", List("Ras", "Raf"), mentions) should be (true)
@@ -151,27 +151,27 @@ class TestBindingEvents extends FlatSpec with Matchers {
 
   val sent13 = "ERK negatively regulates the epidermal growth factor mediated interaction of Gab1 and the phosphatidylinositol 3-kinase."
   sent13 should "contain 1 binding event" in {
-    val mentions = parseSentence(sent13)
+    val mentions = getBioMentions(sent13)
     hasEventWithArguments("Binding", List("Gab1", "phosphatidylinositol 3-kinase"), mentions) should be (true)
   }
 
   val sent14 = "Raf and PI3K bind more to ubiquitinated Ras than to non- ubiquitinated Ras To examine whether the binding of ubiquitinated K-Ras to Raf and PI3K inhibits or can actually enhance their kinase activity, both total G12V-K-Ras and the ubiquitinated subfraction of G12V-K-Ras were purified from cell lysates and subjected to an in vitro kinase (I.V.K.) assay (Fig. 4A)."
   sent14 should "contain 2 binding events" in {
-    val mentions = parseSentence(sent14)
+    val mentions = getBioMentions(sent14)
     hasEventWithArguments("Binding", List("Raf", "K-Ras"), mentions) should be (true)
     hasEventWithArguments("Binding", List("PI3K", "K-Ras"), mentions) should be (true)
   }
 
   val sent16 = "We observed increased ERBB3 binding to PI3K following MEK inhibition (Figure 1D), and accordingly, MEK inhibition substantially increased tyrosine phosphorylated ERBB3 levels (Figure 1A)."
   sent16 should "contain 1 binding event" in {
-    val mentions = parseSentence(sent16)
+    val mentions = getBioMentions(sent16)
     hasEventWithArguments("Binding", List("PI3K", "ERBB3"), mentions) should be (true)
   }
 
   val sent17 = "We demonstrate that the RBD of PI3KC2β binds nucleotide-free Ras in vitro."
   sent17 should "contain a binding between PI3KC2β and Ras" in {
 
-    val mentions = parseSentence(sent17)
+    val mentions = getBioMentions(sent17)
 
     val f = mentions.filter(_ matches "Family")
     f should have size (1)
@@ -183,55 +183,55 @@ class TestBindingEvents extends FlatSpec with Matchers {
   }
 
   "testBindingDecl1" should "find 2 binding events" in {
-    val mentions = parseSentence("Mechanistically, ASPP1 and ASPP2 bind RAS-GTP.")
+    val mentions = getBioMentions("Mechanistically, ASPP1 and ASPP2 bind RAS-GTP.")
     hasEventWithArguments("Binding", List("ASPP1", "RAS-GTP"), mentions) should be (true)
     hasEventWithArguments("Binding", List("ASPP2", "RAS-GTP"), mentions) should be (true)
   }
 
   "testBindingDecl2" should "find 2 binding events" in {
-    val mentions = parseSentence("Mechanistically, ASPP1 and ASPP2 bind with RAS-GTP.")
+    val mentions = getBioMentions("Mechanistically, ASPP1 and ASPP2 bind with RAS-GTP.")
     hasEventWithArguments("Binding", List("ASPP1", "RAS-GTP"), mentions) should be (true)
     hasEventWithArguments("Binding", List("ASPP2", "RAS-GTP"), mentions) should be (true)
   }
 
   "testBindingPass1" should "find 2 binding events" in {
-    val mentions = parseSentence("Mechanistically, ASPP1 and ASPP2 are bound by RAS-GTP.")
+    val mentions = getBioMentions("Mechanistically, ASPP1 and ASPP2 are bound by RAS-GTP.")
     hasEventWithArguments("Binding", List("ASPP1", "RAS-GTP"), mentions) should be (true)
     hasEventWithArguments("Binding", List("ASPP2", "RAS-GTP"), mentions) should be (true)
   }
 
   "testBindingPrepNom1" should "find 1 binding events" in {
-    val mentions = parseSentence("We detected elevated binding of p53 to K-Ras.")
+    val mentions = getBioMentions("We detected elevated binding of p53 to K-Ras.")
     hasEventWithArguments("Binding", List("p53", "K-Ras"), mentions) should be (true)
   }
 
   "testBindingPrepNom2" should "find 1 binding events" in {
-    val mentions = parseSentence("We detected elevated binding of p53 and K-Ras.")
+    val mentions = getBioMentions("We detected elevated binding of p53 and K-Ras.")
     hasEventWithArguments("Binding", List("p53", "K-Ras"), mentions) should be (true)
   }
 
   "testBindingPrepNom3" should "find 1 binding events" in {
-    val mentions = parseSentence("We detected elevated binding of p53 with K-Ras.")
+    val mentions = getBioMentions("We detected elevated binding of p53 with K-Ras.")
     hasEventWithArguments("Binding", List("p53", "K-Ras"), mentions) should be (true)
   }
 
   "testBindingSubjNom1" should "find 1 binding events" in {
-    val mentions = parseSentence("We detected elevated p53 binding to K-Ras.")
+    val mentions = getBioMentions("We detected elevated p53 binding to K-Ras.")
     hasEventWithArguments("Binding", List("p53", "K-Ras"), mentions) should be (true)
   }
 
   "testBindingObjNom1" should "find 1 binding events" in {
-    val mentions = parseSentence("We detected elevated K-Ras binding by p53.")
+    val mentions = getBioMentions("We detected elevated K-Ras binding by p53.")
     hasEventWithArguments("Binding", List("p53", "K-Ras"), mentions) should be (true)
   }
 
   "testBindingSubjRel1" should "find 1 binding events" in {
-    val mentions = parseSentence("We detected elevated phosphorylation of K-Ras, a protein that subsequently binds p53.")
+    val mentions = getBioMentions("We detected elevated phosphorylation of K-Ras, a protein that subsequently binds p53.")
     hasEventWithArguments("Binding", List("p53", "K-Ras"), mentions) should be (true)
   }
 
   "testBindingObjRel1" should "find 1 binding events" in {
-    val mentions = parseSentence("We detected elevated phosphorylation of K-Ras, a protein that is subsequently bound by p53.")
+    val mentions = getBioMentions("We detected elevated phosphorylation of K-Ras, a protein that is subsequently bound by p53.")
     hasEventWithArguments("Binding", List("p53", "K-Ras"), mentions) should be (true)
   }
 
@@ -253,83 +253,83 @@ class TestBindingEvents extends FlatSpec with Matchers {
   }
 
   "testBindingGerund1" should "find 1 binding event" in {
-    val mentions = parseSentence("IKKgamma appears capable of binding linear polyubiquitin.")
+    val mentions = getBioMentions("IKKgamma appears capable of binding linear polyubiquitin.")
     hasEventWithArguments("Binding", List("IKKgamma", "polyubiquitin"), mentions) should be (true)
   }
 
   val sent19 = "The dimerization of cRaf with BRaf helps something."
   sent19 should "contain 1 binding event" in {
-    val mentions = parseSentence(sent19)
+    val mentions = getBioMentions(sent19)
     hasEventWithArguments("Binding", List("cRaf", "BRaf"), mentions) should be (true)
   }
 
   val sent20 = "MEK binds with MEK."
   sent20 should "not contain any binding events" in {
-    val mentions = parseSentence(sent20)
+    val mentions = getBioMentions(sent20)
     mentions.count(_ matches "Binding") should be (0)
   }
 
   val sent21 = "Highly purified DNA-PKcs, Ku70/Ku80 heterodimer and the two documented XRCC1 binding partners LigIII and DNA polbeta were dot-blotted"
   sent21 should "contain 1 binding event between Ku70 and Ku80" in {
-    val mentions = parseSentence(sent21)
+    val mentions = getBioMentions(sent21)
     hasEventWithArguments("Binding", List("Ku70", "Ku80"), mentions) should be (true)
   }
   val sent22 = "The heterodimer Ku70-DNA ligase IV is awesome"
   sent22 should "contain 1 binding event between Ku70 and DNA ligase IV" in {
-    val mentions = parseSentence(sent22)
+    val mentions = getBioMentions(sent22)
     hasEventWithArguments("Binding", List("Ku70", "DNA ligase IV"), mentions) should be (true)
   }
   val sent23 = "The complex Ku70/Ku80 is awesome"
   sent23 should "contain 1 binding event between Ku70 and Ku80" in {
-    val mentions = parseSentence(sent23)
+    val mentions = getBioMentions(sent23)
     hasEventWithArguments("Binding", List("Ku70", "Ku80"), mentions) should be (true)
   }
   val sent24 = "That Ku70/Ku80 complex is awesome"
   sent24 should "contain 1 binding event between Ku70 and Ku80" in {
-    val mentions = parseSentence(sent24)
+    val mentions = getBioMentions(sent24)
     hasEventWithArguments("Binding", List("Ku70", "Ku80"), mentions) should be (true)
   }
 
   val sent25 = "Identification by mass spectroscopy of DNA-PKcs associated with XRCC1"
   sent25 should "contain 1 binding event" in {
-    val mentions = parseSentence(sent25)
+    val mentions = getBioMentions(sent25)
     hasEventWithArguments("Binding", List("DNA-PKcs", "XRCC1"), mentions) should be (true)
   }
   val sent26 = "Our assumption is that DNA-PKcs is associated with  XRCC1"
   sent26 should "contain 1 binding event" in {
-    val mentions = parseSentence(sent26)
+    val mentions = getBioMentions(sent26)
     hasEventWithArguments("Binding", List("DNA-PKcs", "XRCC1"), mentions) should be (true)
   }
 
   val sent27 = "Once bound to the DSB, the DNA-PK holoenzyme facilitates the recruitment..."
   sent27 should "contain 1 binding event (MARCO)" in {
-    val mentions = parseSentence(sent27)
+    val mentions = getBioMentions(sent27)
     // TODO: this should be matched by the binding_oncebound rule, but it doesn't...
     hasEventWithArguments("Binding", List("DNA-PK holoenzyme", "DSB"), mentions) should be (true)
   }
 
   val sent28 = "To confirm whether XRCC1 and DNA-PK coexist in a common complex, we carried out co-immunoprecipitation experiments in HeLa nuclear extracts."
   sent28 should "contain 1 binding event" in {
-    val mentions = parseSentence(sent28)
+    val mentions = getBioMentions(sent28)
     hasEventWithArguments("Binding", List("DNA-PK", "XRCC1"), mentions) should be (true)
   }
 
   val sent29 = "We found that the three subunits of DNA-PK co-purified only with BRCT1 containing XRCC1-fusion proteins             confirming that XRCC1 and DNA-PK are present in a complex. "
   sent29 should "contain 1 binding event" in {
-    val mentions = parseSentence(sent29)
+    val mentions = getBioMentions(sent29)
     hasEventWithArguments("Binding", List("DNA-PK", "XRCC1"), mentions) should be (true)
   }
 
   val sent30 = "Figure 3. Raf and PI3K bind more to ubiquitinated Ras than to non-ubiquitinated Ras"
   sent30 should "contain 2 binding events" in {
-    val mentions = parseSentence(sent30)
+    val mentions = getBioMentions(sent30)
     hasEventWithArguments("Binding", List("Raf", "Ras"), mentions) should be (true)
     hasEventWithArguments("Binding", List("PI3K", "Ras"), mentions) should be (true)
   }
 
   val sent31 = "We observed that endogenous PLC, Afadin, Calmodulin and Tubulin co-immunoprecipitated with G12V-K-Ras (GUS)"
   sent31 should "contain 4 binding events for G12V-K-Ras" in {
-    val mentions = parseSentence(sent31)
+    val mentions = getBioMentions(sent31)
     // TODO: this doesn't work because we don't recognize G12V-K-Ras as entity. Please add it to the model.
     hasEventWithArguments("Binding", List("PLC", "G12V-K-Ras"), mentions) should be (true)
     hasEventWithArguments("Binding", List("Afadin", "G12V-K-Ras"), mentions) should be (true)
@@ -339,20 +339,20 @@ class TestBindingEvents extends FlatSpec with Matchers {
 
   val sent32 = "Something increases the fraction of GTP-bound Ras"
   sent32 should "contain 1 binding event" in {
-    val mentions = parseSentence(sent32)
+    val mentions = getBioMentions(sent32)
     hasEventWithArguments("Binding", List("GTP", "Ras"), mentions) should be (true)
   }
 
   val sent33 = "As expected based on previous studies, wild-type K-Ras bound primarily 32P-GDP, while G12V-Ras bound 32P-GTP (Fig.2, A and B)."
   sent33  should "contain 2 binding events" in {
-    val mentions = parseSentence(sent33)
+    val mentions = getBioMentions(sent33)
     hasEventWithArguments("Binding", List("K-Ras", "32P-GDP"), mentions) should be (true)
     hasEventWithArguments("Binding", List("G12V-Ras", "32P-GTP"), mentions) should be (true)
   }
 
   val sent34 = "Recruitment of p53 to the p21 or PUMA promoter was normalized to input."
   sent34 should "contain 2 binding events" in {
-    val mentions = parseSentence(sent34)
+    val mentions = getBioMentions(sent34)
     mentions.filter(_ matches "Binding") should have size (2)
     hasEventWithArguments("Binding", List("p53", "p21"), mentions) should be (true)
     hasEventWithArguments("Binding", List("p53", "PUMA"), mentions) should be (true)
@@ -360,7 +360,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
 
   val sent35 = "LMTK2 signals via protein phosphatase-1C (PP1C) to increase inhibitory phosphorylation of GSK3β on serine-9 that reduces KLC2 phosphorylation and promotes binding of the known KLC2 cargo Smad2."
   sent35 should "not contain bindings" in {
-    val mentions = parseSentence(sent35)
+    val mentions = getBioMentions(sent35)
     mentions.filter(_ matches "Binding") should be ('empty)
   }
 
@@ -368,7 +368,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
   // val sent36 = "Lower: purified wild-type and mutant p32, but not recombinant TFAM-His and GST proteins, bind to poly(A) oligonucleoside."
   val sent36 = "Lower: purified wild-type and mutant p32, but not recombinant ASPP2 and GST proteins, bind to Mek."
   sent36 should "not contain binding between p32 and ASPP2 or GST" in {
-    val mentions = parseSentence(sent36)
+    val mentions = getBioMentions(sent36)
     mentions filter (_ matches "Binding") should have size (3)
     hasEventWithArguments("Binding", List("p32", "Mek"), mentions) should be (true)
     hasEventWithArguments("Binding", List("ASPP2", "Mek"), mentions) should be (true)

--- a/src/test/scala/edu/arizona/sista/reach/TestCoreference.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestCoreference.scala
@@ -11,17 +11,17 @@ import edu.arizona.sista.reach.mentions._
 class TestCoreference extends FlatSpec with Matchers {
   val sent1 = "ASPP2 is even more common than Ras, and it is often ubiquitinated."
   sent1 should "not produce a ubiquitination of ASPP2" in {
-    val mentions = parseSentence(sent1)
+    val mentions = getBioMentions(sent1)
     TestUtils.hasEventWithArguments("Ubiquitination", List("ASPP2"), mentions) should be (true)
   }
   it should "produce a ubiquitination of Ras" in {
-    val mentions = parseSentence(sent1)
+    val mentions = getBioMentions(sent1)
     TestUtils.hasEventWithArguments("Ubiquitination", List("Ras"), mentions) should be (false)
   }
 
   val sent2 = "Even more than Ras, ASPP2 is common, as is their phosphorylation."
   sent2 should "produce two phosphorylations, one of ASPP2 and one of Ras" in {
-    val mentions = parseSentence(sent2)
+    val mentions = getBioMentions(sent2)
     TestUtils.hasEventWithArguments("Phosphorylation", List("Ras"), mentions) should be (true)
     TestUtils.hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     mentions.filter(_.label == "Phosphorylation") should have size 2
@@ -29,14 +29,14 @@ class TestCoreference extends FlatSpec with Matchers {
 
   val sent3 = "Even more than Ras, ASPP2 is common, as is their binding."
   sent3 should "produce one binding of Ras and ASPP2" in {
-    val mentions = parseSentence(sent3)
+    val mentions = getBioMentions(sent3)
     TestUtils.hasEventWithArguments("Binding", List("Ras", "ASPP2"), mentions) should be (true)
     mentions.filter(_.label == "Binding") should have size 1
   }
 
   val sent4 = "ASPP2 is common, even more than Ras and Mek, and so is its binding to them."
   sent4 should "produce two bindings: (Ras, ASPP2), (Mek, ASPP2)" in {
-    val mentions = parseSentence(sent4)
+    val mentions = getBioMentions(sent4)
     TestUtils.hasEventWithArguments("Binding", List("Ras", "ASPP2"), mentions) should be (true)
     TestUtils.hasEventWithArguments("Binding", List("Mek", "ASPP2"), mentions) should be (true)
     TestUtils.hasEventWithArguments("Binding", List("Mek", "Ras"), mentions) should be (false)
@@ -47,7 +47,7 @@ class TestCoreference extends FlatSpec with Matchers {
     "total G12V-K-Ras or the ubiquitinated subfraction of G12V-K-Ras was immunoprecipitated and the immunoprecipitates " +
     "were probed with antibodies to detect associated Ras effector molecules."
   sent5 should "contain 2 binding events" in {
-    val mentions = parseSentence(sent5)
+    val mentions = getBioMentions(sent5)
     hasEventWithArguments("Ubiquitination", List("Ras"), mentions) should be (true)
     hasEventWithArguments("Binding", List("Ras", "Raf"), mentions) should be (true)
     hasEventWithArguments("Binding", List("PI3K", "Ras"), mentions) should be (true)
@@ -56,7 +56,7 @@ class TestCoreference extends FlatSpec with Matchers {
   // Ensure that regulation is removed if no resolved controller is found.
   val sent6 = "It phosphorylates Ras."
   sent6 should "contain no positive regulation" in {
-    val mentions = parseSentence(sent6)
+    val mentions = getBioMentions(sent6)
     mentions.filter(_ matches "Positive_regulation") should have size (0)
     hasEventWithArguments("Phosphorylation", List("Ras"), mentions) should be (true)
   }
@@ -64,14 +64,14 @@ class TestCoreference extends FlatSpec with Matchers {
   // Ensure that controller cannot be antecedent to controlled's arguments
   val sent7 = "Ras phosphorylates it."
   sent7 should "produce no events" in {
-    val mentions = parseSentence(sent7)
+    val mentions = getBioMentions(sent7)
     mentions.filter(_.isInstanceOf[BioEventMention]) should have size (0)
     mentions should have size (1)
   }
 
   val sent8 = "ASPP2 is common, it is well known, and Ras sumoylates it."
   sent8 should "contain one sumoylation and one regulation" in {
-    val mentions = parseSentence(sent8)
+    val mentions = getBioMentions(sent8)
     TestUtils.hasEventWithArguments("Sumoylation", List("ASPP2"), mentions) should be (true)
     val reg = mentions.find(_ matches "Positive_regulation")
     reg should be ('defined)
@@ -86,7 +86,7 @@ class TestCoreference extends FlatSpec with Matchers {
   // Works across sentences; ignores irrelevant pronouns.
   val sent9 = "Much work has been done on ASPP2. It is known that Ras binds it."
   sent9 should "contain one binding and no other events" in {
-    val mentions = parseSentence(sent9)
+    val mentions = getBioMentions(sent9)
     mentions.find(_ matches "ComplexEvent") should not be ('defined)
     hasEventWithArguments("Binding", List("Ras", "ASPP2"), mentions) should be (true)
     mentions.filter(_.isInstanceOf[BioEventMention]) should have size (1)
@@ -96,14 +96,14 @@ class TestCoreference extends FlatSpec with Matchers {
   val sent10 = "Ras and Mek are in proximity, and they phosphorylate ASPP2."
   val sent10a = "Ras and Mek are in proximity, and they upregulate the phosphorylation of ASPP2."
   sent10 should "contain one phosphorylation and two regulations" in {
-    val mentions = parseSentence(sent10)
+    val mentions = getBioMentions(sent10)
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions)
     mentions.filter(_ matches "Positive_regulation") should have size (2)
     hasPositiveRegulationByEntity("Ras","BioChemicalEntity",Seq("ASPP2"),mentions)
     hasPositiveRegulationByEntity("Mek","BioChemicalEntity",Seq("ASPP2"),mentions)
   }
   sent10a should "contain one phosphorylation and two regulations" in {
-    val mentions = parseSentence(sent10a)
+    val mentions = getBioMentions(sent10a)
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions)
     mentions.filter(_ matches "Positive_regulation") should have size (2)
     hasPositiveRegulationByEntity("Ras","BioChemicalEntity",Seq("ASPP2"),mentions)
@@ -113,7 +113,7 @@ class TestCoreference extends FlatSpec with Matchers {
   // Number-sensitive search works with cause controlleds but not triggered regulation plurals
   val sent11 = "Ras and Mek are in proximity, and ASPP2 phosphorylates them."
   sent11 should "contain two phosphorylation and two regulations" in {
-    val mentions = parseSentence(sent11)
+    val mentions = getBioMentions(sent11)
     mentions.filter(_ matches "Phosphorylation") should have size (2)
     hasEventWithArguments("Phosphorylation", List("Ras"), mentions) should be (true)
     hasEventWithArguments("Phosphorylation", List("Mek"), mentions) should be (true)
@@ -125,7 +125,7 @@ class TestCoreference extends FlatSpec with Matchers {
   // Number-sensitive search works with activation controllers, but plurals are forbidden.
   val sent12 = "Ras is in proximity, and it activates ASPP2."
   sent12 should "contain a Positive_activation" in {
-    val mentions = parseSentence(sent12)
+    val mentions = getBioMentions(sent12)
     mentions.filter(_ matches "ActivationEvent") should have size (1)
     hasEventWithArguments("Positive_activation", List("Ras", "ASPP2"), mentions) should be (true)
   }
@@ -133,7 +133,7 @@ class TestCoreference extends FlatSpec with Matchers {
   // Number-sensitive search works with activation controlleds, but plurals are forbidden.
   val sent13 = "Mek is in proximity, and ASPP2 activates it."
   sent13 should "contain one activation and one regulation" in {
-    val mentions = parseSentence(sent13)
+    val mentions = getBioMentions(sent13)
     mentions.filter(_ matches "ActivationEvent") should have size (1)
     hasEventWithArguments("Positive_activation", List("ASPP2", "Mek"), mentions) should be (true)
   }
@@ -141,7 +141,7 @@ class TestCoreference extends FlatSpec with Matchers {
   // Sane noun phrases should be matched
   val sent14 = "ASPP1 is common, and this protein binds GTP."
   sent14 should "contain one binding event only" in {
-    val mentions = parseSentence(sent14)
+    val mentions = getBioMentions(sent14)
     hasEventWithArguments("Binding", List("ASPP1", "GTP"), mentions) should be (true)
     mentions should have size (4)
   }
@@ -149,7 +149,7 @@ class TestCoreference extends FlatSpec with Matchers {
   // Filter out bindings with one complete theme and one unresolved theme.
   val sent14b = "This protein binds GTP."
   sent14b should "contain no binding events" in {
-    val mentions = parseSentence(sent14b)
+    val mentions = getBioMentions(sent14b)
     mentions.filter(_ matches "Binding") should have size (0)
     mentions should have size (1)
   }
@@ -157,7 +157,7 @@ class TestCoreference extends FlatSpec with Matchers {
   // Ignore noun phrases that can't have BioChemicalEntity antecedents
   val sent15 = "Ras is common, and a mouse binds GTP."
   sent15 should "not contain any events" in {
-    val mentions = parseSentence(sent15)
+    val mentions = getBioMentions(sent15)
     mentions filter (_ matches "Event") should have size (0)
     mentions should have size (3)
   }
@@ -165,14 +165,14 @@ class TestCoreference extends FlatSpec with Matchers {
    // Ignore anything two sentences prior when searching for antecedents.
    val sent16 = "Ras is common. This is an intervening sentence. It binds Mek."
    sent16 should "not contain any events" in {
-     val mentions = parseSentence(sent16)
+     val mentions = getBioMentions(sent16)
      mentions filter (_ matches "Event") should have size (0)
    }
 
   // Can find an antecedent mention between start of event mention and start of text bound mention
   val sent17 = "ASPP2 is common, and Ras binds the Mek protein."
   sent17 should "contain a single binding between Mek and Ras" in {
-    val mentions = parseSentence(sent17)
+    val mentions = getBioMentions(sent17)
     hasEventWithArguments("Binding", List("Ras", "Mek"), mentions) should be (true)
     hasEventWithArguments("Binding", List("Ras", "ASPP2"), mentions) should be (false)
     hasEventWithArguments("Binding", List("Mek", "ASPP2"), mentions) should be (false)
@@ -183,17 +183,17 @@ class TestCoreference extends FlatSpec with Matchers {
   val sent18a = "ASPP2 and Ras are common, as is their activation."
   val sent18b = "The phosphorylation of ASPP2 and Ras is common, as is their upregulation."
   sent18 should "not contain any events" in {
-    val mentions = parseSentence(sent18)
+    val mentions = getBioMentions(sent18)
     mentions filter (_ matches "Event") should have size (0)
   }
 
   sent18a should "not contain any events" in {
-    val mentions = parseSentence(sent18a)
+    val mentions = getBioMentions(sent18a)
     mentions filter (_ matches "Event") should have size (0)
   }
 
   sent18b should "contain no activations or regulations" in {
-    val mentions = parseSentence(sent18b)
+    val mentions = getBioMentions(sent18b)
     mentions filter (_ matches "ComplexEvent") should have size (0)
     mentions filter (_ matches "ActivationEvent") should have size (0)
     mentions filter (_ matches "Phosphorylation") should have size (2)
@@ -203,7 +203,7 @@ class TestCoreference extends FlatSpec with Matchers {
 
   val sent19 = "ASPP1 is common, and it binds Mek and Ras"
   sent19 should "contain two bindings, (ASPP1,Mek) and (ASPP1,Ras)" in {
-    val mentions = parseSentence(sent19)
+    val mentions = getBioMentions(sent19)
     mentions filter (_ matches "Binding") should have size (2)
     mentions filter (_ matches "Event") should have size (2)
     hasEventWithArguments("Binding", List("ASPP1", "Mek"), mentions) should be (true)
@@ -214,7 +214,7 @@ class TestCoreference extends FlatSpec with Matchers {
     "different LMTK2 siRNAs all markedly reduced LMTK2 levels and this led to a corresponding decrease in PP1Cthr320 " +
     "phosphorylation."
   sent20 should "not contain an activation of and by the same entity" in {
-    val mentions = parseSentence(sent20)
+    val mentions = getBioMentions(sent20)
     hasPositiveActivation("LMTK2","LMTK2",mentions) should be (false)
   }
 
@@ -222,7 +222,7 @@ class TestCoreference extends FlatSpec with Matchers {
     "RAPA, Rapamune, AY-22989, and NSC-226080). Rapamycin is an FDA-approved agent used as immunosuppressive therapy " +
     "post organ transplant ."
   sent21 should "not produce a requirement error from Anaphoric.antecedent" in {
-    val mentions = parseSentence(sent21)
+    val mentions = getBioMentions(sent21)
     mentions.forall { mention =>
       !mention.toCorefMention.antecedentOrElse(mention.toCorefMention).isGeneric
     } should be (true)
@@ -233,7 +233,7 @@ class TestCoreference extends FlatSpec with Matchers {
     "experimental studies show that the loss of STAT1 partially rescues the growth-inhibitory action of FGF signaling " +
     "in chondrocytes     ,     , both suggesting the role of STAT1 in the growth-inhibitory FGFR3 action in cartilage."
   sent22 should "not produce an activation with an activation controlled" in {
-    val mentions = parseSentence(sent22)
+    val mentions = getBioMentions(sent22)
     mentions filter (_ matches "ActivationEvent") should have size (3)
     mentions.forall { mention =>
       !(mention matches "ActivationEvent") ||
@@ -246,7 +246,7 @@ class TestCoreference extends FlatSpec with Matchers {
     "that bind RasGTP . However , our data raise the possibility that there is a class of proteins , such as " +
     "PI3KC2beta , that bind nucleotide-free Ras and are negatively regulated by this interaction ."
   sent23 should "not produce any Regulations" in {
-    val mentions = parseSentence(sent23)
+    val mentions = getBioMentions(sent23)
     mentions filter (_ matches "Regulation") should have size (0)
   }
 
@@ -256,7 +256,7 @@ class TestCoreference extends FlatSpec with Matchers {
     "sites on Gab1 that bind to p85, thus terminating recruitment of PI-3 kinase and EGF-induced activation of the " +
     "PI-3 kinase pathway"
   sent24 should "have a complex controller if it produces an ActivationEvent" in {
-    val mentions = parseSentence(sent24)
+    val mentions = getBioMentions(sent24)
     val act = mentions.find(_ matches "ActivationEvent")
     if (act.nonEmpty) {
       val controller = act.get.arguments("controller").head
@@ -268,7 +268,7 @@ class TestCoreference extends FlatSpec with Matchers {
     "illustrated by the fact that this protein is found mutated in ∼50% of human cancers. In most cases, mutations " +
     "in p53 greatly increase the otherwise short half life of this protein and cause it to accumulate in tumor cells."
   sent25 should "not produce an error due to multiple antecedents" in {
-    val mentions = parseSentence(sent25)
+    val mentions = getBioMentions(sent25)
     mentions.find(_.text == "p53").nonEmpty should be (true)
   }
 
@@ -276,7 +276,7 @@ class TestCoreference extends FlatSpec with Matchers {
     "do both    . While direct Grb2/RTK interactions involve binding of the Grb2 SH2 domain to pYXNX motifs, Shc " +
     "proteins interact with RTKs primarily through the binding of their N-terminal PTB domain to NPXpY motifs."
   sent26 should "not produce an error due to multiple antecedents" in {
-    val mentions = parseSentence(sent26)
+    val mentions = getBioMentions(sent26)
     mentions.find(_.text == "Grb2").nonEmpty should be (true)
   }
 
@@ -316,13 +316,13 @@ class TestCoreference extends FlatSpec with Matchers {
     val sent27a = s"We found that ASPP1 ${simpleEventVbs(i)} ASPP2, and this ${simpleEventNs(i)} upregulates STAT1."
     val sent27b = s"We found that ASPP1 ${simpleEventVbs(i)} ASPP2, and ${simpleEventNs(i)} upregulates STAT1."
     sent27a should "contain an ActivationEvent" in {
-      val mentions = parseSentence(sent27a)
+      val mentions = getBioMentions(sent27a)
       mentions filter (_ matches "ActivationEvent") should have size (1)
       hasEventWithArguments(simpleEventTypes(i), List("ASPP2"), mentions) should be(true)
       hasEventWithArguments("Positive_activation", List(s"ASPP2", "STAT1"), mentions) should be(true)
     }
     sent27b should "not contain an ActivationEvent" in {
-      val mentions = parseSentence(sent27b)
+      val mentions = getBioMentions(sent27b)
       mentions filter (_ matches "ActivationEvent") should have size (0)
       hasEventWithArguments(simpleEventTypes(i), List("ASPP2"), mentions) should be(true)
     }
@@ -332,11 +332,11 @@ class TestCoreference extends FlatSpec with Matchers {
   val sent28a = "ASPP1 is common, and a protein is phosphorylated."
   val sent28b = "ASPP1 is common, and a cistron phosphorylates ASPP2."
   sent28a should "not contain any events" in {
-    val mentions = parseSentence(sent28a)
+    val mentions = getBioMentions(sent28a)
     mentions filter (_ matches "Event") should have size (0)
   }
   sent28b should "not contain any complex events" in {
-    val mentions = parseSentence(sent28b)
+    val mentions = getBioMentions(sent28b)
     mentions filter (_ matches "ComplexEvent") should have size (0)
   }
 

--- a/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
@@ -59,7 +59,7 @@ class TestEntities extends FlatSpec with Matchers {
 
   val sent2 = "It has recently been shown that oncogenic RAS can enhance the apoptotic function of p53 via ASPP1 and ASPP2"
   sent2 should "contain 4 entities" in {
-    val mentions = parseSentence(sent2)
+    val mentions = getBioMentions(sent2)
     hasEntity("RAS", mentions) should be (true)
     hasEntity("p53", mentions) should be (true)
     hasEntity("ASPP1", mentions) should be (true)
@@ -68,7 +68,7 @@ class TestEntities extends FlatSpec with Matchers {
 
   val sent3 = "We hypothesized that MEK inhibition activates AKT by inhibiting ERK activity, which blocks an inhibitory threonine phosphorylation on the JM domains of EGFR and HER2, thereby increasing ERBB3 phosphorylation."
   sent3 should "contain at least 4 entities" in {
-    val mentions = parseSentence(sent3)
+    val mentions = getBioMentions(sent3)
     hasEntity("ERK", mentions) should be (true)
     hasEntity("EGFR", mentions) should be (true)
     hasEntity("HER2", mentions) should be (true)
@@ -77,7 +77,7 @@ class TestEntities extends FlatSpec with Matchers {
 
   val sent4 = "To test this hypothesis, we transiently transfected CHO-KI cells, which do not express ERBB receptors endogenously, with wildtype ERBB3 with either wild-type EGFR or EGFR T669A."
   sent4 should "contain at least 3 entities" in {
-    val mentions = parseSentence(sent4)
+    val mentions = getBioMentions(sent4)
     hasEntity("ERBB receptors", mentions) should be (true)
     hasEntity("ERBB3", mentions) should be (true)
     hasEntity("EGFR", mentions) should be (true)
@@ -85,13 +85,13 @@ class TestEntities extends FlatSpec with Matchers {
 
   val sent5 = "See Figure S31 and Table R15"
   sent5 should "not contain any sites" in {
-    val mentions = parseSentence(sent5)
+    val mentions = getBioMentions(sent5)
     mentions.count(_ matches "Site") should be (0)
   }
 
   val sent6 = "The K-Ras substrate and mTOR substrates shouldn't be found."
   sent6 should "not contain any entities (because of substrate constraint)" in {
-    val mentions = parseSentence(sent6)
+    val mentions = getBioMentions(sent6)
     mentions.size should be (0)
   }
 

--- a/src/test/scala/edu/arizona/sista/reach/TestGrounding.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestGrounding.scala
@@ -11,7 +11,7 @@ class TestGrounding extends FlatSpec with Matchers {
 
   val grounding1 = "p65 and NF-kappaB p65 are the same entity."
   grounding1 should "contain 2 entities with the same grounding ID: Xref(uniprot,P21579)" in {
-    val mentions = parseSentence(grounding1)
+    val mentions = getBioMentions(grounding1)
     mentions should have size (2)
     val e1 = mentions.head
     val e2 = mentions.last
@@ -22,7 +22,7 @@ class TestGrounding extends FlatSpec with Matchers {
   //We love NF-kappaB p65, p65, and NF-kappaB.
   val groundingTwo = "We love NF-kappaB p65, p65, and NF-kappaB."
   groundingTwo should "contain 3 entities, 2 of which have the same grounding ID: Xref(uniprot,P21579)" in {
-    val mentions = parseSentence(groundingTwo)
+    val mentions = getBioMentions(groundingTwo)
     mentions should have size (3)
     val e1 = mentions.find(_.text == "p65").get
     val e2 = mentions.find(_.text == "NF-kappaB p65").get
@@ -33,7 +33,7 @@ class TestGrounding extends FlatSpec with Matchers {
 
   val grounding3 = "MEK phosphorylates Ras."
   grounding3 should "contain grounded entities" in {
-    val mentions = parseSentence(grounding3)
+    val mentions = getBioMentions(grounding3)
     val tbms = mentions flatMap {
       case m: BioTextBoundMention => Some(m)
       case _ => None

--- a/src/test/scala/edu/arizona/sista/reach/TestModifications.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestModifications.scala
@@ -574,13 +574,13 @@ class TestModifications extends FlatSpec with Matchers {
   val sent1b = "The ubiquitinated AKT binds to ASPP2."
   "ReachSystem" should "not find a PTMs as events" in {
     // TODO: Both fail! (DANE + MARCO)
-    var mentions = parseSentence(sent1)
+    var mentions = getBioMentions(sent1)
     val p = mentions.find(_ matches "Phosphorylation") // Dane: this is a PTM not an event!
     p.isDefined should be (false) // Dane
     var b = mentions.find(_ matches "Binding") // Marco: why does this fail??
     b.isDefined should be (true) // Marco
 
-    mentions = parseSentence(sent1b)
+    mentions = getBioMentions(sent1b)
     val u = mentions.find(_ matches "Ubiquitination")
     u.isDefined should be (false)
     b = mentions.find(_ matches "Binding")
@@ -669,7 +669,7 @@ class TestModifications extends FlatSpec with Matchers {
   val sent9 = "The phosphorylated p53 by ASPP2 is doing something..."
   // this is not a PTM! It is an event with a cause
   sent9 should "contain 1 phosphorylation and 1 regulation event" in {
-    val mentions = parseSentence(sent9)
+    val mentions = getBioMentions(sent9)
     hasEventWithArguments("Phosphorylation", List("p53"), mentions) should be (true)
     hasPositiveRegulationByEntity("ASPP2", "Phosphorylation", List("p53"), mentions) should be (true)
   }
@@ -679,7 +679,7 @@ class TestModifications extends FlatSpec with Matchers {
   //
   val sent10 = "Note that only K650M and K650E-FGFR3 mutants cause STAT1 phosphorylation"
   sent10 should "have 2 mutations for FGFR3" in {
-    val mentions = parseSentence(sent10)
+    val mentions = getBioMentions(sent10)
     val fgfr = mentions.filter(m => (m.text contains "FGFR3") && m.isInstanceOf[BioTextBoundMention])
     fgfr should have size (2)
     fgfr(0).countMutations should be (1)
@@ -691,7 +691,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val sent11 = "Note that only FGFR3 K650M causes STAT1 phosphorylation"
   sent11 should "have 1 mutation for FGFR3" in {
-    val mentions = parseSentence(sent11)
+    val mentions = getBioMentions(sent11)
     val fgfr = mentions.filter(m => (m.text contains "FGFR3") && m.isInstanceOf[BioTextBoundMention])
     fgfr should have size (1)
     fgfr.head.countMutations should be (1)
@@ -699,7 +699,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val sent12 = "Note that only the K650M-FGFR3 mutant causes STAT1 phosphorylation"
   sent12 should "have 1 mutation for FGFR3" in {
-    val mentions = parseSentence(sent12)
+    val mentions = getBioMentions(sent12)
     val fgfr = mentions.filter(m => (m.text contains "FGFR3") && m.isInstanceOf[BioTextBoundMention])
     fgfr should have size (1)
     fgfr.head.hasMutation("K650M") should be (true)
@@ -707,7 +707,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val sent13 = "monoubiquitinated K-Ras is less sensitive than the unmodified protein to GAP-mediated GTP hydrolysis"
   sent13 should "not contain a ubiquitination event (this is a PTM)" in {
-    val mentions = parseSentence(sent13)
+    val mentions = getBioMentions(sent13)
     mentions.count(_ matches "Ubiquitination") should be (0)
     hasEventWithArguments("Ubiquitination", List("K-Ras"), mentions) should be (false)
     val kras = mentions.find(_.text contains "K-Ras")
@@ -723,7 +723,7 @@ class TestModifications extends FlatSpec with Matchers {
   //
   val sent14 = "all six FGFR3 mutants induced activatory ERK(T202/Y204) phosphorylation (Fig. 2)."
   sent14 should "contain 2 phosphorylations (one for each ERK mutation) and 2 Positive Regulations" in {
-    val mentions = parseSentence(sent14)
+    val mentions = getBioMentions(sent14)
 
     // We have one phosphorylation per Site
     val phosphos = mentions.filter(_ matches "Phosphorylation")
@@ -742,7 +742,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val sent15 = "all six FGFR3 mutants induced activatory ERK(K156M/H204M) phosphorylation (Fig. 2)."
   sent15 should "contain 2 Positive Regulations NOT Activations (1 for each ERK mutation)" in {
-    val mentions = parseSentence(sent15)
+    val mentions = getBioMentions(sent15)
 
     // We have 1 Reg per ERK mutant
     val regs = mentions.filter(_ matches "Positive_regulation")
@@ -751,7 +751,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val sent16 = "all six FGFR3 mutants induced activatory ERK(K156M, H204M) phosphorylation (Fig. 2)."
   sent16 should "contain 2 Positive Regulations NOT Activations (1 for each ERK mutation)" in {
-    val mentions = parseSentence(sent16)
+    val mentions = getBioMentions(sent16)
 
     // We have 1 Reg per ERK mutant
     val regs = mentions.filter(_ matches "Positive_regulation")
@@ -761,7 +761,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val siteTest1 = "activatory ERK(T202/Y204) phosphorylation (Fig. 2)."
   siteTest1 should "contain 2 sites (distinct phosphorylations)" in {
-    val mentions = parseSentence(siteTest1)
+    val mentions = getBioMentions(siteTest1)
 
     // We have one phosphorylation per Site
     val phosphos = mentions.filter(_ matches "Phosphorylation")
@@ -777,14 +777,14 @@ class TestModifications extends FlatSpec with Matchers {
 
   val siteTest2 = "Ser56 RAS"
   siteTest2 should "contain 2 entities (1 Site)" in {
-    val mentions = parseSentence(siteTest2)
+    val mentions = getBioMentions(siteTest2)
     mentions should have size (2)
     mentions.count(_ matches "Site") should be (1)
   }
 
   val mutantTest1 = "all six FGFR3 mutants induced activatory ERK(K156M/H204M) phosphorylation (Fig. 2)."
   mutantTest1 should "contain 2 mutations for ERK and 1 for FGFR3" in {
-    val mentions = parseSentence(mutantTest1)
+    val mentions = getBioMentions(mutantTest1)
 
     val fgfr = mentions filter(_.text == "FGFR3")
     fgfr should have size (1)
@@ -802,7 +802,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest2 = "all six FGFR3 mutants induced activatory ERK(K156M, H204M) phosphorylation (Fig. 2)."
   mutantTest2 should "contain 2 mutations for ERK and 1 for FGFR3" in {
-    val mentions = parseSentence(mutantTest2)
+    val mentions = getBioMentions(mutantTest2)
 
     val fgfr = mentions filter(_.text == "FGFR3")
     fgfr should have size (1)
@@ -820,7 +820,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest3 = "MEK R567Q"
   mutantTest3 should "contain 1 entity with 1 Mutant modification" in {
-    val mentions = parseSentence(mutantTest3)
+    val mentions = getBioMentions(mutantTest3)
     mentions should have size (1)
     mentions.head.countMutations should be (1)
     mentions.head hasMutation "R567Q" should be (true)
@@ -828,7 +828,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest4 = "MEK mutant R567Q"
   mutantTest4 should "contain 1 entity with 1 Mutant modification" in {
-    val mentions = parseSentence(mutantTest4)
+    val mentions = getBioMentions(mutantTest4)
     mentions should have size (1)
     mentions.head.countMutations should be (1)
     mentions.head hasMutation "R567Q" should be (true)
@@ -836,7 +836,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest5 = "MEK (R678Q, G890K)"
   mutantTest5 should "contain 1 entity with 2 Mutant modification" in {
-    val mentions = parseSentence(mutantTest5)
+    val mentions = getBioMentions(mutantTest5)
     mentions should have size (2)
     mentions(0).countMutations should be (1)
     mentions(1).countMutations should be (1)
@@ -847,7 +847,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest6 = "K111M and K112M ASPP1 mutants and ASPP2"
   mutantTest6 should "countain 2 ASPP1 with 1 Mutant each and ASPP2 with 0 Mutant mods" in {
-    val mentions = parseSentence(mutantTest6)
+    val mentions = getBioMentions(mutantTest6)
     mentions should have size (3)
     val asppOne = mentions filter (_.text == "ASPP1")
     asppOne should have size (2)
@@ -864,7 +864,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest7 = "K111M, K112M, and K113M ASPP1 mutants and ASPP2"
   mutantTest7 should "countain 3 ASPP1 with 1 Mutant each and ASPP2 with 0 Mutant mods" in {
-    val mentions = parseSentence(mutantTest7)
+    val mentions = getBioMentions(mutantTest7)
     mentions should have size (4)
     val asppOne = mentions filter (_.text == "ASPP1")
     asppOne should have size (3)
@@ -883,7 +883,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest8 = "ASPP1 mutants K111M, K112M, and K113M and ASPP2"
   mutantTest8 should "countain 3 ASPP1 with 1 Mutant each and ASPP2 with 0 Mutant mods" in {
-    val mentions = parseSentence(mutantTest8)
+    val mentions = getBioMentions(mutantTest8)
     mentions should have size (4)
     val asppOne = mentions filter (_.text == "ASPP1")
     asppOne should have size (3)
@@ -902,7 +902,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest9 = "Ser785His mutant RAS"
   mutantTest9 should "contain 1 entity with 1 Mutant modification" in {
-    val mentions = parseSentence(mutantTest9)
+    val mentions = getBioMentions(mutantTest9)
     mentions should have size (1)
     mentions.head.countMutations should be (1)
     mentions.head hasMutation "Ser785His" should be (true)
@@ -910,7 +910,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest10 = "Ser785His RAS"
   mutantTest10 should "contain 1 entity with 1 Mutant modification" in {
-    val mentions = parseSentence(mutantTest10)
+    val mentions = getBioMentions(mutantTest10)
     mentions should have size (1)
     mentions.head.countMutations should be (1)
     mentions.head hasMutation "Ser785His" should be (true)
@@ -918,7 +918,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest11 = "Ser785His mutant of RAS"
   mutantTest11 should "contain 1 entity with 1 Mutant modification" in {
-    val mentions = parseSentence(mutantTest11)
+    val mentions = getBioMentions(mutantTest11)
     mentions should have size (1)
     mentions.head.countMutations should be (1)
     mentions.head hasMutation "Ser785His" should be (true)
@@ -926,7 +926,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest12 = "K111M, K112M, and K113M mutants of ASPP1 and the RAS complex are phosphorylated."
   mutantTest12 should "countain 3 ASPP1 with 1 Mutant each and ASPP2 with 0 Mutant mods" in {
-    val mentions = parseSentence(mutantTest12)
+    val mentions = getBioMentions(mutantTest12)
     mentions should have size (8)
     val asppOne = mentions filter (_.text == "ASPP1")
     asppOne should have size (3)
@@ -945,7 +945,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest13 = "Ser785His mutation of RAS"
   mutantTest13 should "contain 1 entity with 1 Mutant modification" in {
-    val mentions = parseSentence(mutantTest13)
+    val mentions = getBioMentions(mutantTest13)
     mentions should have size (1)
     mentions.head.countMutations should be (1)
     mentions.head hasMutation "Ser785His" should be (true)
@@ -953,7 +953,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest14 = "K111M, K112M, and K113M mutations of ASPP1 and the RAS complex are phosphorylated."
   mutantTest14 should "countain 3 ASPP1 with 1 Mutant each and ASPP2 with 0 Mutant mods" in {
-    val mentions = parseSentence(mutantTest14)
+    val mentions = getBioMentions(mutantTest14)
     mentions should have size (8)
     val asppOne = mentions filter (_.text == "ASPP1")
     asppOne should have size (3)
@@ -972,7 +972,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val mutantTest15 = "Mutation of the PIK3CA gene"
   mutantTest15 should "contain 1 entity with 1 Mutant modification" in {
-    val mentions = parseSentence(mutantTest15)
+    val mentions = getBioMentions(mutantTest15)
     mentions should have size (1)
     mentions.head.countMutations should be (1)
     mentions.head hasMutation "Mutation" should be (true)
@@ -980,7 +980,7 @@ class TestModifications extends FlatSpec with Matchers {
 
   val siteTest3 = "Phosphorylation (p) of Akt (Ser-473), mTOR (Ser 2448) and Rictor (Ser 792) was quantified."
   siteTest2 should "contain 3 Sites" in {
-    val mentions = parseSentence(siteTest3)
+    val mentions = getBioMentions(siteTest3)
     val sites = mentions.filter(_ matches "Site")
     sites should have size (3)
     sites.exists(_.text contains "Ser-473") should be (true)

--- a/src/test/scala/edu/arizona/sista/reach/TestRegulationEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestRegulationEvents.scala
@@ -31,7 +31,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent3 = "Interestingly, we observed two conserved putative MAPK phosphorylation sites in ASPP1 and ASPP2"
   sent3 should "contain 2 phosphorylations and 2 regulations" in {
-    val mentions = parseSentence(sent3)
+    val mentions = getBioMentions(sent3)
     hasEntity("MAPK", mentions) should be (true)
     hasEntity("ASPP1", mentions) should be (true)
     hasEntity("ASPP2", mentions) should be (true)
@@ -45,7 +45,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent4 = "We thus tested whether RAS activation may regulate ASPP2 phosphorylation"
   sent4 should "contain 1 phosphorylation and no regulation" in {
-    val mentions = parseSentence(sent4)
+    val mentions = getBioMentions(sent4)
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     // we don't do unspecified regulations anymore, only + and -
     hasPositiveRegulationByEntity("RAS", "Phosphorylation", List("ASPP2"), mentions) should be (false)
@@ -53,14 +53,14 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent5 = "MAPK1 was clearly able to phosphorylate the ASPP2 fragment in vitro"
   sent5 should "contain 1 regulation" in {
-    val mentions = parseSentence(sent5)
+    val mentions = getBioMentions(sent5)
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("MAPK1", "Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   val sent6 = "Under the same conditions, ASPP2 (693-1128) fragment phosphorylated by p38 SAPK had very low levels of incorporated 32P"
   sent6 should "contain 1 regulation" in {
-    val mentions = parseSentence(sent6)
+    val mentions = getBioMentions(sent6)
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     // TODO: This is failing because we're missing SAPK in "p38 SAPK"; we only get p38, but we used to get "p38 SAPK"
     hasPositiveRegulationByEntity("p38 SAPK", "Phosphorylation", List("ASPP2"), mentions) should be (true)
@@ -68,21 +68,21 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent7 = "The phosphorylated ASPP2 fragment by MAPK1 was digested by trypsin and fractioned on a high performance liquid chromatography."
   sent7 should "contain 1 regulation" in {
-    val mentions = parseSentence(sent7)
+    val mentions = getBioMentions(sent7)
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("MAPK1", "Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   val sent8 = "Hence ASPP2 can be phosphorylated at serine 827 by MAPK1 in vitro."
   sent8 should "contain 1 regulation" in {
-    val mentions = parseSentence(sent8)
+    val mentions = getBioMentions(sent8)
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("MAPK1", "Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   val sent10 = "ASPP1 fails to upregulate the phosphorylation of ASPP2."
   sent10 should "contains 1 regulation and 1 phosphorylation event" in {
-    val mentions = parseSentence(sent10)
+    val mentions = getBioMentions(sent10)
     // this matches over negative verbal triggers such as "fails"
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("ASPP1", "Phosphorylation", List("ASPP2"), mentions) should be (true)
@@ -90,7 +90,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent11 = "ASPP1 fails to downregulate the phosphorylation of ASPP2."
   sent11 should "contains 1 downregulation and 1 phosphorylation event" in {
-    val mentions = parseSentence(sent11)
+    val mentions = getBioMentions(sent11)
     // this matches over negative verbal triggers such as "fails"
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasNegativeRegulationByEntity("ASPP1", "Phosphorylation", List("ASPP2"), mentions) should be (true)
@@ -98,7 +98,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent12 = "ASPP1 downregulates the phosphorylation of ASPP2."
   sent12 should "contains 1 downregulation and 1 phosphorylation event" in {
-    val mentions = parseSentence(sent12)
+    val mentions = getBioMentions(sent12)
     // this matches over negative verbal triggers such as "fails"
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasNegativeRegulationByEntity("ASPP1", "Phosphorylation", List("ASPP2"), mentions) should be (true)
@@ -106,21 +106,21 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent13 = "The inhibition of ASPP1 increases the phosphorylation of ASPP2."
   sent13 should "contain 1 downregulation and NO upregulation events" in {
-    val mentions = parseSentence(sent13)
+    val mentions = getBioMentions(sent13)
     hasNegativeRegulationByEntity("ASPP1", "Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("ASPP1", "Phosphorylation", List("ASPP2"), mentions) should be (false)
   }
 
   val sent14 = "the phosphorylation of ASPP2 is increased by the inhibition of ASPP1."
   sent14 should "contain 1 downregulation and NO upregulation events" in {
-    val mentions = parseSentence(sent14, verbose = false)
+    val mentions = getBioMentions(sent14, verbose = false)
     hasNegativeRegulationByEntity("ASPP1", "Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("ASPP1", "Phosphorylation", List("ASPP2"), mentions) should be (false)
   }
 
   val sent15 = "We observed increased ERBB3 binding to PI3K following MEK inhibition (Figure 1D)."
   sent15 should "contain 1 negative regulation and NO positive activation or regulation events" in {
-    val mentions = parseSentence(sent15)
+    val mentions = getBioMentions(sent15)
     hasNegativeRegulationByEntity("MEK", "Binding", List("ERBB3", "PI3K"), mentions) should be (true)
     mentions.filter(_.label == "Negative_activation") should have size (0)
     mentions.filter(_.label == "Positive_activation") should have size (0)
@@ -128,7 +128,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent16 = "the inhibition of ASPP1 decreases ASPP2 phosphorylation."
   sent16 should "contain 1 positive regulation, and NO negative regulations or activations" in {
-    val mentions = parseSentence(sent16)
+    val mentions = getBioMentions(sent16)
     hasPositiveRegulationByEntity("ASPP1", "Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasNegativeRegulationByEntity("ASPP1", "Phosphorylation", List("ASPP2"), mentions) should be (false)
     mentions.filter(_.label.contains("activation")) should have size (0)
@@ -136,7 +136,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent17 = "ASPP1 is an activator of the ubiquitination of ASPP2"
   sent17 should "contain 1 positive regulation, and NO negative regulations or activations" in {
-    val mentions = parseSentence(sent17)
+    val mentions = getBioMentions(sent17)
     hasPositiveRegulationByEntity("ASPP1", "Ubiquitination", List("ASPP2"), mentions) should be (true)
     hasNegativeRegulationByEntity("ASPP1", "Ubiquitination", List("ASPP2"), mentions) should be (false)
     mentions.filter(_.label.contains("activation")) should have size (0)
@@ -144,7 +144,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent18 = "ASPP1 is an inhibitor of the ubiquitination of ASPP2"
   sent18 should "contain 1 negative regulation, and NO positive regulations or activations" in {
-    val mentions = parseSentence(sent18)
+    val mentions = getBioMentions(sent18)
     hasNegativeRegulationByEntity("ASPP1", "Ubiquitination", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("ASPP1", "Ubiquitination", List("ASPP2"), mentions) should be (false)
     mentions.filter(_.label.contains("activation")) should have size (0)
@@ -152,7 +152,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent19 = "The phosphorylation of ASPP1 inhibits the ubiquitination of ASPP2"
   sent19 should "contain a controller with a PTM" in {
-    val mentions = parseSentence(sent19)
+    val mentions = getBioMentions(sent19)
     val reg = mentions.find(_ matches "Negative_regulation")
     reg should be ('defined)
     reg.get.arguments should contain key ("controller")
@@ -172,7 +172,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent20 = "The binding of ASPP1 and ASPP2 promotes the phosphorylation of MEK"
   sent20 should "contain a controller with a complex" in {
-    val mentions = parseSentence(sent20)
+    val mentions = getBioMentions(sent20)
     val reg = mentions.find(_ matches "Positive_regulation")
     reg should be ('defined)
     reg.get.arguments should contain key ("controller")
@@ -191,7 +191,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent21 = "Human deoxycytidine kinase is phosphorylated by ASPP2 on serine 128."
   sent21 should "contain exactly one positive regulation and one phosphorylation with site" in {
-    val mentions = parseSentence(sent21)
+    val mentions = getBioMentions(sent21)
     mentions.filter(_ matches "Positive_regulation") should have size (1)
     val reg = mentions.find(_ matches "Positive_regulation")
     reg.get.arguments should contain key ("controller")
@@ -210,7 +210,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent22 = "Human deoxycytidine kinase is phosphorylated on serine 128 by ASPP2."
   sent22 should "contain exactly one positive regulation and one phosphorylation with site" in {
-    val mentions = parseSentence(sent22)
+    val mentions = getBioMentions(sent22)
     mentions.filter(_ matches "Positive_regulation") should have size (1)
     val reg = mentions.find(_ matches "Positive_regulation")
     reg.get.arguments should contain key ("controller")
@@ -230,14 +230,14 @@ class TestRegulationEvents extends FlatSpec with Matchers {
   // a weird text from the PMC384* where we used to overmatch
   val sent23 = "histone 2B phosphorylated by p38 SAPK had high levels of incorporated 32P, suggesting that p38 SAPK was active; while under the same conditions, ASPP2 (693-1128) fragment"
   sent23 should "contain 1 phosphorylation and 1 positive regulation" in {
-    val mentions = parseSentence(sent23)
+    val mentions = getBioMentions(sent23)
     mentions.filter(_.label == "Positive_regulation") should have size (1)
     mentions.filter(_.label == "Phosphorylation") should have size (1)
   }
 
   val sent24 = "The binding of BS1 and BS2 promotes the phosphorylation of MEK"
   sent24 should "contain one positive regulation" in {
-    val mentions = parseSentence(sent24)
+    val mentions = getBioMentions(sent24)
     val posReg = mentions.filter(_ matches "Positive_regulation")
     posReg should have size (1)
     posReg.head.arguments should contain key ("controller")
@@ -252,38 +252,38 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent25 = "ASPP1 aids in the translocation of Kras to the membrane"
   sent25 should "contain one positive regulation" in {
-    val mentions = parseSentence(sent25)
+    val mentions = getBioMentions(sent25)
     hasPositiveRegulationByEntity("ASPP1", "Translocation", List("Kras"), mentions) should be (true)
   }
 
 /*  val sent26 = "oncogenic Kras promotes tumorigenesis by inducing expression of NRF2"
   sent26 should "contain 1 positive regulation and 1 transcription" in {
-    val mentions = parseSentence(sent26)
+    val mentions = getBioMentions(sent26)
     hasPositiveRegulationByEntity("Kras", "Transcription", List("NRF2"), mentions) should be (true)
   }*/
 
   val sent27 = "rapamycin blocked the serum-stimulated phosphorylation of ERK"
   sent27 should "contain one regulation controlled by rapamycin" in {
-    val mentions = parseSentence(sent27)
+    val mentions = getBioMentions(sent27)
     hasNegativeRegulationByEntity("rapamycin", "Phosphorylation", List("ERK"), mentions) should be (true)
   }
 
   val sent28 = "rapamycin inhibition of the phosphorylation of ERK"
   sent28 should "contain one regulation controlled by rapamycin" in {
-    val mentions = parseSentence(sent28)
+    val mentions = getBioMentions(sent28)
     hasNegativeRegulationByEntity("rapamycin", "Phosphorylation", List("ERK"), mentions) should be (true)
   }
 
   val sent29 = "B-Raf phosphorylates MEK1 and MEK2 on Ser217 and Ser221"
   sent29 should "contain 4 phosphorylations and 4 regulations (GUS)" in {
-    val mentions = parseSentence(sent29)
+    val mentions = getBioMentions(sent29)
     mentions.filter(_.label == "Positive_regulation") should have size (4)
     mentions.filter(_.label == "Phosphorylation") should have size (4)
   }
 
   val sent30 = "Note that only K650M and K650E-FGFR3 mutants cause STAT1 phosphorylation"
   sent30 should "contain 1 phospho and 2 pos reg" in {
-    val mentions = parseSentence(sent30)
+    val mentions = getBioMentions(sent30)
     mentions.filter(_.label == "Positive_regulation") should have size (2)
     mentions.filter(_.label == "Phosphorylation") should have size (1)
     hasPositiveRegulationByEntity("FGFR3", "Phosphorylation", List("STAT1"), mentions) should be (true)
@@ -291,7 +291,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent31 = "Note that only K650M, K660M, and K650E-FGFR3 mutants cause STAT1 phosphorylation on Y123 and T546"
   sent31 should "contain 2 phospho and 6 pos reg" in {
-    val mentions = parseSentence(sent31)
+    val mentions = getBioMentions(sent31)
     mentions.filter(_.label == "Positive_regulation") should have size (6)
     mentions.filter(_.label == "Phosphorylation") should have size (2)
     hasPositiveRegulationByEntity("FGFR3", "Phosphorylation", List("STAT1", "Y123"), mentions) should be (true)
@@ -300,7 +300,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent32 = "p53-phosphorylation of ERK"
   sent32 should "contain 1 phospho and 1 pos reg" in {
-    val mentions = parseSentence(sent32)
+    val mentions = getBioMentions(sent32)
     mentions.filter(_.label == "Positive_regulation") should have size (1)
     mentions.filter(_.label == "Phosphorylation") should have size (1)
     hasPositiveRegulationByEntity("p53", "Phosphorylation", List("ERK"), mentions) should be (true)
@@ -309,7 +309,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
   // Unrelated to coref
   /*val sent33 = "Phosphorylation of PIMT by the RAF/ERK2 complex potentiates Med1 dependent transcriptional activity."
   sent33 should "contain 1 binding, 1 phospho, and 1 pos reg controlled by the complex (GUS)" in {
-    val mentions = parseSentence(sent33)
+    val mentions = getBioMentions(sent33)
     // TODO: this fails because we pick 2 controllers (RAF and ERK2) instead of the complex
     mentions.filter(_.label == "Positive_regulation") should have size (1)
     mentions.filter(_.label == "Phosphorylation") should have size (1)
@@ -319,14 +319,14 @@ class TestRegulationEvents extends FlatSpec with Matchers {
   // Unrelated to coref...
   /*val sent34 = "ATR and ATM phosphorylate p53 at Ser37 and Ser46 , respectively"
   sent34 should "contain only 2 (not 4!) pos regulations because of \"respectively\"" in {
-    val mentions = parseSentence(sent34)
+    val mentions = getBioMentions(sent34)
     // TODO: this fails because we generate 4 regs instead of 2, as "respectively" should enforce
     mentions.filter(_.label == "Positive_regulation") should have size (2)
   }*/
 
   val sent35 = "p53 can be acetylated by p300 and CBP at multiple lysine residues ( K164 , 370 , 372 , 373 , 381 , 382 and 386 ) ."
   sent35 should  "contain 16 positive regulations due to the multiple controllers and multiple sites" in {
-    val mentions = parseSentence(sent35)
+    val mentions = getBioMentions(sent35)
     // TODO: needs coref for sites ("residues"). We should get 7 pos regs by p300 and 7 by CBP
     // This is a great example for handling enumerations
     mentions.filter(_.label == "Positive_regulation") should have size (16)
@@ -334,14 +334,14 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent36 = "Taken together , these data suggest that decreased PTPN13 expression enhances EphrinB1 and Erk1 and phosphorylation in epithelial cells ."
   sent36 should "contain 2 negative regulations (not positive)" in {
-    val mentions = parseSentence(sent36)
+    val mentions = getBioMentions(sent36)
     // this tests that we capture amods for elements in the paths; necessary to correctly model semantic negatives
     mentions.filter(_.label == "Negative_regulation") should have size (2)
   }
 
   /*val sent37 = "First , while the extent of PTPN13 knock-down was not very efficient , it was enough to increase EphrinB1 phosphorylation"
   sent37 should "contain 1 negative regulation (not positive)" in {
-    val mentions = parseSentence(sent37)
+    val mentions = getBioMentions(sent37)
     // TODO: very hard. we we incorrectly label the reg as positive because we miss "knock-down", but that is missed because of the coref by "it"
     mentions.filter(_.label == "Negative_regulation") should have size (1)
     hasNegativeRegulationByEntity("PTPN13", "Phosphorylation", List("EphrinB1"), mentions) should be (true)
@@ -349,7 +349,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
 
   val sent38 = "These data are consistent with EphrinB1 being a PTPN13 phosphatase substrate and suggest that decreased PTPN13 expression in BL breast cancer cell lines increases phosphorylation of EphrinB1 ."
   sent38 should "contain 1 negative regulation (not positive)" in {
-    val mentions = parseSentence(sent38)
+    val mentions = getBioMentions(sent38)
     // this tests that we capture amods for elements in the paths; necessary to correctly model semantic negatives
     mentions.filter(_.label == "Negative_regulation") should have size (1)
   }
@@ -357,7 +357,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
   // Problematic because of inclusion of "combination of rapamycin"; "rapamycin is found as the cause
 /*  val sent39 = "inhibition of ERK phosphorylation by combination of rapamycin"
   sent39 should "contain 1 negative regulation and 1 phosphorylation" in {
-    val mentions = parseSentence(sent39)
+    val mentions = getBioMentions(sent39)
     mentions.filter(_ matches "Negative_regulation") should have size (1)
     mentions.filter(_ matches "Positive_regulation") should have size (0)
     mentions.filter(_ matches "Phosphorylation") should have size (1)

--- a/src/test/scala/edu/arizona/sista/reach/TestTemplaticSimpleEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestTemplaticSimpleEvents.scala
@@ -11,14 +11,14 @@ import TestUtils._
 class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
   val sent1 = "The phosphorylation on AKT was great."
   sent1 should "not produce a phosphorylation based on the preposition \"on\"" in {
-    val mentions = parseSentence(sent1)
+    val mentions = getBioMentions(sent1)
     val p = mentions.find(_ matches "Phosphorylation")
     p.isDefined should be (false)
   }
 
   val sent2 = "JAK3 phosphorylates three HuR residues (Y63, Y68, Y200)"
   sent2 should "extract 3 phosphorylations and 3 positive regulations" in {
-    val mentions = parseSentence(sent2)
+    val mentions = getBioMentions(sent2)
 
     val p = mentions.filter(_ matches "Phosphorylation")
     p should have size (3)
@@ -80,19 +80,19 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent8 = "We next considered the effect of Ras monoubiquitination on GAP-mediated hydrolysis"
   sent8 should "contain a ubiquitination" in {
-    val mentions = parseSentence(sent8)
+    val mentions = getBioMentions(sent8)
     hasEventWithArguments("Ubiquitination", List("Ras"), mentions) should be (true)
   }
 
   val sent9 = "The effects of monoubiquitination on Ras are not isoform-specific."
   sent9 should "contain a ubiquitination" in {
-    val mentions = parseSentence(sent9)
+    val mentions = getBioMentions(sent9)
     hasEventWithArguments("Ubiquitination", List("Ras"), mentions) should be (true)
   }
 
   val sent10 = "We measured the rate of GAP-mediated GTP hydrolysis and observed that the response of Ras ligated to Ubiquitin was identical"
   sent10 should "contain a ubiquitination NOT binding" in {
-    val mentions = parseSentence(sent10)
+    val mentions = getBioMentions(sent10)
     // per Ryan/Guang's comment this is Ubiq not Binding
     // we do not do hydrolysis, so we can ignore that
     hasEventWithArguments("Binding", List("Ras", "Ubiquitin"), mentions) should be (false)
@@ -103,238 +103,238 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
   /*
   val sent12 = "Here we show that monoubiquitination decreases the sensitivity of Ras to GAP-mediated hydrolysis"
   sent12 should "contain a ubiquitination" in {
-    val mentions = parseSentence(sent12)
+    val mentions = getBioMentions(sent12)
     hasEventWithArguments("Ubiquitination", List("Ras"), mentions) should be (true)
   }
   */
 
   val sent13 = "Indicating that p38 SAPK is not an efficient kinase for ASPP2 phosphorylation."
   sent13 should "contain a phosphorylation" in {
-    val mentions = parseSentence(sent13)
+    val mentions = getBioMentions(sent13)
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   val sent14a = "Experiments revealed ubiquitination at Lys residues 104 and 147 of K-Ras"
   sent14a should "contain 2 ubiquitinations" in {
-    val mentions = parseSentence(sent14a)
+    val mentions = getBioMentions(sent14a)
     mentions.filter(_ matches "Ubiquitination") should have size (2)
   }
 
   val sent14b = "Experiments revealed ubiquitination at Lys residues 117, 147, and 170 for H-Ras."
   sent14b should "contain 3 ubiquitinations" in {
-    val mentions = parseSentence(sent14b)
+    val mentions = getBioMentions(sent14b)
     mentions.filter(_ matches "Ubiquitination") should have size (3)
   }
 
   "testHydrolysisPass1" should "find 1 hydrolysis event" in {
-    val mentions = parseSentence("Ras-GDP is hydrolyzed by 26S proteasome without ubiquitination.")
+    val mentions = getBioMentions("Ras-GDP is hydrolyzed by 26S proteasome without ubiquitination.")
     hasEventWithArguments("Hydrolysis", List("Ras-GDP"), mentions) should be (true)
   }
 
   "testHydrolysisSubjNom1" should "find 1 hydrolysis event" in {
-    val mentions = parseSentence("MEK hydrolysis of Ras-GDP increased.")
+    val mentions = getBioMentions("MEK hydrolysis of Ras-GDP increased.")
     hasEventWithArguments("Hydrolysis", List("Ras-GDP"), mentions) should be (true)
   }
 
   "testHydrolysisObjNom1" should "find 1 hydrolysis event" in {
-    val mentions = parseSentence("Ras-GDP hydrolysis by MEK increased.")
+    val mentions = getBioMentions("Ras-GDP hydrolysis by MEK increased.")
     hasEventWithArguments("Hydrolysis", List("Ras-GDP"), mentions) should be (true)
   }
 
   "testHydrolysisSubjectRel1" should "find 1 hydrolysis event" in {
-    val mentions = parseSentence("Its many abnormal phenotypes can be rescued via Pde2, which specifically hydrolyzes Ras-GDP.")
+    val mentions = getBioMentions("Its many abnormal phenotypes can be rescued via Pde2, which specifically hydrolyzes Ras-GDP.")
     hasEventWithArguments("Hydrolysis", List("Ras-GDP"), mentions) should be (true)
   }
 
   "testHydrolysisSubjectRel2" should "find 1 hydrolysis event" in {
-    val mentions = parseSentence("Pde2, which has been found to hydrolyze Ras-GDP, activates MEK.")
+    val mentions = getBioMentions("Pde2, which has been found to hydrolyze Ras-GDP, activates MEK.")
     hasEventWithArguments("Hydrolysis", List("Ras-GDP"), mentions) should be (true)
   }
 
   "testHydrolysisSubjectRelApposition1" should "find 1 hydrolysis event" in {
-    val mentions = parseSentence("Its many abnormal phenotypes can be rescued via overexpressing Pde2, a phosphodiesterase that specifically hydrolyzes Ras-GDP.")
+    val mentions = getBioMentions("Its many abnormal phenotypes can be rescued via overexpressing Pde2, a phosphodiesterase that specifically hydrolyzes Ras-GDP.")
     hasEventWithArguments("Hydrolysis", List("Ras-GDP"), mentions) should be (true)
   }
 
   "testHydrolysisSubjectRelApposition2" should "find 1 hydrolysis event" in {
-    val mentions = parseSentence("A main rate-controlling step in RAS is renin, an enzyme that hydrolyzes Ras-GTP.")
+    val mentions = getBioMentions("A main rate-controlling step in RAS is renin, an enzyme that hydrolyzes Ras-GTP.")
     hasEventWithArguments("Hydrolysis", List("Ras-GTP"), mentions) should be (true)
   }
 
   "testHydrolysisObjectRel1" should "find 1 hydrolysis event" in {
-    val mentions = parseSentence("We measured transcription activation in the presence of MEK, which is hydrolyzed by CRP.")
+    val mentions = getBioMentions("We measured transcription activation in the presence of MEK, which is hydrolyzed by CRP.")
     hasEventWithArguments("Hydrolysis", List("MEK"), mentions) should be (true)
   }
 
   "testPhosphorylationDecl1" should "find 1 phosphorylation event and 1 regulation event" in {
-    val mentions = parseSentence("Ras is phosphorylating ASPP2.")
+    val mentions = getBioMentions("Ras is phosphorylating ASPP2.")
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testPhosphorylationPass1" should "find 1 phosphorylation event and 1 regulation event" in {
-    val mentions = parseSentence("ASPP2 is phosphorylated by Ras.")
+    val mentions = getBioMentions("ASPP2 is phosphorylated by Ras.")
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testPhosphorylationSubjNom1" should "find 1 phosphorylation event and 1 regulation event" in {
-    val mentions = parseSentence("Ras phosphorylation of ASPP2 increased.")
+    val mentions = getBioMentions("Ras phosphorylation of ASPP2 increased.")
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testPhosphorylationObjNom1" should "find 1 phosphorylation event and 1 regulation event" in {
-    val mentions = parseSentence("ASPP2 phosphorylation by Ras increased.")
+    val mentions = getBioMentions("ASPP2 phosphorylation by Ras increased.")
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testPhosphorylationSubjectRel1" should "find 1 phosphorylation event and 1 regulation event" in {
-    val mentions = parseSentence("Its many abnormal phenotypes can be rescued via Ras, which specifically phosphorylates ASPP2.")
+    val mentions = getBioMentions("Its many abnormal phenotypes can be rescued via Ras, which specifically phosphorylates ASPP2.")
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testPhosphorylationSubjectRel2" should "find 1 phosphorylation event and 1 regulation event" in {
-    val mentions = parseSentence("Ras, which has been found to phosphorylate ASPP2, activates MEK.")
+    val mentions = getBioMentions("Ras, which has been found to phosphorylate ASPP2, activates MEK.")
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testPhosphorylationSubjectRelApposition1" should "find 1 phosphorylation event and 1 regulation event" in {
-    val mentions = parseSentence("Its many abnormal phenotypes can be rescued via overexpressing Ras, an XXX that specifically phosphorylates ASPP2.")
+    val mentions = getBioMentions("Its many abnormal phenotypes can be rescued via overexpressing Ras, an XXX that specifically phosphorylates ASPP2.")
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testPhosphorylationSubjectRelApposition2" should "find 1 phosphorylation event" in {
-    val mentions = parseSentence("A main rate-controlling step in AAAA is renin, an enzyme that phosphorylates ASPP2 to generate XXXX")
+    val mentions = getBioMentions("A main rate-controlling step in AAAA is renin, an enzyme that phosphorylates ASPP2 to generate XXXX")
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testPhosphorylationObjectRel1" should "find 1 phosphorylation event and 1 regulation event" in {
-    val mentions = parseSentence("We measured transcription activation in the presence of ASPP2, which is phosphorylated by Ras.")
+    val mentions = getBioMentions("We measured transcription activation in the presence of ASPP2, which is phosphorylated by Ras.")
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Phosphorylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testHydroxylationDecl1" should "find 1 hydroxylation event and 1 regulation event" in {
-    val mentions = parseSentence("Ras is hydroxylating ASPP2.")
+    val mentions = getBioMentions("Ras is hydroxylating ASPP2.")
     hasEventWithArguments("Hydroxylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Hydroxylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testHydroxylationPass1" should "find 1 hydroxylation event and 1 regulation event" in {
-    val mentions = parseSentence("ASPP2 is hydroxylated by Ras.")
+    val mentions = getBioMentions("ASPP2 is hydroxylated by Ras.")
     hasEventWithArguments("Hydroxylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Hydroxylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testHydroxylationSubjNom1" should "find 1 hydroxylation event and 1 regulation event" in {
-    val mentions = parseSentence("Ras hydroxylation of ASPP2 increased.")
+    val mentions = getBioMentions("Ras hydroxylation of ASPP2 increased.")
     hasEventWithArguments("Hydroxylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Hydroxylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testHydroxylationObjNom1" should "find 1 hydroxylation event and 1 regulation event" in {
-    val mentions = parseSentence("ASPP2 hydroxylation by Ras increased.")
+    val mentions = getBioMentions("ASPP2 hydroxylation by Ras increased.")
     hasEventWithArguments("Hydroxylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Hydroxylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testHydroxylationSubjectRel1" should "find 1 hydroxylation event and 1 regulation event" in {
-    val mentions = parseSentence("Its many abnormal phenotypes can be rescued via Ras, which specifically hydroxylates ASPP2.")
+    val mentions = getBioMentions("Its many abnormal phenotypes can be rescued via Ras, which specifically hydroxylates ASPP2.")
     hasEventWithArguments("Hydroxylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Hydroxylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testHydroxylationSubjectRel2" should "find 1 hydroxylation event and 1 regulation event" in {
-    val mentions = parseSentence("Ras, which has been found to hydroxylate ASPP2, activates MEK.")
+    val mentions = getBioMentions("Ras, which has been found to hydroxylate ASPP2, activates MEK.")
     hasEventWithArguments("Hydroxylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Hydroxylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testHydroxylationSubjectRelApposition1" should "find 1 hydroxylation event and 1 regulation event" in {
-    val mentions = parseSentence("Its many abnormal phenotypes can be rescued via overexpressing Ras, an XXX that specifically hydroxylates ASPP2.")
+    val mentions = getBioMentions("Its many abnormal phenotypes can be rescued via overexpressing Ras, an XXX that specifically hydroxylates ASPP2.")
     hasEventWithArguments("Hydroxylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Hydroxylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testHydroxylationSubjectRelApposition2" should "find 1 hydroxylation event" in {
-    val mentions = parseSentence("A main rate-controlling step in AAAA is renin, an enzyme that hydroxylates ASPP2 to generate XXXX")
+    val mentions = getBioMentions("A main rate-controlling step in AAAA is renin, an enzyme that hydroxylates ASPP2 to generate XXXX")
     hasEventWithArguments("Hydroxylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testHydroxylationObjectRel1" should "find 1 hydroxylation event and 1 regulation event" in {
-    val mentions = parseSentence("We measured transcription activation in the presence of ASPP2, which is hydroxylated by Ras.")
+    val mentions = getBioMentions("We measured transcription activation in the presence of ASPP2, which is hydroxylated by Ras.")
     hasEventWithArguments("Hydroxylation", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Hydroxylation", List("ASPP2"), mentions) should be (true)
   }
 
   "testUbiquitinationDecl1" should "find 1 ubiquitination event and 1 regulation event" in {
-    val mentions = parseSentence("Ras is ubiquitinating ASPP2.")
+    val mentions = getBioMentions("Ras is ubiquitinating ASPP2.")
     hasEventWithArguments("Ubiquitination", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Ubiquitination", List("ASPP2"), mentions) should be (true)
   }
 
   "testUbiquitinationPass1" should "find 1 ubiquitination event and 1 regulation event" in {
-    val mentions = parseSentence("ASPP2 is ubiquitinated by Ras.")
+    val mentions = getBioMentions("ASPP2 is ubiquitinated by Ras.")
     hasEventWithArguments("Ubiquitination", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Ubiquitination", List("ASPP2"), mentions) should be (true)
   }
 
   "testUbiquitinationSubjNom1" should "find 1 ubiquitination event and 1 regulation event" in {
-    val mentions = parseSentence("Ras ubiquitination of ASPP2 increased.")
+    val mentions = getBioMentions("Ras ubiquitination of ASPP2 increased.")
     hasEventWithArguments("Ubiquitination", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Ubiquitination", List("ASPP2"), mentions) should be (true)
   }
 
   "testUbiquitinationObjNom1" should "find 1 ubiquitination event and 1 regulation event" in {
-    val mentions = parseSentence("ASPP2 ubiquitination by Ras increased.")
+    val mentions = getBioMentions("ASPP2 ubiquitination by Ras increased.")
     hasEventWithArguments("Ubiquitination", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Ubiquitination", List("ASPP2"), mentions) should be (true)
   }
 
   "testUbiquitinationObjNom2" should "find 1 ubiquitination event and 2 regulation events" in {
-    val mentions = parseSentence("RAS ubiquitination and degradation by ASPP2 and p53 increased.")
+    val mentions = getBioMentions("RAS ubiquitination and degradation by ASPP2 and p53 increased.")
     hasEventWithArguments("Ubiquitination", List("RAS"), mentions) should be (true)
     hasPositiveRegulationByEntity("ASPP2", "Ubiquitination", List("RAS"), mentions) should be (true)
     hasPositiveRegulationByEntity("p53", "Ubiquitination", List("RAS"), mentions) should be (true)
   }
 
   "testUbiquitinationSubjectRel1" should "find 1 ubiquitination event and 1 regulation event" in {
-    val mentions = parseSentence("Its many abnormal phenotypes can be rescued via Ras, which specifically ubiquitinates ASPP2.")
+    val mentions = getBioMentions("Its many abnormal phenotypes can be rescued via Ras, which specifically ubiquitinates ASPP2.")
     hasEventWithArguments("Ubiquitination", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Ubiquitination", List("ASPP2"), mentions) should be (true)
   }
 
   "testUbiquitinationSubjectRel2" should "find 1 ubiquitination event and 1 regulation event" in {
-    val mentions = parseSentence("Ras, which has been found to ubiquitinate ASPP2, activates MEK.")
+    val mentions = getBioMentions("Ras, which has been found to ubiquitinate ASPP2, activates MEK.")
     hasEventWithArguments("Ubiquitination", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Ubiquitination", List("ASPP2"), mentions) should be (true)
   }
 
   "testUbiquitinationSubjectRelApposition1" should "find 1 ubiquitination event and 1 regulation event" in {
-    val mentions = parseSentence("Its many abnormal phenotypes can be rescued via overexpressing Ras, an XXX that specifically ubiquitinates ASPP2.")
+    val mentions = getBioMentions("Its many abnormal phenotypes can be rescued via overexpressing Ras, an XXX that specifically ubiquitinates ASPP2.")
     hasEventWithArguments("Ubiquitination", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Ubiquitination", List("ASPP2"), mentions) should be (true)
   }
 
   "testUbiquitinationSubjectRelApposition2" should "find 1 ubiquitination event" in {
-    val mentions = parseSentence("A main rate-controlling step in AAAA is renin, an enzyme that ubiquitinates ASPP2 to generate XXXX")
+    val mentions = getBioMentions("A main rate-controlling step in AAAA is renin, an enzyme that ubiquitinates ASPP2 to generate XXXX")
     hasEventWithArguments("Ubiquitination", List("ASPP2"), mentions) should be (true)
   }
 
   "testUbiquitinationObjectRel1" should "find 1 ubiquitination event and 1 regulation event" in {
-    val mentions = parseSentence("We measured transcription activation in the presence of ASPP2, which is ubiquitinated by Ras.")
+    val mentions = getBioMentions("We measured transcription activation in the presence of ASPP2, which is ubiquitinated by Ras.")
     hasEventWithArguments("Ubiquitination", List("ASPP2"), mentions) should be (true)
     hasPositiveRegulationByEntity("Ras", "Ubiquitination", List("ASPP2"), mentions) should be (true)
   }
 
   val sent15 = "ASPP2 phosphorylates p53 at serine 125 and serine 126."
   sent15 should "contains 2 phosphorylation and 2 regulation events" in {
-    val mentions = parseSentence(sent15)
+    val mentions = getBioMentions(sent15)
 
     val p = mentions.filter(_ matches "Phosphorylation")
     p should have size (2)
@@ -347,7 +347,7 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent16 = "ASPP2 phosphorylates p53 at serine 125, 126, and 127."
   sent16 should "contain 3 phosphorylation and 3 regulation events" in {
-    val mentions = parseSentence(sent16)
+    val mentions = getBioMentions(sent16)
 
     val p = mentions.filter(_ matches "Phosphorylation")
     p should have size (3)
@@ -360,7 +360,7 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent17 = "Its many abnormal phenotypes can be rescued via Pde2, which does not hydrolyze Ras-GDP."
   sent17 should "contain a negated regulated hydrolysis" in {
-    val mentions = parseSentence(sent17)
+    val mentions = getBioMentions(sent17)
     val h = mentions.filter(_ matches "Hydrolysis")
     h should have size 1
     hasEventWithArguments("Hydrolysis", List("Ras-GDP"), mentions) should be (true)
@@ -369,7 +369,7 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent18 = "Ras does not phosphorylate ASPP2."
   sent18 should "contain a negated regulated phosphorylation" in {
-    val mentions = parseSentence(sent18)
+    val mentions = getBioMentions(sent18)
     val p = mentions.filter(_ matches "Phosphorylation")
     p should have size 1
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
@@ -378,7 +378,7 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent19 = "Its many abnormal phenotypes can be rescued via overexpressing Ras, an XXX that does not phosphorylate ASPP2."
   sent19 should "contain a negated regulated phosphorylation" in {
-    val mentions = parseSentence(sent19)
+    val mentions = getBioMentions(sent19)
     val h = mentions.filter(_ matches "Phosphorylation")
     h should have size 1
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
@@ -387,7 +387,7 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent20 = "We measured transcription activation in the presence of ASPP2, which is not ubiquitinated by Ras."
   sent20 should "contain a negated regulated ubiquitination" in {
-    val mentions = parseSentence(sent20)
+    val mentions = getBioMentions(sent20)
     val u = mentions.filter(_ matches "Ubiquitination")
     u should have size 1
     hasEventWithArguments("Ubiquitination", List("ASPP2"), mentions) should be (true)
@@ -396,7 +396,7 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent21 = "phosphorylation of HuR at Y200 influences the response of immune cells to cytokines"
   sent21 should "contain a single phosphorylation with site" in {
-    val mentions = parseSentence(sent21)
+    val mentions = getBioMentions(sent21)
     val p = mentions.filter(_ matches "Phosphorylation")
     p should have size (1)
     hasEventWithArguments("Phosphorylation", List("HuR", "Y200"), mentions) should be (true)
@@ -404,7 +404,7 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent22 = "CK2 phosphorylation of XRCC1 stimulates binding to either PNK or aprataxin"
   sent22 should "not contain a phosphorylation with CK2 as theme" in {
-    val mentions = parseSentence(sent22)
+    val mentions = getBioMentions(sent22)
     hasEventWithArguments("Phosphorylation", List("XRCC1"), mentions) should be (true)
     hasEventWithArguments("Phosphorylation", List("CK2"), mentions) should be (false)
     hasPositiveRegulationByEntity("CK2", "Phosphorylation", List("XRCC1"), mentions) should be (true)
@@ -412,7 +412,7 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent23 = "Shown in Figure     is a Western blot detecting the phosphorylation of the mTOR substrate, 4EBP1."
   sent23 should "contain a phosphorylation of 4EBP1 not mTOR (GUS)" in {
-    val mentions = parseSentence(sent23)
+    val mentions = getBioMentions(sent23)
     hasEventWithArguments("Phosphorylation", List("4EBP1"), mentions) should be (true)
     // the above applies to ALL events taking proteins as arguments, including activations and regulations...
     hasEventWithArguments("Phosphorylation", List("mTOR"), mentions) should be (false)
@@ -420,42 +420,42 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent24 = "We found that XRCC1 can be phosphorylated on S371 by DNA-PK"
   sent24 should "contain 1 phosphorylation and 1 cause" in {
-    val mentions = parseSentence(sent24)
+    val mentions = getBioMentions(sent24)
     hasEventWithArguments("Phosphorylation", List("XRCC1", "S371"), mentions) should be (true)
     hasPositiveRegulationByEntity("DNA-PK", "Phosphorylation", List("XRCC1", "S371"), mentions) should be (true)
   }
 
   val sent25 = "We found that XRCC1 R399Q can be phosphorylated on S371 by DNA-PK"
   sent25 should "contain 1 phosphorylation on S371 and not R399Q, which is a mutation (GUS)" in {
-    val mentions = parseSentence(sent25)
+    val mentions = getBioMentions(sent25)
     hasEventWithArguments("Phosphorylation", List("XRCC1", "S371"), mentions) should be (true)
     hasEventWithArguments("Phosphorylation", List("XRCC1", "R399Q"), mentions) should be (false)
   }
 
   val sent25b = "We found that R399Q-XRCC1 mutant can be phosphorylated on S371 by DNA-PK"
   sent25b should "contain 1 phosphorylation on S371 and not R399Q, which is a mutation (GUS)" in {
-    val mentions = parseSentence(sent25b)
+    val mentions = getBioMentions(sent25b)
     hasEventWithArguments("Phosphorylation", List("XRCC1", "S371"), mentions) should be (true)
     hasEventWithArguments("Phosphorylation", List("XRCC1", "R399Q"), mentions) should be (false)
   }
 
   val sent26 = "The BRCT1 domain of XRCC1 is phosphorylated in vitro by DNA-PK"
   sent26 should "contain 1 phospho with site + 1 reg (GUS)" in {
-    val mentions = parseSentence(sent26)
+    val mentions = getBioMentions(sent26)
     hasEventWithArguments("Phosphorylation", List("XRCC1", "BRCT1 domain"), mentions) should be (true)
     hasPositiveRegulationByEntity("DNA-PK", "Phosphorylation", List("XRCC1", "BRCT1 domain"), mentions) should be (true)
   }
 
   val sent27 = "The study reveals that XRCC1 is phosphorylated by the co-immunoprecipitated DNA-PK."
   sent27 should "contain 1 phospho + 1 reg (GUS)" in {
-    val mentions = parseSentence(sent27)
+    val mentions = getBioMentions(sent27)
     hasEventWithArguments("Phosphorylation", List("XRCC1"), mentions) should be (true)
     hasPositiveRegulationByEntity("DNA-PK", "Phosphorylation", List("XRCC1"), mentions) should be (true)
   }
 
   val sent28 = "all six FGFR3 mutants induced activatory ERK(T202/Y204) phosphorylation (Fig. 2)."
   sent28 should "contain 2 phospho + 2 pos reg (GUS/MARCO)" in {
-    val mentions = parseSentence(sent28)
+    val mentions = getBioMentions(sent28)
     hasEventWithArguments("Phosphorylation", List("ERK", "T202"), mentions) should be (true)
     hasEventWithArguments("Phosphorylation", List("ERK", "Y204"), mentions) should be (true)
     hasPositiveRegulationByEntity("FGFR3", "Phosphorylation", List("ERK", "T202"), mentions) should be (true)
@@ -464,28 +464,28 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent29 = "Figure 5 shows that only the K650M and K650E mutants caused significant STAT5(Y694) phosphorylation"
   sent29 should "contain 1 phospho (GUS/MARCO)" in {
-    val mentions = parseSentence(sent29)
+    val mentions = getBioMentions(sent29)
     // TODO: mutants caused X...should be this be Reg. of some kind?
     hasEventWithArguments("Phosphorylation", List("STAT5", "Y694"), mentions) should be (true)
   }
 
   val sent30 = "we found slight STAT1(Y701) phosphorylation induced by wild-type FGFR3."
   sent30 should "contain 1 phospho and 1 pos reg" in {
-    val mentions = parseSentence(sent30)
+    val mentions = getBioMentions(sent30)
     hasEventWithArguments("Phosphorylation", List("STAT1", "Y701"), mentions) should be (true)
     hasPositiveRegulationByEntity("FGFR3", "Phosphorylation", List("STAT1", "Y701"), mentions) should be (true)
   }
 
   val sent31 = "We found that endogenous K-Ras and H-Ras underwent mono-ubiquitination in HEK293T cells."
   sent31 should "contain 2 ubiquitinations" in {
-    val mentions = parseSentence(sent31)
+    val mentions = getBioMentions(sent31)
     hasEventWithArguments("Ubiquitination", List("K-Ras"), mentions) should be (true)
     hasEventWithArguments("Ubiquitination", List("H-Ras"), mentions) should be (true)
   }
 
   val sent32 = "The K650M, K660M, and K650E-FGFR3 mutants are phosphorylated on Y123 and T546"
   sent32 should "contain 6 phosphos" in {
-    val mentions = parseSentence(sent32)
+    val mentions = getBioMentions(sent32)
     mentions.filter(_ matches "Phosphorylation") should have size (6)
     hasEventWithArguments("Phosphorylation", List("FGFR3", "Y123"), mentions) should be (true)
     hasEventWithArguments("Phosphorylation", List("FGFR3", "T546"), mentions) should be (true)
@@ -493,7 +493,7 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent33 = "blot analysis of in vitro p53-acetylation"
   sent33 should "contain 1 entity and 1 acetylation" in {
-    val mentions = parseSentence(sent33)
+    val mentions = getBioMentions(sent33)
     mentions.filter(_ matches "Gene_or_gene_product") should have size (1) // blot should not be an entity
     mentions.filter(_ matches "Acetylation") should have size (1)
     hasEventWithArguments("Acetylation", List("p53"), mentions) should be (true)
@@ -501,7 +501,7 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
 
   val sent34 = "p35 regulation of GSK3betaser9 phosphorylation"
   sent34 should "not contain a phospho of p35 (GUS)" in {
-    val mentions = parseSentence(sent34)
+    val mentions = getBioMentions(sent34)
     // TODO: this fails because the *_token_8_noun rule over matches. Please fix
     hasEventWithArguments("Phosphorylation", List("p35"), mentions) should be (false)
   }

--- a/src/test/scala/edu/arizona/sista/reach/TestTokenPatterns.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestTokenPatterns.scala
@@ -5,9 +5,11 @@ import edu.arizona.sista.processors.bionlp.BioNLPProcessor
 import edu.arizona.sista.struct.Interval
 import edu.arizona.sista.odin.impl.TokenPattern
 import edu.arizona.sista.odin._
+import TestUtils._
 
 class TestTokenPatterns extends FlatSpec with Matchers {
-  val proc = new BioNLPProcessor
+  // use shared processor instance from TestUtils
+  val proc = bioproc
   val text1 = "TGFBR2 phosphorylates peri-kappa B and inhibits the ubiquitination of SMAD3."
   val text2 = "TGFBR2 phosphorylates peri-kappa B and peri-kappa C and inhibits the ubiquitination of SMAD3."
   val text3 = "TGFBR2 phosphorylates peri-kappa B and peri-kappa C by TGFBR3 and inhibits the ubiquitination of SMAD3."

--- a/src/test/scala/edu/arizona/sista/reach/TestTranscriptionEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestTranscriptionEvents.scala
@@ -13,7 +13,7 @@ import org.scalatest.{Matchers, FlatSpec}
    val sent1 = "expression of NRF2 by Kras"
 
    sent1 should "contain a transcription event" in {
-     val mentions = parseSentence(sent1)
+     val mentions = getBioMentions(sent1)
      hasEventWithArguments("Positive_regulation", List("Kras"), mentions) should be (true)
      hasEventWithArguments("Transcription", List("NRF2"), mentions) should be (true)
    }
@@ -21,28 +21,28 @@ import org.scalatest.{Matchers, FlatSpec}
    val sent2 = "ErbB3 gene transcription"
 
    sent2 should "contain a transcription event" in {
-     val mentions = parseSentence(sent2)
+     val mentions = getBioMentions(sent2)
      hasEventWithArguments("Transcription", List("ErbB3"), mentions) should be (true)
    }
 
    val sent3 = "Transcription of Kras"
 
    sent3 should "contain a transcription event" in {
-     val mentions = parseSentence(sent3)
+     val mentions = getBioMentions(sent3)
      hasEventWithArguments("Transcription", List("Kras"), mentions) should be (true)
    }
 
    val sent4 = "PTEN protein expression was detectable by Western blot in all cell lines."
 
    sent4 should "contain a transcription event" in {
-     val mentions = parseSentence(sent4)
+     val mentions = getBioMentions(sent4)
      hasEventWithArguments("Transcription", List("PTEN"), mentions) should be (true)
    }
 
    val sent6 = "Indeed, EGFR is overexpressed by Mek in 30%-85% patients with CRC."
 
    sent6 should "contain a transcription event" in {
-     val mentions = parseSentence(sent6)
+     val mentions = getBioMentions(sent6)
      hasEventWithArguments("Positive_regulation", List("Mek"), mentions) should be (true)
      hasEventWithArguments("Transcription", List("EGFR"), mentions) should be (true)
    }
@@ -50,7 +50,7 @@ import org.scalatest.{Matchers, FlatSpec}
    val sent7 = "We went on to examine the levels of MCL-1 and BIM expressed in several uveal melanoma cell lines"
 
    sent7 should "contain two transcription events" in {
-     val mentions = parseSentence(sent7)
+     val mentions = getBioMentions(sent7)
      hasEventWithArguments("Transcription", List("BIM"), mentions) should be (true)
      hasEventWithArguments("Transcription", List("MCL-1"), mentions) should be (true)
    }

--- a/src/test/scala/edu/arizona/sista/reach/TestTranslocationEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestTranslocationEvents.scala
@@ -12,7 +12,7 @@ class TestTranslocationEvents extends FlatSpec with Matchers {
 
   /*val sent1 = "We show here that ASPP2 is phosphorylated by the RAS/Raf/MAPK pathway and that this phosphorylation leads to its increased translocation to the cytosol or nucleus and increased binding to p53"
   sent1 should "contain 2 translocation events" in {
-    val mentions = parseSentence(sent1)
+    val mentions = getBioMentions(sent1)
 
     hasEventWithArguments("Phosphorylation", List("ASPP2"), mentions) should be (true)
 
@@ -26,7 +26,7 @@ class TestTranslocationEvents extends FlatSpec with Matchers {
 
   val sent2 = "ASPP2 is transported from the membrane to the nucleus and cytosol"
   sent2 should "contain 2 translocation events for ASPP2" in {
-    val mentions = parseSentence(sent2)
+    val mentions = getBioMentions(sent2)
 
     hasEventWithArguments("Translocation", List("ASPP2", "membrane", "cytosol"), mentions) should be (true)
     hasEventWithArguments("Translocation", List("ASPP2", "membrane", "nucleus"), mentions) should be (true)
@@ -37,21 +37,21 @@ class TestTranslocationEvents extends FlatSpec with Matchers {
   val sent3b = "ASPP1 is common, and its release from the plasma membrane and nuclear membrane increases with its phosphorylation."
   val sent3c = "ASPP1 is common, and its release from the plasma membrane and nuclear membrane to the cytosol increases with its phosphorylation."
   sent3a should "contain two translocation events" in {
-    val mentions = parseSentence(sent3a)
+    val mentions = getBioMentions(sent3a)
     mentions filter (_ matches "Translocation") should have size (2)
     hasEventWithArguments("Translocation", List("ASPP1", "plasma membrane"), mentions) should be (true)
     hasEventWithArguments("Translocation", List("ASPP1", "nuclear membrane"), mentions) should be (true)
   }
 
   sent3b should "contain two translocation events" in {
-    val mentions = parseSentence(sent3b)
+    val mentions = getBioMentions(sent3b)
     mentions filter (_ matches "Translocation") should have size (2)
     hasEventWithArguments("Translocation", List("ASPP1", "plasma membrane"), mentions) should be (true)
     hasEventWithArguments("Translocation", List("ASPP1", "nuclear membrane"), mentions) should be (true)
   }
 
   sent3c should "contain two translocation events" in {
-    val mentions = parseSentence(sent3c)
+    val mentions = getBioMentions(sent3c)
     mentions filter (_ matches "Translocation") should have size (2)
     hasEventWithArguments("Translocation", List("ASPP1", "plasma membrane", "cytosol"), mentions) should be (true)
     hasEventWithArguments("Translocation", List("ASPP1", "nuclear membrane", "cytosol"), mentions) should be (true)
@@ -59,29 +59,29 @@ class TestTranslocationEvents extends FlatSpec with Matchers {
 
 
   "testTranslocation1" should "find 1 translocation event" in {
-    val mentions = parseSentence("Phosphorylation leads the plasma membrane to release p53 to the cytosol.")
+    val mentions = getBioMentions("Phosphorylation leads the plasma membrane to release p53 to the cytosol.")
     hasEventWithArguments("Translocation", List("p53", "plasma membrane", "cytosol"), mentions) should be (true)
   }
 
   "testTranslocation2" should "find 1 translocation event" in {
-    val mentions = parseSentence("Recruitment of p53 from the cytosol to the plasma membrane increases with phosphorylation.")
+    val mentions = getBioMentions("Recruitment of p53 from the cytosol to the plasma membrane increases with phosphorylation.")
     hasEventWithArguments("Translocation", List("p53", "plasma membrane", "cytosol"), mentions) should be (true)
   }
 
   "testTranslocation3" should "find 1 translocation event" in {
-    val mentions = parseSentence("With increased phosphorylation, p53 is exported from the plasma membrane to the cytosol.")
+    val mentions = getBioMentions("With increased phosphorylation, p53 is exported from the plasma membrane to the cytosol.")
     hasEventWithArguments("Translocation", List("p53", "plasma membrane", "cytosol"), mentions) should be (true)
   }
 
   "testTranslocation4" should "find 1 translocation event" in {
-    val mentions = parseSentence("ASPP2, a protein which is translocated from the membrane to the nucleus, is subsequently phosphorylated.")
+    val mentions = getBioMentions("ASPP2, a protein which is translocated from the membrane to the nucleus, is subsequently phosphorylated.")
     mentions.count(_ matches "Translocation") should be (1)
     mentions.count(_ matches "Phosphorylation") should be (1)
     hasEventWithArguments("Translocation", List("ASPP2", "membrane", "nucleus"), mentions) should be (true)
   }
 
   "testTranslocation5" should "find 1 translocation event" in {
-    val mentions = parseSentence("ASPP2, a protein which translocates Pde2 from the membrane to the nucleus, is subsequently phosphorylated.")
+    val mentions = getBioMentions("ASPP2, a protein which translocates Pde2 from the membrane to the nucleus, is subsequently phosphorylated.")
     mentions.count(_ matches "Translocation") should be (1)
     mentions.count(_ matches "Phosphorylation") should be (1)
     hasEventWithArguments("Translocation", List("Pde2", "membrane", "nucleus"), mentions) should be (true)
@@ -89,14 +89,14 @@ class TestTranslocationEvents extends FlatSpec with Matchers {
   }
 
   "testTranslocation6" should "find 2 translocation events" in {
-    val mentions = parseSentence("KRAS translocation to the cytosol and nucleus")
+    val mentions = getBioMentions("KRAS translocation to the cytosol and nucleus")
     mentions.filter(_ matches "Translocation") should have size (2)
     hasEventWithArguments("Translocation", List("KRAS", "cytosol"), mentions) should be (true)
     hasEventWithArguments("Translocation", List("KRAS", "nucleus"), mentions) should be (true)
   }
 
   "testTranslocation7" should "find 1 translocation with a regulation" in {
-    val mentions = parseSentence("ASPP2, a protein which is translocated from the membrane to the nucleus by ASPP1, is subsequently phosphorylated")
+    val mentions = getBioMentions("ASPP2, a protein which is translocated from the membrane to the nucleus by ASPP1, is subsequently phosphorylated")
     mentions.filter(_.label == "Translocation") should have size (1)
     hasEventWithArguments("Translocation", List("ASPP2", "membrane", "nucleus"), mentions) should be (true)
     hasPositiveRegulationByEntity("ASPP1", "Translocation", Seq("ASPP2", "membrane", "nucleus"), mentions) should be (true)

--- a/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
@@ -17,11 +17,11 @@ object TestUtils {
   val chunkId = "1"
   val mentionManager = new MentionManager()
 
-  def parseSentence(sentence:String, verbose:Boolean = false):Seq[BioMention] = {
-    val entry = FriesEntry(docId, chunkId, "example", "example", isTitle = false, sentence)
+  def getBioMentions(text:String, verbose:Boolean = false):Seq[BioMention] = {
+    val entry = FriesEntry(docId, chunkId, "example", "example", isTitle = false, text)
     val result = Try(testReach.extractFrom(entry))
     if(! result.isSuccess)
-      throw new RuntimeException("ERROR: parseSentence failed on sentence: " + sentence)
+      throw new RuntimeException("ERROR: getBioMentions failed on sentence: " + text)
     val mentions = printMentions(result, verbose)
     mentions
   }
@@ -31,7 +31,7 @@ object TestUtils {
     // Get only entities (after modficationEngine)
     val result = Try(testReach.extractEntitiesFrom(doc))
     if(! result.isSuccess)
-      throw new RuntimeException("ERROR: parseSentence failed on sentence: " + sentence)
+      throw new RuntimeException("ERROR: getBioMentions failed on sentence: " + sentence)
     val mentions = printMentions(result, verbose)
     mentions
   }

--- a/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
@@ -13,6 +13,7 @@ import scala.util.Try
  */
 object TestUtils {
   val testReach = new ReachSystem // All tests should use this system!
+  val bioproc = testReach.processor // quick access to a process, if needed.
   val docId = "testdoc"
   val chunkId = "1"
   val mentionManager = new MentionManager()

--- a/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
@@ -1,6 +1,6 @@
 package edu.arizona.sista.reach
 
-import edu.arizona.sista.reach.nxml.FriesEntry
+import edu.arizona.sista.reach.nxml.{NxmlReader, FriesEntry}
 import edu.arizona.sista.reach.display._
 import edu.arizona.sista.reach.extern.export.MentionManager
 import edu.arizona.sista.reach.mentions._
@@ -13,6 +13,7 @@ import scala.util.Try
  */
 object TestUtils {
   val testReach = new ReachSystem // All tests should use this system!
+  val testReader = new NxmlReader
   val bioproc = testReach.processor // quick access to a process, if needed.
   val docId = "testdoc"
   val chunkId = "1"

--- a/src/test/scala/edu/arizona/sista/reach/context/TestDeterministicPolicies.scala
+++ b/src/test/scala/edu/arizona/sista/reach/context/TestDeterministicPolicies.scala
@@ -1,30 +1,24 @@
 package edu.arizona.sista.reach.context
 
+import edu.arizona.sista.reach.TestUtils._
 import io.Source
-import scala.collection.mutable
 import org.scalatest.{Matchers, FlatSpec}
-import edu.arizona.sista.reach.nxml.NxmlReader
 import edu.arizona.sista.reach.mentions._
-import edu.arizona.sista.reach.ReachSystem
 
 trait Fixtures {
   // Set up the fixtures
   def nxml1 = Source.fromURL(getClass.getResource("/inputs/nxml/PMC2597732.nxml")).mkString
   def nxml2 = Source.fromURL(getClass.getResource("/inputs/nxml/PMC3441633.nxml")).mkString
   def nxml3 = Source.fromURL(getClass.getResource("/inputs/nxml/PMC1289294.nxml")).mkString
-
-  val reader = new NxmlReader
-  val reachSystem = new ReachSystem
-  /////////
 }
 
 class DeterministicPoliciesTests extends FlatSpec with Matchers with Fixtures {
 
   def contextAssignmentBehavior(nxml:String){
     info("Testing context assignment")
-    val entries = reader.readNxml(nxml, nxml)
+    val entries = testReader.readNxml(nxml, nxml)
 
-    val mentions:Seq[BioEventMention] = reachSystem.extractFrom(entries).filter{
+    val mentions:Seq[BioEventMention] = testReach.extractFrom(entries).filter{
         case em:BioEventMention => true
         case _ => false
       }.map(_.asInstanceOf[BioEventMention])
@@ -57,9 +51,9 @@ class DeterministicPoliciesTests extends FlatSpec with Matchers with Fixtures {
   def boundedPaddingBehavior(nxml:String){
     info(s"Testing bounding padding context")
     // Extract context for the sentences of a doc, not to the attached mentions
-    val friesEntries = reader.readNxml(nxml, "")
-    val documents = friesEntries map (e => reachSystem.mkDoc(e.text, e.name, e.chunkId))
-    val entitiesPerEntry =  for (doc <- documents) yield reachSystem.extractEntitiesFrom(doc)
+    val friesEntries = testReader.readNxml(nxml, "")
+    val documents = friesEntries map (e => testReach.mkDoc(e.text, e.name, e.chunkId))
+    val entitiesPerEntry =  for (doc <- documents) yield testReach.extractEntitiesFrom(doc)
 
 
     val boundedPaddingEngine = new BoundedPaddingContext

--- a/src/test/scala/edu/arizona/sista/reach/context/TestDeterministicPolicies.scala
+++ b/src/test/scala/edu/arizona/sista/reach/context/TestDeterministicPolicies.scala
@@ -14,8 +14,8 @@ trait Fixtures {
   def nxml3 = Source.fromURL(getClass.getResource("/inputs/nxml/PMC1289294.nxml")).mkString
 
   // save RAM by passing in BioNLPProcessor instance from TestUtils
-  lazy val reachSystemP4 = new ReachSystem(proc = Some(bioproc), contextEngineType = Engine.withName("Policy4"), contextParams = Map("bound" -> "5"))
-  lazy val reachSystemP3 = new ReachSystem(proc = Some(bioproc), contextEngineType = Engine.withName("Policy3"), contextParams = Map("bound" -> "5"))
+  val reachSystemP4 = new ReachSystem(proc = Some(bioproc), contextEngineType = Engine.withName("Policy4"), contextParams = Map("bound" -> "5"))
+  val reachSystemP3 = new ReachSystem(proc = Some(bioproc), contextEngineType = Engine.withName("Policy3"), contextParams = Map("bound" -> "5"))
 }
 
 class DeterministicPoliciesTests extends FlatSpec with Matchers with Fixtures {

--- a/src/test/scala/edu/arizona/sista/reach/nxml/NxmlReaderTests.scala
+++ b/src/test/scala/edu/arizona/sista/reach/nxml/NxmlReaderTests.scala
@@ -1,5 +1,6 @@
 package edu.arizona.sista.reach.nxml
 
+import edu.arizona.sista.reach.TestUtils._
 import io.Source
 import org.scalatest.{Matchers, FlatSpec}
 
@@ -30,7 +31,7 @@ trait Fixtures {
     e => !e.sectionId.startsWith("supm-")
   }
 
-  def reader = new NxmlReader
+  def reader = testReader
 
   def filteredReader = new NxmlReader(Seq("materials|methods", "supplementary-material"))
 


### PR DESCRIPTION
I renamed a `TestUtils` method and reduced our reliance on multiple instances of `BioNLPProcessor`.  All tests pass.