### PR TITLE
Alias

### DIFF
--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
@@ -7,7 +7,7 @@
     (@alias:Family | @alias:MacroMolecule)
     [tag="-LRB-"]
     (@alias:Family | @alias:MacroMolecule)
-    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+    ([word=/^,|\/|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
     [tag="-RRB-"]
 
 - name: alias_paren2_referredto
@@ -22,7 +22,7 @@
     ([tag="RB"]?
     "referred" "to" "as")?
     (@alias:Family | @alias:MacroMolecule)
-    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+    ([word=/^,|\/|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
     [tag="-RRB-"]
 
 - name: alias_paren3_knownas
@@ -37,7 +37,7 @@
     ([tag="RB"]?
     [word=/^known|designated$/ & tag="VBN"] "as"?)?
     (@alias:Family | @alias:MacroMolecule)
-    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+    ([word=/^,|\/|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
     [tag="-RRB-"]
 
 - name: alias_paren4_called
@@ -52,7 +52,7 @@
     ([tag="RB"]?
     [lemma=/^call|term|name$/ & tag="VBN"])?
     (@alias:Family | @alias:MacroMolecule)
-    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+    ([word=/^,|\/|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
     [tag="-RRB-"]
 
 - name: alias_paren5_alias
@@ -65,7 +65,7 @@
     [tag="-LRB-"]
     [word=/^alias|a\.k\.a\.$/]
     (@alias:Family | @alias:MacroMolecule)
-    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+    ([word=/^,|\/|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
     [tag="-RRB-"]
 
 - name: alias_comma1_referredto
@@ -80,7 +80,8 @@
     [tag="RB"]?
     "referred" "to" "as"
     (@alias:Family | @alias:MacroMolecule)
-    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+    ([word=/^,|\/|or$/]+ (@alias:Family | @alias:MacroMolecule))*
+    [tag=/^\.|,|:$/]
 
 - name: alias_comma2_knownas
   label: Alias
@@ -94,7 +95,8 @@
     [tag="RB"]?
     [word=/^known|designated$/ & tag="VBN"] "as"?
     (@alias:Family | @alias:MacroMolecule)
-    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+    ([word=/^,|\/|or$/]+ (@alias:Family | @alias:MacroMolecule))*
+    [tag=/^\.|,|:$/]
 
 - name: alias_comma2_called
   label: Alias
@@ -108,5 +110,6 @@
     [tag="RB"]?
     [lemma=/^call|term|name$/ & tag="VBN"]
     (@alias:Family | @alias:MacroMolecule)
-    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+    ([word=/^,|\/|or$/]+ (@alias:Family | @alias:MacroMolecule))*
+    [tag=/^\.|,|:$/]
 

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
@@ -1,0 +1,10 @@
+- name: alias_entityparen1
+  label: Alias
+  action: mkBioMention
+  priority: 4
+  type: token
+  pattern: |
+    (@alias:Family | @alias:MacroMolecule)
+    "("
+    (@alias:Family | @alias:MacroMolecule)
+    ")"

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
@@ -7,6 +7,7 @@
     (@alias:Family | @alias:MacroMolecule)
     [tag="-LRB-"]
     (@alias:Family | @alias:MacroMolecule)
+    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
     [tag="-RRB-"]
 
 - name: alias_paren2_referredto
@@ -21,6 +22,7 @@
     ([tag="RB"]?
     "referred" "to" "as")?
     (@alias:Family | @alias:MacroMolecule)
+    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
     [tag="-RRB-"]
 
 - name: alias_paren3_knownas
@@ -30,12 +32,41 @@
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
-    [word=/^( \( | \[ )$/]
+    [tag="-LRB-"]
     ("which" [lemma="be"])?
     ([tag="RB"]?
-    "known" "as")?
+    [word=/^known|designated$/ & tag="VBN"] "as"?)?
     (@alias:Family | @alias:MacroMolecule)
-    [word=/^( \) | \] )$/]
+    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+    [tag="-RRB-"]
+
+- name: alias_paren4_called
+  label: Alias
+  action: mkBioMention
+  priority: 4
+  type: token
+  pattern: |
+    (@alias:Family | @alias:MacroMolecule)
+    [tag="-LRB-"]
+    ("which" [lemma="be"])?
+    ([tag="RB"]?
+    [lemma=/^call|term|name$/ & tag="VBN"])?
+    (@alias:Family | @alias:MacroMolecule)
+    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+    [tag="-RRB-"]
+
+- name: alias_paren5_alias
+  label: Alias
+  action: mkBioMention
+  priority: 4
+  type: token
+  pattern: |
+    (@alias:Family | @alias:MacroMolecule)
+    [tag="-LRB-"]
+    [word=/^alias|a\.k\.a\.$/]
+    (@alias:Family | @alias:MacroMolecule)
+    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+    [tag="-RRB-"]
 
 - name: alias_comma1_referredto
   label: Alias
@@ -49,6 +80,7 @@
     [tag="RB"]?
     "referred" "to" "as"
     (@alias:Family | @alias:MacroMolecule)
+    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
 
 - name: alias_comma2_knownas
   label: Alias
@@ -60,6 +92,21 @@
     ","
     ("which" [lemma="be"])?
     [tag="RB"]?
-    "known" "as"
+    [word=/^known|designated$/ & tag="VBN"] "as"?
     (@alias:Family | @alias:MacroMolecule)
+    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
+
+- name: alias_comma2_called
+  label: Alias
+  action: mkBioMention
+  priority: 4
+  type: token
+  pattern: |
+    (@alias:Family | @alias:MacroMolecule)
+    ","
+    ("which" [lemma="be"])?
+    [tag="RB"]?
+    [lemma=/^call|term|name$/ & tag="VBN"]
+    (@alias:Family | @alias:MacroMolecule)
+    ([word=/^,|or$/]+ (@alias:Family | @alias:MacroMolecule))*?
 

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
@@ -1,10 +1,65 @@
-- name: alias_entityparen1
+- name: alias_paren1_nil
   label: Alias
   action: mkBioMention
   priority: 4
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
-    "("
+    [tag="-LRB-"]
     (@alias:Family | @alias:MacroMolecule)
-    ")"
+    [tag="-RRB-"]
+
+- name: alias_paren2_referredto
+  label: Alias
+  action: mkBioMention
+  priority: 4
+  type: token
+  pattern: |
+    (@alias:Family | @alias:MacroMolecule)
+    [tag="-LRB-"]
+    ("which" [lemma="be"])?
+    ([tag="RB"]?
+    "referred" "to" "as")?
+    (@alias:Family | @alias:MacroMolecule)
+    [tag="-RRB-"]
+
+- name: alias_paren3_knownas
+  label: Alias
+  action: mkBioMention
+  priority: 4
+  type: token
+  pattern: |
+    (@alias:Family | @alias:MacroMolecule)
+    [word=/^( \( | \[ )$/]
+    ("which" [lemma="be"])?
+    ([tag="RB"]?
+    "known" "as")?
+    (@alias:Family | @alias:MacroMolecule)
+    [word=/^( \) | \] )$/]
+
+- name: alias_comma1_referredto
+  label: Alias
+  action: mkBioMention
+  priority: 4
+  type: token
+  pattern: |
+    (@alias:Family | @alias:MacroMolecule)
+    ","
+    ("which" [lemma="be"])?
+    [tag="RB"]?
+    "referred" "to" "as"
+    (@alias:Family | @alias:MacroMolecule)
+
+- name: alias_comma2_knownas
+  label: Alias
+  action: mkBioMention
+  priority: 4
+  type: token
+  pattern: |
+    (@alias:Family | @alias:MacroMolecule)
+    ","
+    ("which" [lemma="be"])?
+    [tag="RB"]?
+    "known" "as"
+    (@alias:Family | @alias:MacroMolecule)
+

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/modifications_master.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/modifications_master.yml
@@ -3,3 +3,4 @@ taxonomy: edu/arizona/sista/reach/biogrammar/taxonomy.yml
 rules:
   - import: edu/arizona/sista/reach/biogrammar/modifications/modifications.yml
   - import: edu/arizona/sista/reach/biogrammar/modifications/mutants.yml
+  - import: edu/arizona/sista/reach/biogrammar/coref/alias.yml

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/taxonomy.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/taxonomy.yml
@@ -1,10 +1,11 @@
-- Cellular_component
-- Site
-- ModificationTrigger
-- Species
+- Alias
 - CellLine
-- Organ
 - CellType
+- Cellular_component
+- ModificationTrigger
+- Organ
+- Site
+- Species
 - Context:
   - ContextDirection
   - ContextLocation

--- a/src/main/scala/edu/arizona/sista/coref/Coref.scala
+++ b/src/main/scala/edu/arizona/sista/coref/Coref.scala
@@ -2,7 +2,7 @@ package edu.arizona.sista.coref
 
 import edu.arizona.sista.odin.{Mention, _}
 import edu.arizona.sista.processors.Document
-import edu.arizona.sista.reach.grounding.{KBEntry, KBResolution}
+import edu.arizona.sista.reach.grounding.{ReachKBConstants, KBEntry, KBResolution}
 import edu.arizona.sista.reach.{DarpaActions, DarpaLinks}
 import edu.arizona.sista.reach.utils.DependencyUtils._
 import edu.arizona.sista.reach.display._
@@ -67,8 +67,8 @@ class Coref {
         !(aliases contains a.grounding.get.entry) &&  // assume any existing entry is correct
         !(aliases contains b.grounding.get.entry)     // so don't replace existing entry
     } {
-      if (a.grounding.get.namespace == "uaz") aliases(a.grounding.get.entry) = b
-      else if (b.grounding.get.namespace == "uaz") aliases(b.grounding.get.entry) = a
+      if (a.grounding.get.namespace == ReachKBConstants.DefaultNamespace) aliases(a.grounding.get.entry) = b
+      else if (b.grounding.get.namespace == ReachKBConstants.DefaultNamespace) aliases(b.grounding.get.entry) = a
     }
 
     if (debug) println("\n=====Alias matching=====")

--- a/src/main/scala/edu/arizona/sista/coref/Coref.scala
+++ b/src/main/scala/edu/arizona/sista/coref/Coref.scala
@@ -2,6 +2,7 @@ package edu.arizona.sista.coref
 
 import edu.arizona.sista.odin.{Mention, _}
 import edu.arizona.sista.processors.Document
+import edu.arizona.sista.reach.grounding.{KBEntry, KBResolution}
 import edu.arizona.sista.reach.{DarpaActions, DarpaLinks}
 import edu.arizona.sista.reach.utils.DependencyUtils._
 import edu.arizona.sista.reach.display._
@@ -13,7 +14,7 @@ import scala.annotation.tailrec
 class Coref {
 
   val debug: Boolean = false
-  val verbose: Boolean = false
+  val verbose: Boolean = debug
   val da: DarpaActions = new DarpaActions()
 
   def apply(mentions: Seq[Mention]): Seq[CorefMention] = applyAll(mentions).lastOption.getOrElse(Nil)
@@ -21,6 +22,7 @@ class Coref {
   def applyAll(mentions: Seq[Mention], keepAll: Boolean = false): Seq[Seq[CorefMention]] = {
 
     val doc: Document = mentions.headOption.getOrElse(return Nil).document
+    val aliases = scala.collection.mutable.HashMap.empty[KBEntry, BioMention]
 
     if (debug) {
       println("BEFORE COREF")
@@ -53,6 +55,32 @@ class Coref {
         }
       }
     }).sorted[Mention]
+
+    // find aliases
+    val aliasRelations = orderedMentions filter (_ matches "Alias")
+    for {
+      aliasRelation <- aliasRelations
+      entities = aliasRelation.arguments.getOrElse("alias", Nil)
+      pair <- entities.combinations(2)
+      (a, b) = (pair.head.toCorefMention, pair.last.toCorefMention)
+      if compatibleGrounding(a, b) && // includes check to see that they're both grounded
+        !(aliases contains a.grounding.get.entry) &&  // assume any existing entry is correct
+        !(aliases contains b.grounding.get.entry)     // so don't replace existing entry
+    } {
+      if (a.grounding.get.namespace == "uaz") aliases(a.grounding.get.entry) = b
+      else if (b.grounding.get.namespace == "uaz") aliases(b.grounding.get.entry) = a
+    }
+
+    if (debug) println("\n=====Alias matching=====")
+    // share more complete grounding based on alias map
+    orderedMentions.filter(_.isInstanceOf[TextBoundMention]).foreach {
+      mention =>
+        val kbEntry = mention.grounding.get.entry
+        if (aliases contains kbEntry) {
+          if (debug) println(s"${mention.text} matches ${aliases(kbEntry).text}")
+          mention.copyGroundingFrom(aliases(kbEntry))
+        }
+    }
 
     val links = new DarpaLinks(doc)
 
@@ -326,7 +354,8 @@ class Coref {
      * Using subfunctions for TextBoundMentions, SimpleEvents, and ComplexEvents, create maps for each mention in
      * mentions to its antecedent as determined by the linking functions already applied, creating new mentions as
      * necessary
-     * @param mentions all the input mentions with their antecedents already chosen by the linking functions
+      *
+      * @param mentions all the input mentions with their antecedents already chosen by the linking functions
      * @return mentions with generic mentions replaced by their antecedents
      */
     def resolve(mentions: Seq[CorefMention]): Seq[CorefMention] = {

--- a/src/main/scala/edu/arizona/sista/coref/CorefUtils.scala
+++ b/src/main/scala/edu/arizona/sista/coref/CorefUtils.scala
@@ -68,4 +68,31 @@ object CorefUtils {
     }
   }
 
+  /**
+    * Do two mentions have groundings that match? E.g. 'H-Ras' (a family) and 'S135' (a site)
+    * are not compatible because they don't have the same labels
+    * @param a
+    * @param b
+    */
+  def compatibleGrounding(a: CorefMention, b: CorefMention): Boolean = {
+    a.isInstanceOf[CorefTextBoundMention] && b.isInstanceOf[CorefTextBoundMention] &&
+      a.label == b.label &&
+      !a.isGeneric && !b.isGeneric &&
+      compatibleContext(a, b) &&
+      ((a.isGrounded && a.grounding().get.namespace == "uaz") ^
+        (b.isGrounded && b.grounding().get.namespace == "uaz"))
+  }
+
+  /**
+    * Do two mentions have contexts that match?
+    * @param a
+    * @param b
+    */
+  def compatibleContext(a: CorefMention, b: CorefMention): Boolean = {
+    val aContext = a.context.getOrElse(Map[String,Seq[String]]())
+    val bContext = b.context.getOrElse(Map[String,Seq[String]]())
+    a.label == b.label &&
+      aContext.keySet.intersect(bContext.keySet)
+        .forall(k => aContext(k).toSet == bContext(k).toSet) // FIXME: Too strict?
+  }
 }

--- a/src/main/scala/edu/arizona/sista/coref/CorefUtils.scala
+++ b/src/main/scala/edu/arizona/sista/coref/CorefUtils.scala
@@ -1,5 +1,6 @@
 package edu.arizona.sista.coref
 
+import edu.arizona.sista.reach.grounding.ReachKBConstants
 import edu.arizona.sista.reach.mentions._
 
 import scala.annotation.tailrec
@@ -71,6 +72,7 @@ object CorefUtils {
   /**
     * Do two mentions have groundings that match? E.g. 'H-Ras' (a family) and 'S135' (a site)
     * are not compatible because they don't have the same labels
+    *
     * @param a
     * @param b
     */
@@ -79,12 +81,13 @@ object CorefUtils {
       a.label == b.label &&
       !a.isGeneric && !b.isGeneric &&
       compatibleContext(a, b) &&
-      ((a.isGrounded && a.grounding().get.namespace == "uaz") ^
-        (b.isGrounded && b.grounding().get.namespace == "uaz"))
+      ((a.isGrounded && a.grounding().get.namespace == ReachKBConstants.DefaultNamespace) ^
+        (b.isGrounded && b.grounding().get.namespace == ReachKBConstants.DefaultNamespace))
   }
 
   /**
     * Do two mentions have contexts that match?
+    *
     * @param a
     * @param b
     */

--- a/src/main/scala/edu/arizona/sista/reach/DarpaLinks.scala
+++ b/src/main/scala/edu/arizona/sista/reach/DarpaLinks.scala
@@ -10,7 +10,7 @@ import edu.arizona.sista.struct.Interval
 class DarpaLinks(doc: Document) extends Links {
 
   val debug: Boolean = false
-  val verbose: Boolean = false
+  val verbose: Boolean = debug
   val defaultSelector: AntecedentSelector = new LinearSelector
 
   /**

--- a/src/test/scala/edu/arizona/sista/reach/TestCoreference.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestCoreference.scala
@@ -351,4 +351,13 @@ class TestCoreference extends FlatSpec with Matchers {
     val mentions = getBioMentions(sent30)
     mentions filter (_ matches "Event") should have size (0)
   }
+
+  // Spread grounding from Ras to ungrounded alias H-Ras.
+  val sent31 = "H-Ras (Ras) is phosphorylated."
+  sent31 should "apply Ras grounding to H-Ras" in {
+    val mentions = getBioMentions(sent31)
+    val entities = mentions filter (_ matches "Entity")
+    entities should have size (2)
+    entities.head.grounding.get.equals(entities.last.grounding.get) should be (true)
+  }
 }

--- a/src/test/scala/edu/arizona/sista/reach/TestCoreference.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestCoreference.scala
@@ -353,11 +353,35 @@ class TestCoreference extends FlatSpec with Matchers {
   }
 
   // Spread grounding from Ras to ungrounded alias H-Ras.
-  val sent31 = "H-Ras (Ras) is phosphorylated."
-  sent31 should "apply Ras grounding to H-Ras" in {
-    val mentions = getBioMentions(sent31)
+  val sent31a = "H-Ras (hereafter referred to as Ras) is phosphorylated."
+  sent31a should "apply Ras grounding to H-Ras" in {
+    val mentions = getBioMentions(sent31a)
     val entities = mentions filter (_ matches "Entity")
     entities should have size (2)
     entities.head.grounding.get.equals(entities.last.grounding.get) should be (true)
   }
+  // Order shouldn't matter
+  val sent31b = "Ras (hereafter referred to as K-Ras) is phosphorylated."
+  sent31b should "apply Ras grounding to K-Ras" in {
+    val mentions = getBioMentions(sent31b)
+    val entities = mentions filter (_ matches "Entity")
+    entities should have size (2)
+    entities.head.grounding.get.equals(entities.last.grounding.get) should be (true)
+  }
+
+  val sent32 = "Ras (hereafter referred to as S135) is phosphorylated."
+  sent32 should "not apply Ras grounding to S135 or vice versa" in {
+    val mentions = getBioMentions(sent32)
+    val entities = mentions filter (m => (m matches "Entity") || (m matches "Site"))
+    entities should have size (2)
+    entities.head.grounding.get.equals(entities.last.grounding.get) should be (false)
+  }
+  val sent33 = "K-Ras (hereafter referred to as S135) is phosphorylated."
+  sent32 should "not apply S135 grounding to H-Ras or vice versa" in {
+    val mentions = getBioMentions(sent32)
+    val entities = mentions filter (m => (m matches "Entity") || (m matches "Site"))
+    entities should have size (2)
+    entities.head.grounding.get.equals(entities.last.grounding.get) should be (false)
+  }
+
 }


### PR DESCRIPTION
This is a first attempt at having entity mentions share grounding when only one has good grounding and the text indicates that the mentions are synonymous. This sharing continues across sentences. For example, "Akt (also called Akt334, AktTR, or Akt4H) is phosphorylated. AktTR is also ubiquitinated." now produces five entity mentions, all with identical grounding from `Akt`.

This is accomplished by means of rule-based collection of RelationMentions with an `Alias` label that are used by Coref to share grounding and then filtered out.

Limitations: 
* This doesn't work yet for the small number of coordinated examples, e.g. "MLL1/MLL2 (also known as KMT2A and KMT2B, respectively)"
* This only works for mentions tagged Family and MacroMolecule. An example such as "Ras S135M (RasM)" won't do this sharing because the mutation is getting in the way.
* The two mentions must have the same label. This is problematic for those times when they actually are the same, but for NER reasons have been given different labels, but it seems better to be conservative at first.