### PR TITLE
Issue90a: Restrict PTM protein matching pattern in grounding step 1

### DIFF
--- a/src/main/scala/edu/arizona/sista/reach/grounding/ReachKBKeyTransforms.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/ReachKBKeyTransforms.scala
@@ -6,7 +6,7 @@ import edu.arizona.sista.reach.grounding.ReachKBKeyTransforms._
 /**
   * REACH-related methods for transforming text strings into potential keys for lookup in KBs.
   *   Written by Tom Hicks. 11/10/2015.
-  *   Last Modified: Allow case-sensitive transforms. Redo patterns as case-insensitive.
+  *   Last Modified: Restrict PTM patterns per issue #90.
   */
 trait ReachKBKeyTransforms extends KBKeyTransforms {
 
@@ -88,8 +88,7 @@ object ReachKBKeyTransforms extends ReachKBKeyTransforms {
   val OrganSuffixPat = """(?i)(.*)(cells?|tissues?|fluids?)""".r
 
   /** Match protein names beginning with special PTM-related prefix characters. */
-  // val PTMPrefixPat = """(p|u)([A-Z0-9_-][A-Za-z0-9_-]*)""".r // LATER: USE THIS ONE?
-  val PTMPrefixPat = """(p|u)([A-Za-z0-9_-]+)""".r
+  val PTMPrefixPat = """(p|u)([A-Z0-9_-][A-Za-z0-9_-]*)""".r
 
   /** Match phosphorylation mutation phrases, case insensitive. */
   val PhosphorMutationPat = """(?i)phosphorylated\s+(.*)\s+\w+\s+mutant""".r

--- a/src/test/scala/edu/arizona/sista/reach/TestProteinResolutions.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestProteinResolutions.scala
@@ -83,17 +83,22 @@ class TestProteinResolutions extends FlatSpec with Matchers {
     (imkbP.resolve("pnotinkb").isDefined) should be (false)
     (imkbP.resolve("uNOTINKB").isDefined) should be (false)
     (imkbP.resolve("unotinkb").isDefined) should be (false)
+    // does not match restricted pattern (and not in KB without pattern matching)
+    (imkbP.resolve("PSTAT1").isDefined) should be (false)
+    (imkbP.resolve("Pstat1").isDefined) should be (false)
+    (imkbP.resolve("pstat1").isDefined) should be (false)
+    (imkbP.resolve("uerk").isDefined) should be (false)
+    (imkbP.resolve("ustat1").isDefined) should be (false)
+    (imkbP.resolve("ustba").isDefined) should be (false)
   }
 
   "ProteinKBL resolve" should "work with PTM prefix stripping" in {
     (imkbP.resolve("pSTAT1").isDefined) should be (true)
-    (imkbP.resolve("pstat1").isDefined) should be (true)
-    (imkbP.resolve("pSTBA").isDefined) should be (true)
-    (imkbP.resolve("pstba").isDefined) should be (true)
+    (imkbP.resolve("pSTBC").isDefined) should be (true)
+    (imkbP.resolve("pERK").isDefined) should be (true)
+    (imkbP.resolve("uERK").isDefined) should be (true)
     (imkbP.resolve("uSTAT1").isDefined) should be (true)
-    (imkbP.resolve("ustat1").isDefined) should be (true)
     (imkbP.resolve("uSTBA").isDefined) should be (true)
-    (imkbP.resolve("ustba").isDefined) should be (true)
   }
 
 

--- a/src/test/scala/edu/arizona/sista/reach/testGrounding.sh
+++ b/src/test/scala/edu/arizona/sista/reach/testGrounding.sh
@@ -9,4 +9,5 @@ edu.arizona.sista.reach.TestGroundingTrait \
 edu.arizona.sista.reach.TestProteinResolutions \
 edu.arizona.sista.reach.TestFamilyResolutions \
 edu.arizona.sista.reach.TestOrganCellTypeResolutions \
+edu.arizona.sista.reach.TestReachContextKBLister.scala \
 edu.arizona.sista.reach.TestGrounding'


### PR DESCRIPTION
This restriction discussed in issue #90 in the comments.