### PR TITLE
Integration of BioProcess entity type into taxonomy and Activation rules

### DIFF
--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/entities/entities.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/entities/entities.yml
@@ -177,6 +177,15 @@
   pattern: |
     [entity='B-Site'] [entity='I-Site']*
 
+- name: ner-bioprocess-entities
+  label: BioProcess
+  action: mkNERMentions
+  example: "apoptosis"
+  priority: 3
+  type: token
+  pattern: |
+    [entity='B-BioProcess'] [entity='I-BioProcess']*
+
 # TODO: Ideally, this should somehow be added to the KB
 - name: missing-simple_chemical
   label: Simple_chemical

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events_master.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events_master.yml
@@ -127,7 +127,7 @@ rules:
       triggers: "acceler|activat|aid|allow|augment|direct|elev|elicit|enabl|enhanc|increas|induc|initi|modul|necess|overexpress|potenti|produc|prolong|promot|rais|reactivat|rescu|respons|restor|re-express|retent|sequest|signal|stimul|support|synerg|synthes|trigger|up-regul|upregul"
       actionFlow: "mkActivation"
       priority: "7" # must be 1 + priority of regulations!
-      controlledType: "BioChemicalEntity"
+      controlledType: "BioEntity" # include bioprocesses as possible controlled
       controllerType: "PossibleController"
 
   # Negative Activation
@@ -138,5 +138,5 @@ rules:
       triggers: "attenu|block|deactiv|decreas|degrad|diminish|disrupt|impair|imped|inhibit|knockdown|limit|lower|negat|reduc|reliev|repress|restrict|revers|slow|starv|suppress|supress"
       actionFlow: "mkActivation"
       priority: "7" # must be 1 + priority of regulations!
-      controlledType: "BioChemicalEntity"
+      controlledType: "BioEntity" # include bioprocesses as possible controlled
       controllerType: "PossibleController"

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/taxonomy.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/taxonomy.yml
@@ -38,6 +38,9 @@
                 - Positive_activation
                 - Negative_activation
     - Entity:
+      # Any BioEntity may appear as the controlled in an Activation
+      - BioEntity:
+        - BioProcess   # ex. "apoptosis"
         - BioChemicalEntity:
             - Generic_entity
             - Family

--- a/src/test/scala/edu/arizona/sista/reach/TestActivationEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestActivationEvents.scala
@@ -246,4 +246,12 @@ class TestActivationEvents extends FlatSpec with Matchers {
     hasNegativeActivation("trichostatin A", "HDAC", mentions) should be(true)
     hasNegativeActivation("TSA", "HDAC", mentions) should be(true)
   }
+
+  // Test Activations where the controlled is a BioProcess
+  val sent30 = "In some cases, the presence of Ras inhibits oncogenesis."
+  sent30 should "contain 1 negative activation over a BioProcess" in {
+    val mentions = getBioMentions(sent30)
+    mentions.filter(_.label.contains("Negative_activation")) should have size (1)
+    hasNegativeActivation("Ras", "oncogenesis", mentions) should be (true)
+  }
 }

--- a/src/test/scala/edu/arizona/sista/reach/TestActivationEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestActivationEvents.scala
@@ -248,10 +248,10 @@ class TestActivationEvents extends FlatSpec with Matchers {
   }
 
   // Test Activations where the controlled is a BioProcess
-  val sent30 = "In some cases, the presence of Ras inhibits oncogenesis."
+  val sent30 = "In some cases, the presence of Ras inhibits autophagy."
   sent30 should "contain 1 negative activation over a BioProcess" in {
     val mentions = getBioMentions(sent30)
     mentions.filter(_.label.contains("Negative_activation")) should have size (1)
-    hasNegativeActivation("Ras", "oncogenesis", mentions) should be (true)
+    hasNegativeActivation("Ras", "autophagy", mentions) should be (true)
   }
 }

--- a/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
@@ -95,4 +95,11 @@ class TestEntities extends FlatSpec with Matchers {
     mentions.size should be (0)
   }
 
+  // test recognition of BioProcess entities
+  val sent7 = "In some cases, the presence of Ras inhibits autophagy."
+  sent7 should "contain 1 BioProcess entity (\"autophagy\")" in {
+    val mentions = getBioMentions(sent7)
+    mentions.count (_ matches "BioProcess") should be (1) 
+  }
+
 }


### PR DESCRIPTION
This resolves #63.  I added a test for the recognition of `BioProcess` entities, as well as a test for Activations with a `BioProcess` serving as the `controlled`.  All tests pass, except for two context tests in [TestDeterministicPolicies](https://github.com/clulab/reach/blob/7ee0e47c242526a4ac273f9fc88fb6eaeff6351a/src/test/scala/edu/arizona/sista/reach/context/TestDeterministicPolicies.scala) which are also failing on `master`.

```
[info] Run completed in 19 minutes, 4 seconds.
[info] Total number of tests run: 516
[info] Suites: completed 29, aborted 0
[info] Tests: succeeded 514, failed 2, canceled 0, ignored 0, pending 0
[info] *** 2 TESTS FAILED ***
[error] Failed tests:
[error]         edu.arizona.sista.reach.context.TestDeterministicPolicies
[error] (test:test) sbt.TestsFailedException: Tests unsuccessful
```