### PR TITLE
Issue90: grounding pXXX => XXX

### DIFF
--- a/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
@@ -126,7 +126,7 @@ class TestEntities extends FlatSpec with Matchers {
     doc.text = Some(mekText2)
     doc.sentences.head.entities = Some(ggpLabels)
     val mentions = testReach.extractFrom(doc)
-    displayMentions(mentions, doc)
+    // displayMentions(mentions, doc)
     mentions should have size (1)
     mentions.head matches "Family" should be (true)
   }

--- a/src/test/scala/edu/arizona/sista/reach/TestProteinResolutions.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestProteinResolutions.scala
@@ -14,7 +14,7 @@ import edu.arizona.sista.reach.grounding.ReachKBUtils._
 /**
   * Unit tests to ensure alternate resolutions are working for KB grounding.
   *   Written by: Tom Hicks. 11/16/2015.
-  *   Last Modified: Add tests for protein-domain pattern.
+  *   Last Modified: Add tests for PTM-related protein prefixes.
   */
 class TestProteinResolutions extends FlatSpec with Matchers {
 
@@ -55,6 +55,10 @@ class TestProteinResolutions extends FlatSpec with Matchers {
     (imkbP.resolve("zyx-1").isDefined) should be (true)
     (imkbP.resolve("zyx-1_human").isDefined) should be (true)
     (imkbP.resolve("zyx-1 protein").isDefined) should be (true)
+    (imkbP.resolve("STAT1").isDefined) should be (true)
+    (imkbP.resolve("stat1").isDefined) should be (true)
+    (imkbP.resolve("STBA").isDefined) should be (true)
+    (imkbP.resolve("stba").isDefined) should be (true)
   }
 
   "ProteinKBL resolve" should "work via protein domain lookup" in {
@@ -72,6 +76,24 @@ class TestProteinResolutions extends FlatSpec with Matchers {
     (imkbP.resolve("PI3KC2b-RBD").isDefined) should be (false) // protein not in KB
     (imkbP.resolve("zyx-1-rbd").isDefined) should be (false) // pre-key text fails pattern match
     (imkbP.resolve("PI3K-C2-alpha-RBD").isDefined) should be (false) // pre-key text fails pattern match
+  }
+
+  "ProteinKBL resolve" should "fail despite PTM prefix stripping" in {
+    (imkbP.resolve("pNOTINKB").isDefined) should be (false)
+    (imkbP.resolve("pnotinkb").isDefined) should be (false)
+    (imkbP.resolve("uNOTINKB").isDefined) should be (false)
+    (imkbP.resolve("unotinkb").isDefined) should be (false)
+  }
+
+  "ProteinKBL resolve" should "work with PTM prefix stripping" in {
+    (imkbP.resolve("pSTAT1").isDefined) should be (true)
+    (imkbP.resolve("pstat1").isDefined) should be (true)
+    (imkbP.resolve("pSTBA").isDefined) should be (true)
+    (imkbP.resolve("pstba").isDefined) should be (true)
+    (imkbP.resolve("uSTAT1").isDefined) should be (true)
+    (imkbP.resolve("ustat1").isDefined) should be (true)
+    (imkbP.resolve("uSTBA").isDefined) should be (true)
+    (imkbP.resolve("ustba").isDefined) should be (true)
   }
 
 


### PR DESCRIPTION
Implements PTM-related prefix stripping as alternate lookup method for proteins. 
This simple approach should be very effective but, because of current grounding design and data limitations, has the remote potential to create some false positive groundings (i.e. stripping a PTM-prefix from a string could potentially result in an incorrect protein identification). This should be very unlikely, especially as this algorithm is run last in the series of key lookups.