### PR TITLE
Added sbt-ghpages plugin to easily publish our documentation to clulab.github.io/reach

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,3 +76,13 @@ libraryDependencies ++= Seq(
   "org.apache.lucene" % "lucene-analyzers-common" % "5.3.1",
   "org.apache.lucene" % "lucene-queryparser" % "5.3.1"
 )
+
+// settings for building project website
+
+site.settings
+// include documentation
+site.includeScaladoc()
+
+ghpages.settings
+
+git.remoteRepo := "git@github.com:clulab/reach.git"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+// used for building project website
+resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>REACH</title>
+      <!-- Latest compiled and minified CSS -->
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+
+      <!-- theme -->
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css" integrity="sha384-fLW2N01lMqjakBkx3l/M9EahuwpSfeNvV63J5ezn3uZzapT0u7EYsXMjQV+0En5r" crossorigin="anonymous">
+      <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
+    </head>
+    <body>
+      <div class="container theme-showcase" role="main">
+
+      <!-- jumbotron -->
+      <div class="jumbotron">
+        <h1>About</h1>
+        <!-- description here -->
+        <p>
+          Reach stands for <strong>Re</strong>ading and <strong>A</strong>ssembling <strong>C</strong>ontextual and <strong>H</strong>olistic Mechanisms from Text. In plain English, Reach is an information extraction system for the biomedical domain, which aims to read scientific literature and extract cancer signaling pathways. Reach implements a fairly complete extraction pipeline, including: recognition of biochemical entities (proteins, chemicals, etc.), grounding them to known knowledge bases such as Uniprot, extraction of BioPAX-like interactions, e.g., phosphorylation, complex assembly, positive/negative regulations, and coreference resolution, for both entities and interactions.
+
+          Reach is developed using <a href="https://github.com/clulab/processors/wiki/ODIN-(Open-Domain-INformer)">Odin</a>, our open-domain information extraction framework, which is released within our
+          <a href="https://github.com/clulab/processors"><code>processors</code></a> repository.
+        </p>
+      </div>
+
+
+      <div class="page-header">
+
+        <h2>Authors</h2>
+          <p>
+            Reach was created by the following members of the <a href="http://clulab.cs.arizona.edu/">CLU lab at the University of Arizona</a>:
+            <ul>
+              <li><a href="https://github.com/marcovzla">Marco Valenzuela</a></li>
+              <li><a href="https://github.com/myedibleenso">Gus Hahn-Powell</a></li>
+              <li><a href="https://github.com/danebell">Dane Bell</a></li>
+              <li><a href="https://github.com/hickst">Tom Hicks</a></li>
+              <li><a href="https://github.com/enoriega">Enrique Noriega</a></li>
+              <li><a href="https://github.com/MihaiSurdeanu">Mihai Surdeanu</a></li>
+            </ul>
+          </p>
+
+        <h2>Citations</h2>
+          <p>
+            If you use Reach, please cite this paper:
+            <pre><code>
+              @inproceedings{Valenzuela+:2015aa,
+                author    = {Valenzuela-Esc\'{a}rcega, Marco A. and Gustave Hahn-Powell and Thomas Hicks and Mihai Surdeanu},
+                title     = {A Domain-independent Rule-based Framework for Event Extraction},
+                organization = {ACL-IJCNLP 2015},
+                booktitle = {Proceedings of the 53rd Annual Meeting of the Association for Computational Linguistics and the 7th International Joint Conference on Natural Language Processing of the Asian Federation of Natural Language Processing: Software Demonstrations (ACL-IJCNLP)},
+                url = {http://www.aclweb.org/anthology/P/P15/P15-4022.pdf},
+                year      = {2015},
+                pages = {127--132},
+                Note = {Paper available at \url{http://www.aclweb.org/anthology/P/P15/P15-4022.pdf}},
+              }
+            </code></pre>
+          </p>
+          <p>
+            More publications from the Reach project are available <a href="https://github.com/clulab/reach/wiki/Publications">here</a>.
+          </p>
+
+
+        <h2>Reach datasets</h2>
+          <p>
+            We have generated multiple datasets by reading publications from the <a href="http://www.ncbi.nlm.nih.gov/pmc/tools/openftlist/">open-access PubMed subset</a> using Reach. All datasets are freely available <a href="https://github.com/clulab/reach/wiki/Datasets">here</a>.
+          </p>
+
+        <h2>Reach web services</h2>
+          <p>
+            We have developed a series of web services on top of the Reach library. All are freely available <a href="http://agathon.sista.arizona.edu:8080/odinweb/">here</a>.
+          </p>
+
+        <h2>Funding</h2>
+          <p>
+            The development of Reach was funded by the <a href="http://www.darpa.mil/program/big-mechanism">DARPA Big Mechanism program</a> under ARO contract W911NF-14-1-0395.
+          </p>
+
+        <h2>Licensing</h2>
+          <p>
+            All our own code is licensed under Apache License Version 2.0. <strong>However, some of the libraries used here, most notably CoreNLP, are GPL v2.</strong> If <code>BioNLPProcessor</code> is not removed from this package, technically our whole code becomes GPL v2 since `BioNLPProcessor` builds on Stanford's <code>CoreNLP</code> functionality. Soon, we will split the code into multiple components, so licensing becomes less ambiguous.
+          </p>
+
+        <h2>Modifying the code</h2>
+          <p>
+            Reach builds upon our Odin event extraction framework. If you want to modify event and entity grammars, please refer to <a href="https://github.com/sistanlp/processors/wiki/ODIN-(Open-Domain-INformer)">Odin's Wiki</a> page for details. The <a href="http://arxiv.org/abs/1509.07513">Odin manual</a> is the best source for details on the rule language and the Odin API.
+          </p>
+
+        <h2>Documentation</h2>
+        <p>
+          <a href="latest/api/index.html">Partial documentation of the code is available here</a>.
+        </p>
+      </div>
+      <div>
+        <img border="0" src="https://travis-ci.org/clulab/reach.svg?branch=master" width="100" height="100">
+      </div>
+    </body>
+</html>


### PR DESCRIPTION
## Motivation
While it's easy to view our project documentation locally with `sbt doc`, these additions make it easy to publish our documentation to our project space at [clulab.github.io/reach](http://clulab.github.io/reach).

- http://clulab.github.io/reach/index.html
- http://clulab.github.io/reach/latest/api/index.html#package

Hopefully this will encourage us to better document our code...

## Using the plugin
Pages added under `src/site` will be built to `target/site`.

The site can be built with `sbt makeSite` and previewed with something like `open target/site/index.html`

Updates can be published to [clulab.github.io/reach](http://clulab.github.io/reach) by running `sbt ghpages-push-site`

See https://github.com/sbt/sbt-ghpages and https://github.com/sbt/sbt-site for details on the sbt plugin.