### PR TITLE
Improved pos_reg rules; Improved resolution of overlap between site_1letter and other ents

### DIFF
--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/entities/entities.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/entities/entities.yml
@@ -13,9 +13,10 @@
     [word = /(?i)residue/]?
     [word = /\d{3}$/]?
 
+# this one is ambiguous: there are proteins that have the same form; in such cases, prefer the proteins
 - name: site_1letter
   label: Site
-  priority: 1
+  priority: 5
   type: token
   action: mkBioMention
   pattern: |

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/entities/entities.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/entities/entities.yml
@@ -13,14 +13,14 @@
     [word = /(?i)residue/]?
     [word = /\d{3}$/]?
 
-# this one is ambiguous: there are proteins that have the same form; in such cases, prefer the proteins
+# this one is ambiguous: there are proteins that have the same form; in such cases, prefer the proteins or chemicals
 - name: site_1letter
   label: Site
   priority: 5
   type: token
   action: mkBioMention
   pattern: |
-    (?<! [word=/(?i)^(table|figure)/]) [word=/(?i)^[ACDEFGHIKLMNQRSTVWY]\d+$/]
+    (?<! [word=/(?i)^(table|figure)/]) [word=/(?i)^[ACDEFGHIKLMNQRSTVWY]\d+$/ & !mention=/^(Gene_or_gene_product|Simple_chemical)$/]
   # old alt. pattern /^P\d+$/
 
 - name: site_3letter

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/pos-reg_template.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/pos-reg_template.yml
@@ -205,25 +205,23 @@
     controlled:${ controlledType } = /poss/
 
 
-# FIXME do we really need a positive regulation without a trigger?
-#- name: Positive_${ ruleType }_syntax_relation
-#  priority: ${ priority }
-#  label: ${ label }
-#  action: ${ actionFlow }
-#  pattern: |
-#    controlled:${ controlledType }
-#    controller:${ controllerType } = prep_by
-
-
 - name: Positive_${ ruleType }_token_1_verb
   priority: ${ priority }
-  example: ""
   type: token
   label: ${ label }
   example: "monoubiquitinated K-Ras is less sensitive than the unmodified protein to GAP-mediated GTP hydrolysis"
   action: ${ actionFlow }
   pattern: |
-    @controller:${ controllerType } (?<trigger> [word=/^mediat/ & !tag=/^JJ/]) @controlled:${ controlledType }
+    @controller:${ controllerType } (?<trigger> [word=/(?i)^(${ triggers })/ & !tag=/^JJ/]) @controlled:${ controlledType }
+
+- name: Positive_${ ruleType }_token_1b_verb
+  priority: ${ priority }
+  type: token
+  label: ${ label }
+  example: "Interacting proteins that facilitate FGFR3 mediated STAT1 activation could exist in cells."
+  action: ${ actionFlow }
+  pattern: |
+    @controller:${ controllerType } (?<trigger> [word=/(?i)^(mediat)/ & !tag=/^JJ/]) @controlled:${ controlledType } /(?i)^(activation)/
 
 
 - name: Positive_${ ruleType }_token_2_verb
@@ -233,7 +231,7 @@
   label: ${ label }
   action: ${ actionFlow }
   pattern: |
-    (?<trigger> [word=increased & !tag=/^JJ/]) @controlled:${ controlledType } following @controller:${ controllerType } (?! [lemma=/${ negnouns}/])
+    (?<trigger> [word=/(?i)^(${ triggers })/ & !tag=/^JJ/]) @controlled:${ controlledType } following @controller:${ controllerType } (?! [lemma=/${ negnouns}/])
 
 
 - name: Positive_${ ruleType }_token_1_noun
@@ -255,3 +253,4 @@
   action: ${ actionFlow }
   pattern: |
     (?<trigger> [word=/(?i)^(${ triggers })/ & tag=/^NN/]) of @controlled:${ controlledType } by @controller:${ controllerType } (?! [lemma=/${ negnouns}/])
+

--- a/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
@@ -129,4 +129,12 @@ class TestEntities extends FlatSpec with Matchers {
     mentions should have size (1)
     mentions.head matches "Family" should be (true)
   }
+
+  val sent8 = "Our model, in which E2-induced SRC-3 phosphorylation occurs in a complex with ER"
+  sent8 should "not contain any sites and it should have 1 simple chemical" in {
+    val mentions = getBioMentions(sent8)
+    mentions.count(_ matches "Site") should be (0)
+    mentions.count(_ matches "Simple_chemical") should be (1)
+  }
+
 }

--- a/src/test/scala/edu/arizona/sista/reach/TestRegulationEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestRegulationEvents.scala
@@ -371,4 +371,12 @@ class TestRegulationEvents extends FlatSpec with Matchers {
     mentions.filter(_ matches "Phosphorylation") should have size (1)
     hasPositiveRegulationByEntity("GSK-3", "Phosphorylation", List("LRP5"), mentions) should be (true)
   }
+
+  val sent41 = "Our model, in which E2-induced SRC-3 phosphorylation occurs in a complex with ER"
+  sent41 should "contain 1 positive regulation and 1 phosphorylation" in {
+    val mentions = getBioMentions(sent41)
+    mentions.filter(_ matches "Positive_regulation") should have size (1)
+    mentions.filter(_ matches "Phosphorylation") should have size (1)
+    hasPositiveRegulationByEntity("E2", "Phosphorylation", List("SRC-3"), mentions) should be (true)
+  }
 }


### PR DESCRIPTION
1. I extended the pos_reg surface rules. This was easy. The tests pass.
2. The site rule site_1letter, which does what its name says, is ambiguous! The same LETTER-DIGIT pattern appears in other, arguably more important entities. For example, in the paper I mentioned, "E2" is a simple chemical we were missing. I changed this simply by lowering the priority of site_1letter to be after all the NER rules in entities.yml, and not allowing any overlap with GGPs or chemicals.