### PR TITLE
Refined GGP and Family NER rules

### DIFF
--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/entities/entities.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/entities/entities.yml
@@ -141,7 +141,10 @@
   priority: 3
   type: token
   pattern: |
-    [entity='B-Gene_or_gene_product' & !word=/(?i)^[ACDEFGHIKLMNQRSTVWY]\d+[ACDEFGHIKLMNPQRSTVWY]?$/]+ [entity='I-Gene_or_gene_product']* (?! [lemma="substrate"])
+    [entity='B-Gene_or_gene_product' & !word=/(?i)^[ACDEFGHIKLMNQRSTVWY]\d+[ACDEFGHIKLMNPQRSTVWY]?$/]+
+    [entity='I-Gene_or_gene_product']*
+    # we can't always trust the crf.  Make sure it isn't an obvious family
+    (?! [lemma="substrate" | lemma="family"])
 
 # TODO: verify this ontology
 - name: ner-family-entities
@@ -151,6 +154,10 @@
   type: token
   pattern: |
     [entity='B-Family']+ [entity='I-Family']* (?! [lemma="substrate"])
+    | # we can't always trust the crf.
+    [entity='B-Gene_or_gene_product']+ [entity='I-Gene_or_gene_product']*
+    # only allow the GGP ner label iff lemma of next tok is "family"
+    (?= [lemma="family"])
 
 # TODO: verify this ontology
 - name: ner-cellular_component-entities

--- a/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
@@ -102,4 +102,17 @@ class TestEntities extends FlatSpec with Matchers {
     mentions.count (_ matches "BioProcess") should be (1) 
   }
 
+  // test lookahead assertions on ner rules for GGP and Family entities
+  val mekText = "the MEK family"
+  mekText should "contain 1 Family entity for \"MEK\" even if the entity tag is B-Gene_or_gene_product" in {
+    val doc = bioproc.annotate(mekText)
+    val ggpLabels: Array[String] = Array("O", "B-Gene_or_gene_product", "O")
+    // manipulate the document for this test
+    doc.id = Some("MEK-test")
+    doc.text = Some(mekText)
+    doc.sentences.head.entities = Some(ggpLabels)
+    val mentions = testReach.extractFrom(doc)
+    mentions should have size (1)
+    mentions.head matches "Family" should be (true)
+  }
 }


### PR DESCRIPTION
This PR resolves #74.  The improvement uses a lookahead assertion on the token that follows the standard ner rule of the form `[entity=B-somelabel] [entity=I=somelabel]*`). 

### Changes
- A token sequence labelled as GGP by the crf will produce a mention with the label `Family` if the lemma form of the token that follows is "family".  

- A similar check prevents a `GGP` mention being created if a token sequence labelled as GGP by the crf is followed by a token which has the lemma "family".

### Problems
While this doesn't seem to break anything, this change deserves a test or two.  I'd appreciate any examples of strings that are consistently being labeled GGP or Family.