### PR TITLE
Avoid forking jvm for Travis compatibility

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,1 +1,1 @@
--J-Xmx8G
+-J-Xmx5G

--- a/build.sbt
+++ b/build.sbt
@@ -10,13 +10,7 @@ scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation")
 
 testOptions in Test += Tests.Argument("-oD")
 
-// fork jvm to separate process
-fork := true
-
 parallelExecution in Test := false
-
-// options for forked jvm
-javaOptions += "-Xmx5G"
 
 // forward sbt's stdin to forked process
 connectInput in run := true


### PR DESCRIPTION
This change addresses the memory errors observed when forking the jvm in Travis builds.