### PR TITLE
Merge branch 'context' into ctx-merge

### DIFF
--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/taxonomy.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/taxonomy.yml
@@ -1,12 +1,12 @@
 - Alias
-- CellLine
-- CellType
-- Cellular_component
 - ModificationTrigger
-- Organ
 - Site
-- Species
 - Context:
+  - Species
+  - CellLine
+  - Organ
+  - CellType
+  - Cellular_component
   - ContextDirection
   - ContextLocation
   - ContextPossessive

--- a/src/main/scala/edu/arizona/sista/reach/ReachSystem.scala
+++ b/src/main/scala/edu/arizona/sista/reach/ReachSystem.scala
@@ -76,6 +76,8 @@ class ReachSystem(
     // Coref introduced incomplete Mentions that now need to be pruned
     val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
     // val complete = MentionFilter.keepMostCompleteMentions(eventsWithContext, State(eventsWithContext)).map(_.toBioMention)
+
+
     resolveDisplay(complete)
   }
 

--- a/src/main/scala/edu/arizona/sista/reach/context/Policies.scala
+++ b/src/main/scala/edu/arizona/sista/reach/context/Policies.scala
@@ -1,5 +1,6 @@
 package edu.arizona.sista.reach.context
 
+import scala.annotation.tailrec
 import edu.arizona.sista.reach.mentions._
 import edu.arizona.sista.reach.nxml.FriesEntry
 import edu.arizona.sista.reach.context.rulebased._
