### PR TITLE
switch trigger label when switching event label

### DIFF
--- a/src/main/scala/edu/arizona/sista/reach/DarpaActions.scala
+++ b/src/main/scala/edu/arizona/sista/reach/DarpaActions.scala
@@ -422,8 +422,10 @@ class DarpaActions extends Actions {
       val numNegatives = arguments.map(arg => countSemanticNegatives(trigger, arg, excluded)).sum
       if (numNegatives % 2 != 0) { // odd number of negatives
         val newLabels = flipLabel(m.labels.head) +: m.labels.tail
+        // trigger labels should match event labels
+        val newTrigger = m.trigger.copy(labels = newLabels)
         // return new mention with flipped label
-        new BioEventMention(newLabels, m.trigger, m.arguments, m.sentence, m.document, m.keep, m.foundBy)
+        new BioEventMention(newLabels, newTrigger, m.arguments, m.sentence, m.document, m.keep, m.foundBy)
       } else {
         m // return mention unmodified
       }

--- a/src/test/scala/edu/arizona/sista/reach/NegationTests.scala
+++ b/src/test/scala/edu/arizona/sista/reach/NegationTests.scala
@@ -206,4 +206,17 @@ class NegationTests extends FlatSpec with Matchers{
       phospho should have size (1)
       getNegations(phospho.head) should have size (0)
     }
+
+    val sent13 = "decreased PTPN13 expression increases phosphorylation of EphrinB1"
+    sent13 should "contain a negative regulation according to hedging rules" in {
+      val mentions = getBioMentions(sent13)
+      val posregs = mentions filter (_ matches "Positive_regulation")
+      val negregs = mentions filter (_ matches "Negative_regulation")
+      posregs should have size (0)
+      negregs should have size (1)
+      val negreg = negregs.head.asInstanceOf[BioEventMention]
+      // event label should match trigger label
+      negreg.label should equal (negreg.trigger.label)
+    }
+
 }


### PR DESCRIPTION
This pull request fixes #104 by switching the trigger label when switching the event label.
It also adds a test for this situation.