### PR TITLE
Redo grounding step1 to propagate ambiguity

### DIFF
--- a/src/main/scala/edu/arizona/sista/reach/grounding/IMKBLookup.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/IMKBLookup.scala
@@ -3,7 +3,7 @@ package edu.arizona.sista.reach.grounding
 /**
   * Base class merging logic for local Knowledge Base lookups on top of in-memory KB.
   *   Written by Tom Hicks. 10/23/2015.
-  *   Last Modified: Add method to return sequence of KB entries.
+  *   Last Modified: Redo grounding step1 to propagate ambiguity.
   */
 class IMKBLookup (
 
@@ -26,10 +26,8 @@ class IMKBLookup (
     * Return a resolution for the entry, if any found.
     */
   override def resolve (text:String): Resolutions = {
-    if (!hasSpeciesInfo)                    // if KB does not have species information
-      resolveNoSpecies(text)                // then try to resolve the text without species
-    else                                    // else prefer human resolution above others
-      resolveHuman(text) orElse memoryKB.lookupAll(makeCanonicalKey(text))
+    val key = makeCanonicalKey(text)        // make a lookup key from the given text
+    memoryKB.lookupAll(key)                 // find all matching entries in memory KB
   }
 
   /** Resolve the given text string to optional group of entries in a knowledge base,
@@ -76,13 +74,8 @@ class IMKBLookup (
     * Return a resolution for the entry, if any found.
     */
   override def resolveAlt (text:String, transforms:KeyTransforms): Resolutions = {
-    var entries: Resolutions = None
-    if (!hasSpeciesInfo)                    // if KB does not have species information
-      resolveNoSpeciesAlt(text, transforms) // then try to resolve the text without species
-    else {                                  // else prefer human resolution above others
-      val allKeys = reachAlternateKeys(text, transforms)
-      resolveHumanAlt(text, transforms) orElse memoryKB.lookupsAll(allKeys)
-    }
+    val allKeys = reachAlternateKeys(text, transforms)
+    memoryKB.lookupsAll(allKeys)
   }
 
   /** Resolve the given text string to an optional entry in a knowledge base,

--- a/src/main/scala/edu/arizona/sista/reach/grounding/InMemoryKB.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/InMemoryKB.scala
@@ -7,7 +7,7 @@ import edu.arizona.sista.reach.grounding.ReachKBConstants._
 /**
   * Class implementing an in-memory knowledge base indexed by key and species.
   *   Written by: Tom Hicks. 10/25/2015.
-  *   Last Modified: Add method to return sequence of KB entries. Remove spurious imports.
+  *   Last Modified: Remove unused lookup methods.
   */
 class InMemoryKB (
 
@@ -43,21 +43,6 @@ class InMemoryKB (
   /** Try lookups for all given keys until one succeeds or all fail. */
   def lookupsAll (allKeys:Seq[String]): Resolutions =
     applyLookupFn(lookupAll, allKeys)
-
-
-  /** Find any optional KB entry for the given key. Returns a resolution
-      for the first KB entry found or None. */
-  def lookupAny (key:String): Option[KBResolution] =
-    makeResolution(theKB.get(key).flatMap(eset => eset.headOption))
-
-  /** Try lookups for all given keys until one succeeds or all fail. */
-  def lookupsAny (allKeys:Seq[String]): Option[KBResolution] = {
-    allKeys.foreach { key =>
-      val entry = lookupAny(key)
-      if (entry.isDefined) return entry
-    }
-    return None                             // tried all keys: no success
-  }
 
 
   /** Find the set of KB entries, for the given key, which match the given single species.

--- a/src/main/scala/edu/arizona/sista/reach/grounding/KBKeyTransforms.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/KBKeyTransforms.scala
@@ -3,7 +3,7 @@ package edu.arizona.sista.reach.grounding
 /**
   * Methods for transforming text strings into potential keys for lookup in KBs.
   *   Written by Tom Hicks. 10/22/2015.
-  *   Last Modified: Enhance logic to strip multiple suffixes.
+  *   Last Modified: Update for case-insensitive transforms.
   */
 trait KBKeyTransforms {
 
@@ -12,8 +12,8 @@ trait KBKeyTransforms {
 
 
   /** Return a sequence of alternate keys, one for each of the given key transforms. */
-  def makeAlternateKeys (text:String, transformFns:KeyTransforms): Seq[String] = {
-    transformFns.map(_.apply(text)).filter(_ != text)
+  def applyTransforms (text:String, transformFns:KeyTransforms): Seq[String] = {
+    transformFns.map(_.apply(text)).filter{ str => (str != text) && (str != text.toLowerCase) }
   }
 
   /** Try to remove all of the suffixes in the given set from the given text. */

--- a/src/main/scala/edu/arizona/sista/reach/grounding/ReachKBKeyTransforms.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/ReachKBKeyTransforms.scala
@@ -6,7 +6,7 @@ import edu.arizona.sista.reach.grounding.ReachKBKeyTransforms._
 /**
   * REACH-related methods for transforming text strings into potential keys for lookup in KBs.
   *   Written by Tom Hicks. 11/10/2015.
-  *   Last Modified: Add logic to strip PTM-related prefixes from proteins.
+  *   Last Modified: Allow case-sensitive transforms. Redo patterns as case-insensitive.
   */
 trait ReachKBKeyTransforms extends KBKeyTransforms {
 
@@ -21,60 +21,58 @@ trait ReachKBKeyTransforms extends KBKeyTransforms {
 
   /** Return alternate lookup keys created from the given text string and transform functions. */
   def reachAlternateKeys (text:String, transformFns:KeyTransforms): Seq[String] = {
-    val lcText = text.toLowerCase           // transform lower cased text only
-    val allTexts = lcText +: makeAlternateKeys(lcText, transformFns)
+    val allTexts = text +: applyTransforms(text, transformFns)
     return allTexts.map(makeCanonicalKey(_))
   }
 
 
-  /** Return the portion of the key string minus one of the protein family suffixes,
-    * if found in the given key string, else return the key unchanged. */
-  def stripFamilySuffixes (key:String): String = {
-    return stripSuffixes(FamilyStopSuffixes, key)
+  /** Return the portion of the text string minus one of the protein family suffixes,
+    * if found in the given text string, else return the text lowercased. */
+  def stripFamilySuffixes (text:String): String = {
+    val lcText = text.toLowerCase           // match lower cased text only
+    stripSuffixes(FamilyStopSuffixes, lcText)
   }
 
-  /** Return the portion of the key string minus one of the organ-cell-type suffixes,
-    * if found in the given key string, else return the key unchanged. */
-  def stripOrganCellTypeSuffixes (key:String): String = {
-    val suffixPat = """(.*)(cells?|tissues?|fluids?)""".r  // trailing context strings
-    return key match {
-      case suffixPat(lhs, _) => lhs
-      case _ => key
+  /** Return the portion of the text string minus one of the organ-cell-type suffixes,
+    * if found in the given text string, else return the text unchanged. */
+  def stripOrganCellTypeSuffixes (text:String): String = {
+    return text match {
+      case OrganSuffixPat(lhs, _) => lhs
+      case _ => text                        // return text unchanged
     }
   }
 
-  /** Return the portion of the key string before a trailing mutation phrase,
-    * if found in the given key string, else return the key unchanged. */
-  def stripMutantProtein (key:String): String = {
-    val phosMutePat = """phosphorylated\s+(.*)\s+\w+\s+mutant""".r  // phosphorylation/mutation phrase
-    val mutePat = """(.*)\s+\w+\s+mutant""".r  // mutation phrase at end of string
-    return key match {
-      case phosMutePat(lhs) => lhs
-      case mutePat(lhs) => lhs
-      case _ => key
+  /** Return the portion of the text string before a trailing mutation phrase,
+    * if found in the given text string, else return the text unchanged. */
+  def stripMutantProtein (text:String): String = {
+    return text match {
+      case PhosphorMutationPat(lhs) => lhs
+      case TrailingMutationPat(lhs) => lhs
+      case _ => text                        // return text unchanged
     }
   }
 
-  /** Return the portion of the key string minus any of the PTM-related prefixes, if found
-    * in the given key string, else return the key unchanged. */
-  def stripPTMPrefixes (key:String): String = key match {
+  /** Return the portion of the text string minus any of the PTM-related prefixes, if found
+    * in the given text string, else return the text unchanged. */
+  def stripPTMPrefixes (text:String): String = text match {
     case PTMPrefixPat(prefix, restOfKey) => restOfKey
-    case _ => key
+    case _ => text
   }
 
-  /** Return the portion of the key string minus one of the protein suffixes, if found
-    * in the given key string, else return the key unchanged. */
-  def stripProteinSuffixes (key:String): String = {
-    return stripSuffixes(ProteinStopSuffixes, key)
+  /** Return the portion of the text string minus one of the protein suffixes, if found
+    * in the given text string, else return the text lowercased. */
+  def stripProteinSuffixes (text:String): String = {
+    val lcText = text.toLowerCase           // match lower cased text only
+    stripSuffixes(ProteinStopSuffixes, lcText)
   }
 
   /** Check for one of several types of hyphen-separated strings and, if found,
-    * extract and return the candidate key portion, else return the key unchanged. */
-  def hyphenatedProteinKey (key:String): String = {
-    return key match {
+    * extract and return the candidate text portion, else return the text unchanged. */
+  def hyphenatedProteinKey (text:String): String = {
+    return text match {
       // check for RHS protein domain or LHS mutant spec: return protein portion only
-      case HyphenatedNamePat(lhs, rhs) => if (proteinDomainSuffixes.contains(rhs)) lhs else rhs
-      case _ => key
+      case HyphenatedNamePat(lhs, rhs) => if (isProteinDomain(rhs)) lhs else rhs
+      case _ => text                        // return text unchanged
     }
   }
 }
@@ -83,11 +81,22 @@ trait ReachKBKeyTransforms extends KBKeyTransforms {
 /** Trait Companion Object allows Mixin OR Import pattern. */
 object ReachKBKeyTransforms extends ReachKBKeyTransforms {
 
-  /** Pattern matching 2 text strings separated by a hyphen. */
-  val HyphenatedNamePat = """(\w+)-(\w+)""".r
+  /** Pattern matching 2 text strings separated by a hyphen, case insensitive. */
+  val HyphenatedNamePat = """(?i)(\w+)-(\w+)""".r
+
+  /** Trailing context strings for organ phrases, case insensitive. */
+  val OrganSuffixPat = """(?i)(.*)(cells?|tissues?|fluids?)""".r
 
   /** Match protein names beginning with special PTM-related prefix characters. */
+  // val PTMPrefixPat = """(p|u)([A-Z0-9_-][A-Za-z0-9_-]*)""".r // LATER: USE THIS ONE?
   val PTMPrefixPat = """(p|u)([A-Za-z0-9_-]+)""".r
+
+  /** Match phosphorylation mutation phrases, case insensitive. */
+  val PhosphorMutationPat = """(?i)phosphorylated\s+(.*)\s+\w+\s+mutant""".r
+
+  /** Match mutation string at end of text string, case insensitive. */
+  val TrailingMutationPat = """(?i)(.*)\s+\w+\s+mutant""".r
+
 
   /** List of transform methods to apply for alternate Protein Family lookups. */
   val familyKeyTransforms = Seq( stripFamilySuffixes _ )
@@ -103,5 +112,8 @@ object ReachKBKeyTransforms extends ReachKBKeyTransforms {
 
   /** Set of protein domain suffixes. */
   val proteinDomainSuffixes: Set[String] = ReachKBUtils.readLines(ProteinDomainSuffixesFilename).map(suffix => makeCanonicalKey(suffix.trim)).toSet
+
+  def isProteinDomain (domain: String): Boolean =
+    proteinDomainSuffixes.contains(makeCanonicalKey(domain))
 
 }

--- a/src/test/scala/edu/arizona/sista/reach/TestAdHocIMKBs.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestAdHocIMKBs.scala
@@ -7,7 +7,7 @@ import edu.arizona.sista.reach.grounding._
 /**
   * Unit tests to ensure a mixed-namespace in-memory KB is working for grounding.
   *   Written by: Tom Hicks. 1/20/2016.
-  *   Last Modified: Update for separate bioresources project with all KBs gzipped.
+  *   Last Modified: Update for removal of lookup any.
   */
 class TestAdHocIMKBs extends FlatSpec with Matchers {
 
@@ -23,17 +23,6 @@ class TestAdHocIMKBs extends FlatSpec with Matchers {
     (ahkb3.lookupAll("apoptosis").isDefined) should be (true)
     (ahkb3.lookupAll("nadph").isDefined) should be (true)
     (ahkb3.lookupAll("ros").isDefined) should be (true)
-  }
-
-  "AdHocKB COL-3" should "lookupAny on AHKB from COL-3 TSV file" in {
-    (ahkb3.lookupAny("NOT-IN-KB").isDefined) should be (false) // not in KB
-    (ahkb3.lookupAny("not-in-kb").isDefined) should be (false) // not in KB
-    (ahkb3.lookupAny("TROP2").isDefined) should be (false)  // uppercase
-    (ahkb3.lookupAny("Trop2").isDefined) should be (false)  // mixed case
-    (ahkb3.lookupAny("trop2").isDefined) should be (true)
-    (ahkb3.lookupAny("apoptosis").isDefined) should be (true)
-    (ahkb3.lookupAny("nadph").isDefined) should be (true)
-    (ahkb3.lookupAny("ros").isDefined) should be (true)
   }
 
   "AdHocKB COL-3" should "lookupByASpecies on AHKB from COL-3 TSV file" in {

--- a/src/test/scala/edu/arizona/sista/reach/TestKBSupport.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestKBSupport.scala
@@ -9,7 +9,7 @@ import edu.arizona.sista.reach.grounding.ReachKBKeyTransforms._
 /**
   * Unit tests to ensure grounding is working properly
   *   Written by: Tom Hicks. 10/23/2015.
-  *   Last Modified: Update for grounding changes.
+  *   Last Modified: Update for grounding method rename.
   */
 class TestKBSupport extends FlatSpec with Matchers {
 
@@ -89,63 +89,63 @@ class TestKBSupport extends FlatSpec with Matchers {
   }
 
   // test ReachKeyTransforms
-  "makeAlternateKeys(identical, proteinKeyTransforms)" should "return identical string" in {
-    (makeAlternateKeys("identical",proteinKeyTransforms)).isEmpty should be (true)
-    (makeAlternateKeys("IDENTICAL",proteinKeyTransforms)).isEmpty should be (true)
-    (makeAlternateKeys("no change",proteinKeyTransforms)).isEmpty should be (true)
-    (makeAlternateKeys("result: empty list",proteinKeyTransforms)).isEmpty should be (true)
+  "applyTransforms(identical, proteinKeyTransforms)" should "return identical string" in {
+    (applyTransforms("identical",proteinKeyTransforms)).isEmpty should be (true)
+    (applyTransforms("IDENTICAL",proteinKeyTransforms)).isEmpty should be (true)
+    (applyTransforms("no change",proteinKeyTransforms)).isEmpty should be (true)
+    (applyTransforms("result: empty list",proteinKeyTransforms)).isEmpty should be (true)
   }
 
-  "makeAlternateKeys(LHS-RHS, proteinKeyTransforms)" should "return RHS" in {
-    // val xkeys = makeAlternateKeys("LHS-RHS", Seq(unmutateProteinKey _))
-    val xkeys = makeAlternateKeys("LHS-RHS", proteinKeyTransforms)
+  "applyTransforms(LHS-RHS, proteinKeyTransforms)" should "return RHS" in {
+    // mostly testing unmutateProteinKey
+    val xkeys = applyTransforms("LHS-RHS", proteinKeyTransforms)
     (xkeys.size == 1) should be (true)
     (xkeys.head == "RHS") should be (true)
   }
 
-  "makeAlternateKeys(hairy protein, proteinKeyTransforms)" should "return hairy" in {
-    // val xkeys = makeAlternateKeys("hairy protein", Seq(stripProteinSuffixes _))
-    val xkeys = makeAlternateKeys("hairy protein", proteinKeyTransforms)
+  "applyTransforms(hairy protein, proteinKeyTransforms)" should "return hairy" in {
+    // mostly testing stripProteinSuffixes
+    val xkeys = applyTransforms("hairy protein", proteinKeyTransforms)
     (xkeys.size == 1) should be (true)
     (xkeys.head == "hairy") should be (true)
   }
 
-  "makeAlternateKeys(savage API mutant, proteinKeyTransforms)" should "return savage" in {
-    // val xkeys = makeAlternateKeys("savage API mutant", Seq(stripMutantProtein _))
-    val xkeys = makeAlternateKeys("savage API mutant", proteinKeyTransforms)
+  "applyTransforms(savage API mutant, proteinKeyTransforms)" should "return savage" in {
+    // mostly testing stripMutantProtein
+    val xkeys = applyTransforms("savage API mutant", proteinKeyTransforms)
     (xkeys.size == 1) should be (true)
     (xkeys.head == "savage") should be (true)
   }
 
-  "makeAlternateKeys(weird protein mutant, proteinKeyTransforms)" should "return weird" in {
-    // val xkeys = makeAlternateKeys("weird protein mutant", Seq(stripProteinSuffixes _))
-    val xkeys = makeAlternateKeys("weird protein mutant", proteinKeyTransforms)
+  "applyTransforms(weird protein mutant, proteinKeyTransforms)" should "return weird" in {
+    // mostly testing stripProteinSuffixes
+    val xkeys = applyTransforms("weird protein mutant", proteinKeyTransforms)
     (xkeys.size == 1) should be (true)
     (xkeys.head == "weird") should be (true)
   }
 
-  "makeAlternateKeys(odd mutant protein, proteinKeyTransforms)" should "return odd" in {
-    // val xkeys = makeAlternateKeys("odd mutant protein", Seq(stripProteinSuffixes _))
-    val xkeys = makeAlternateKeys("odd mutant protein", proteinKeyTransforms)
+  "applyTransforms(odd mutant protein, proteinKeyTransforms)" should "return odd" in {
+    // mostly testing stripProteinSuffixes
+    val xkeys = applyTransforms("odd mutant protein", proteinKeyTransforms)
     (xkeys.size == 1) should be (true)
     (xkeys.head == "odd") should be (true)
   }
 
-  "makeAlternateKeys(phosphorylated WILD XK mutant, proteinKeyTransforms)" should "return WILD" in {
-    // val xkeys = makeAlternateKeys("phosphorylated WILD XK mutant", Seq(stripMutantProtein _))
-    val xkeys = makeAlternateKeys("phosphorylated WILD XK mutant", proteinKeyTransforms)
+  "applyTransforms(phosphorylated WILD XK mutant, proteinKeyTransforms)" should "return WILD" in {
+    // mostly testing stripMutantProtein
+    val xkeys = applyTransforms("phosphorylated WILD XK mutant", proteinKeyTransforms)
     (xkeys.size == 1) should be (true)
     (xkeys.head == "WILD") should be (true)
   }
 
-  "makeAlternateKeys(Parsnip family, familyKeyTransforms)" should "return Parsnip" in {
-    val xkeys = makeAlternateKeys("Parsnip family", familyKeyTransforms)
+  "applyTransforms(Parsnip family, familyKeyTransforms)" should "return Parsnip" in {
+    val xkeys = applyTransforms("Parsnip family", familyKeyTransforms)
     (xkeys.size == 1) should be (true)
-    (xkeys.head == "Parsnip") should be (true)
+    (xkeys.head == "parsnip") should be (true)
   }
 
-  "makeAlternateKeys(sad protein family, familyKeyTransforms)" should "return sad" in {
-    val xkeys = makeAlternateKeys("sad protein family", familyKeyTransforms)
+  "applyTransforms(sad protein family, familyKeyTransforms)" should "return sad" in {
+    val xkeys = applyTransforms("sad protein family", familyKeyTransforms)
     (xkeys.size == 1) should be (true)
     (xkeys.head == "sad") should be (true)
   }

--- a/src/test/scala/edu/arizona/sista/reach/TestTsvKBs.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestTsvKBs.scala
@@ -10,7 +10,7 @@ import edu.arizona.sista.reach.grounding.ReachKBConstants._
 /**
   * Unit tests to ensure the in-memory KB is working for grounding.
   *   Written by: Tom Hicks. 10/26/2015.
-  *   Last Modified: Update for separate bioresources project with all KBs gzipped.
+  *   Last Modified: Update for removal of lookup any.
   */
 class TestTsvKBs extends FlatSpec with Matchers {
 
@@ -24,14 +24,6 @@ class TestTsvKBs extends FlatSpec with Matchers {
     (imkb2.lookupAll("DENDRITE").isDefined) should be (false)  // uppercase
     (imkb2.lookupAll("dendrite").isDefined) should be (true)
     (imkb2.lookupAll("telomere").isDefined) should be (true)
-  }
-
-  "InMemoryKB COL-2" should "lookupAny on IMKB from COL-2 TSV file" in {
-    (imkb2.lookupAny("NOT-IN-KB").isDefined) should be (false) // not in KB
-    (imkb2.lookupAny("not-in-kb").isDefined) should be (false) // not in KB
-    (imkb2.lookupAny("DENDRITE").isDefined) should be (false)  // uppercase
-    (imkb2.lookupAny("dendrite").isDefined) should be (true)
-    (imkb2.lookupAny("telomere").isDefined) should be (true)
   }
 
   "InMemoryKB COL-2" should "fail to lookupByASpecies on IMKB from COL-2 TSV file" in {
@@ -78,13 +70,6 @@ class TestTsvKBs extends FlatSpec with Matchers {
     (imkbPF.lookupAll("PTHR21244").isDefined) should be (false) // uppercase
     (imkbPF.lookupAll("pthr21244").isDefined) should be (true)
     (imkbPF.lookupAll("hk").isDefined) should be (true)
-  }
-
-  "InMemoryKB COL-3" should "lookupAny on IMKB from COL-3 gzipped TSV file" in {
-    (imkbPF.lookupAny("NOT-IN-KB").isDefined) should be (false) // not in KB
-    (imkbPF.lookupAny("PTHR21244").isDefined) should be (false) // uppercase
-    (imkbPF.lookupAny("pthr21244").isDefined) should be (true)
-    (imkbPF.lookupAny("hk").isDefined) should be (true)
   }
 
   "InMemoryKB COL-3" should "lookupByASpecies on IMKB from COL-3 gzipped TSV file" in {


### PR DESCRIPTION
Also allows case-sensitive transforms, removes unused lookup methods, and update tests for same.