### PR TITLE
Update paxtools-core dependency to 4.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ libraryDependencies ++= Seq(
   "org.clulab" %% "processors" % "5.8.1" classifier "models",
   "com.typesafe" % "config" % "1.2.1",
   "commons-io" % "commons-io" % "2.4",
-  "org.biopax.paxtools" % "paxtools-core" % "4.3.0",
+  "org.biopax.paxtools" % "paxtools-core" % "4.3.1",
   "jline" % "jline" % "2.12.1",
   "org.apache.lucene" % "lucene-core" % "5.3.1",
   "org.apache.lucene" % "lucene-analyzers-common" % "5.3.1",

--- a/build.sbt
+++ b/build.sbt
@@ -63,11 +63,6 @@ pomExtra := (
 // end publishing settings
 //
 
-resolvers ++= Seq(
-  "BioPAX Releases" at "http://biopax.sourceforge.net/m2repo/releases",
-  "BioPAX Snapshots" at "http://biopax.sourceforge.net/m2repo/snapshots"
-)
-
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "org.clulab" % "bioresources" % "1.1.1",


### PR DESCRIPTION
BioPAX is now officially releasing to Maven Central as of PaxTools 4.3.1, so
let's make use of that. (See https://groups.google.com/d/msg/biopax-discuss/zwtwDG23T1E/Vu1OK7iXBQAJ for the release announcement mentioning Maven Central)