### PR TITLE
Catch binding in 'X that is bound by Y'

### DIFF
--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/bind_events.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/bind_events.yml
@@ -317,6 +317,16 @@
   pattern: |
     [lemma=/^(when|after|once|if)/] (?<trigger> [lemma="bind"]) [lemma="to"]? [tag=/^(DT|JJ)/]* @theme1:BioChemicalEntity [tag=/^NN/]? ","? [tag=/^(DT|JJ)/]* @theme2:BioChemicalEntity
 
+- name: binding_thatisbound
+  label: Binding
+  action: mkBinding
+  priority: 4
+  example: "Src tyrosyl phosphorylates Ras that is GTP bound"
+  pattern: |
+    trigger = [word=bound & tag=/^VB(D|N)$/]
+    theme1:BioChemicalEntity+ = (<rcmod | <vmod)
+    theme2:BioChemicalEntity+ = (<rcmod | <vmod) (<rcmod | rcmod)
+
 # Token pattern rule for [complex/heterodimer A and B] is
 - name: binding_complex_A_B
   label: Binding

--- a/src/test/scala/edu/arizona/sista/reach/TestBindingEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestBindingEvents.scala
@@ -377,4 +377,20 @@ class TestBindingEvents extends FlatSpec with Matchers {
     hasEventWithArguments("Binding", List("p32", "GST"), mentions) should be (false)
   }
 
+  // Special example from assembly requirement doc
+  val sent37a = "Src tyrosyl phosphorylates Ras that is GTP bound"
+  val sent37b = "Ras that is GTP bound is phosphorylated by Src tyrosyl"
+  sent37a should "contain a binding between GTP and Ras" in {
+    val mentions = getBioMentions(sent37a)
+    hasEventWithArguments("Binding", List("Ras", "GTP"), mentions) should be (true)
+    hasEventWithArguments("Binding", List("Src", "GTP"), mentions) should be (false)
+    hasEventWithArguments("Binding", List("Ras", "Src"), mentions) should be (false)
+  }
+  sent37b should "contain a binding between GTP and Ras" in {
+    val mentions = getBioMentions(sent37b)
+    hasEventWithArguments("Binding", List("Ras", "GTP"), mentions) should be (true)
+    hasEventWithArguments("Binding", List("Src", "GTP"), mentions) should be (false)
+    hasEventWithArguments("Binding", List("Ras", "Src"), mentions) should be (false)
+  }
+
 }


### PR DESCRIPTION
I added a binding rule to match examples from the assembly requirement PPT such as:
> Src tyrosyl phosphorylates Ras that is GTP bound

with the variation 
> Ras that is GTP bound is phosphorylated by Src tyrosyl

which has slightly different syntax because of parser issues.

I also added unit tests for each of these sentences. Other tests still pass.