@@ -16,61 +17,67 @@ class BoundedPaddingContext(
   // TODO: Do something smart to resolve ties
   protected def untie(entities:Seq[(String, String)]) = entities.head
 
-  protected def padContext(prevStep:Seq[Int], remainingSteps:List[Seq[Int]], repetitions:Seq[Int], bound:Int):List[Seq[Int]] = {
+  protected final def padContext(prevStep:Seq[Int], remainingSteps:List[Seq[Int]], repetitions:Seq[Int], bound:Int):List[Seq[Int]] = {
+    @tailrec
+    def iter(prevStep:Seq[Int], remainingSteps:List[Seq[Int]], repetitions:Seq[Int], bound:Int, acc:List[Seq[Int]]):List[Seq[Int]] = {
 
-    remainingSteps match {
 
-      case head::tail =>
-        // Group the prev step inferred row and the current by context type, then recurse
-        val prevContext = prevStep map (this.inverseLatentStateVocabulary(_)) groupBy (_._1)
-        val currentContext = head map (this.inverseLatentStateVocabulary(_)) groupBy (_._1)
+      remainingSteps match {
 
-        // Apply the heuristic
-        // Inferred context of type "x"
-        val newRepetitions = new Array[Int](repetitions.size)
+        case head::tail =>
+          // Group the prev step inferred row and the current by context type, then recurse
+          val prevContext = prevStep map (ContextEngine.getKey(_, ContextEngine.latentVocabulary)) groupBy (_._1)
+          val currentContext = head map (ContextEngine.getKey(_, ContextEngine.latentVocabulary)) groupBy (_._1)
 
-        val currentStep = contextTypes.flatMap{ // Do this for each type of context. Flat Map as there could be more than one context of a type (maybe)
-          contextType =>
-            val stepIx = this.contextTypes.indexOf(contextType)
+          // Apply the heuristic
+          // Inferred context of type "x"
+          val newRepetitions = new Array[Int](repetitions.size)
 
-            if(repetitions(stepIx) < bound){
-              (prevContext.lift(contextType), currentContext.lift(contextType)) match {
-                // No prev, Current
-                case (None, Some(curr)) =>
-                  newRepetitions(stepIx) = 1
-                  Seq(untie(curr))
-                // Prev, No current
-                case (Some(prev), None) =>
-                  newRepetitions(stepIx) = repetitions(stepIx)+1
-                  Seq(prev.head)
-                // Prev, Current
-                case (Some(prev), Some(curr)) =>
-                  newRepetitions(stepIx) = 1
-                  Seq(untie(curr))
-                // No prev, No current
-                case (None, None) =>
-                  newRepetitions(stepIx) = 1
-                  Nil
+          val currentStep = contextTypes.flatMap{ // Do this for each type of context. Flat Map as there could be more than one context of a type (maybe)
+            contextType =>
+              val stepIx = this.contextTypes.indexOf(contextType)
+
+              if(repetitions(stepIx) < bound){
+                (prevContext.lift(contextType), currentContext.lift(contextType)) match {
+                  // No prev, Current
+                  case (None, Some(curr)) =>
+                    newRepetitions(stepIx) = 1
+                    Seq(untie(curr))
+                  // Prev, No current
+                  case (Some(prev), None) =>
+                    newRepetitions(stepIx) = repetitions(stepIx)+1
+                    Seq(prev.head)
+                  // Prev, Current
+                  case (Some(prev), Some(curr)) =>
+                    newRepetitions(stepIx) = 1
+                    Seq(untie(curr))
+                  // No prev, No current
+                  case (None, None) =>
+                    newRepetitions(stepIx) = 1
+                    Nil
+                }
               }
-            }
-            else{
-              newRepetitions(stepIx) = 1
-              currentContext.lift(contextType) match {
-                case Some(curr) =>
-                  Seq(untie(curr))
-                case None =>
-                  Seq()
+              else{
+                newRepetitions(stepIx) = 1
+                currentContext.lift(contextType) match {
+                  case Some(curr) =>
+                    Seq(untie(curr))
+                  case None =>
+                    Seq()
+                }
               }
-            }
 
-        } map (this.latentStateVocabulary(_))
+          } map (ContextEngine.getIndex(_, ContextEngine.latentVocabulary))
 
-        // Recurse
-        currentStep :: padContext(currentStep, tail, newRepetitions, bound)
+          // Recurse
+          iter(currentStep, tail, newRepetitions, bound, currentStep::acc)
 
 
-      case Nil => Nil
+        case Nil => acc
+      }
     }
+
+    iter(prevStep, remainingSteps, repetitions, bound, Nil)
   }
   // Apply the policy
   protected override def inferContext = padContext(Seq(), latentSparseMatrix, Seq.fill(this.contextTypes.size)(1), bound)
@@ -93,7 +100,7 @@ class FillingContext(bound:Int = 3) extends BoundedPaddingContext(bound){
       // Get the most common mentioned context of each type
       val defaultContexts = this.mentions.flatten.map(ContextEngine.getContextKey(_))  // Get the context keys of the mentions
         .filter(x => this.contextTypes.contains(x._1)).groupBy(_._1) // Keep only those we care about and group them by type
-        .mapValues(bucket => bucket.map(this.observationVocabulary(_))) // Get their numeric value from the vocabulary
+        .mapValues(bucket => bucket.map(ContextEngine.getIndex(_, ContextEngine.featureVocabulary))) // Get their numeric value from the vocabulary
         .mapValues(bucket => bucket.groupBy(identity).mapValues(_.size)) // Count the occurences
         .mapValues(bucket => Seq(bucket.maxBy(_._2)._1)) // Select the most common element
 
@@ -104,12 +111,12 @@ class FillingContext(bound:Int = 3) extends BoundedPaddingContext(bound){
       paddedContext map {
         step =>
           // Existing contexts for this line
-          val context = step.map(this.inverseLatentStateVocabulary(_)).groupBy(_._1)
+          val context = step.map(ContextEngine.getKey(_, ContextEngine.latentVocabulary)).groupBy(_._1)
           this.contextTypes flatMap {
             ctype =>
               context.lift(ctype) match {
                 case Some(x) =>
-                  x map (this.latentStateVocabulary(_))
+                  x map (ContextEngine.getIndex(_, ContextEngine.latentVocabulary))
                 case None =>
                   defaultContexts.lift(ctype).getOrElse(Seq())
               }

--- a/src/main/scala/edu/arizona/sista/reach/grounding/ReachContextKBLister.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/ReachContextKBLister.scala
@@ -9,17 +9,17 @@ import edu.arizona.sista.reach.grounding.ReachIMKBMentionLookups._
   */
 object ReachContextKBLister {
   /** A sequence of the context related KB instances, whose values are to be listed. */
-  val ContextKBs = Seq( ContextCellLine, ContextCellType, ContextOrgan, ContextSpecies,
-                        StaticCellLocation, StaticCellLocation2, ModelGendCellLocation )
+  val ContextKBs = Seq( (ContextCellLine, "CellLine"), (ContextCellType, "CellType"),
+   (ContextOrgan, "Organ"), (ContextSpecies, "Species"),
+    (StaticCellLocation, "Cellular_component"), (StaticCellLocation2, "Cellular_component"), (ModelGendCellLocation, "Cellular_component"))
 
   /** Return a sequence of grounding information objects from the context related KBs. */
   def listContextKBs: Seq[ContextGrounding] = {
-    ContextKBs.map(kb => kb.entries).flatten.map(kbe =>
-      ContextGrounding(kbe.text, kbe.key, kbe.namespace, kbe.id, kbe.nsId, kbe.species))
+    ContextKBs.flatMap{ case (kb, ctxType) => kb.entries map (kbe => ContextGrounding(ctxType, kbe.text, kbe.key, kbe.namespace, kbe.id, kbe.nsId, kbe.species))}
   }
 
   /** Case class to hold grounding information about context related KB entries. */
-  case class ContextGrounding(text:String, key:String, namespace:String, id:String,
+  case class ContextGrounding(ctxType:String, text:String, key:String, namespace:String, id:String,
                               nsId:String, species:String)
 
 }


### PR DESCRIPTION
- Restores the proper flow on ReachSystem to annotate papers with all
the Document and FriesEntry instances on hand.
- Bug fixes to the context policies.
- Changed the taxonomy to put the context labels below the context
entry.
- Context’s global dictionary using grounding accessor.