### PR TITLE
Priority variables

### DIFF
--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
@@ -1,7 +1,7 @@
 - name: alias_paren1_nil
   label: Alias
   action: mkBioMention
-  priority: 4
+  priority: ${ priority }
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -13,7 +13,7 @@
 - name: alias_paren2_referredto
   label: Alias
   action: mkBioMention
-  priority: 4
+  priority: ${ priority }
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -28,7 +28,7 @@
 - name: alias_paren3_knownas
   label: Alias
   action: mkBioMention
-  priority: 4
+  priority: ${ priority }
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -43,7 +43,7 @@
 - name: alias_paren4_called
   label: Alias
   action: mkBioMention
-  priority: 4
+  priority: ${ priority }
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -58,7 +58,7 @@
 - name: alias_paren5_alias
   label: Alias
   action: mkBioMention
-  priority: 4
+  priority: ${ priority }
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -71,7 +71,7 @@
 - name: alias_comma1_referredto
   label: Alias
   action: mkBioMention
-  priority: 4
+  priority: ${ priority }
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -86,7 +86,7 @@
 - name: alias_comma2_knownas
   label: Alias
   action: mkBioMention
-  priority: 4
+  priority: ${ priority }
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -101,7 +101,7 @@
 - name: alias_comma2_called
   label: Alias
   action: mkBioMention
-  priority: 4
+  priority: ${ priority }
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/coref/alias.yml
@@ -1,7 +1,7 @@
 - name: alias_paren1_nil
   label: Alias
   action: mkBioMention
-  priority: ${ priority }
+  priority: 4
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -13,7 +13,7 @@
 - name: alias_paren2_referredto
   label: Alias
   action: mkBioMention
-  priority: ${ priority }
+  priority: 4
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -28,7 +28,7 @@
 - name: alias_paren3_knownas
   label: Alias
   action: mkBioMention
-  priority: ${ priority }
+  priority: 4
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -43,7 +43,7 @@
 - name: alias_paren4_called
   label: Alias
   action: mkBioMention
-  priority: ${ priority }
+  priority: 4
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -58,7 +58,7 @@
 - name: alias_paren5_alias
   label: Alias
   action: mkBioMention
-  priority: ${ priority }
+  priority: 4
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -71,7 +71,7 @@
 - name: alias_comma1_referredto
   label: Alias
   action: mkBioMention
-  priority: ${ priority }
+  priority: 4
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -86,7 +86,7 @@
 - name: alias_comma2_knownas
   label: Alias
   action: mkBioMention
-  priority: ${ priority }
+  priority: 4
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)
@@ -101,7 +101,7 @@
 - name: alias_comma2_called
   label: Alias
   action: mkBioMention
-  priority: ${ priority }
+  priority: 4
   type: token
   pattern: |
     (@alias:Family | @alias:MacroMolecule)

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/bind_events.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/bind_events.yml
@@ -4,7 +4,7 @@
 - name: binding1a
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [lemma=/bind|associate|immunoprecipitate|ligate/ & tag=/^V/ & !outgoing=/prep_(to|with)|dobj|acomp/]
     theme1:BioChemicalEntity+ = <rcmod conj_and{,2} | nsubj /nn|conj_|cc/{,2} | <prep_by{,2} nsubj
@@ -12,7 +12,7 @@
 - name: binding1b
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [lemma=/bind|associate|immunoprecipitate|ligate/ & tag=/^V/]
     theme1:BioChemicalEntity+ = <rcmod conj_and{,2} | nsubj /nn|conj_|cc/{,2} | <prep_by{,2} nsubj
@@ -21,7 +21,7 @@
 - name: binding1forms
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = /form(ed|s)?/ (a)? /complex(es)?|dimers?|heteromultimers?/
     theme1:BioChemicalEntity+ = nsubj /nn|conj_|cc/{,2}
@@ -30,7 +30,7 @@
 - name: binding2
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = binding (?! [lemma="site"])
     theme1:BioChemicalEntity+ = <prep_by nsubj /nn|conj_|cc/{,2}
@@ -39,7 +39,7 @@
 - name: binding3
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = /conj_(and|or)/{,2} /prep_(with|to)/? /prep_of/{1,2} /conj_(and|or)/{,2}
@@ -48,7 +48,7 @@
 - name: binding3wrong
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = /conj_(and|or)/{,2} (<agent)? /prep_of/{1,2}
@@ -57,7 +57,7 @@
 - name: binding5
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
       theme1:BioChemicalEntity* = poss
@@ -67,7 +67,7 @@
 - name: binding6
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = [lemma=/bind|associate|interact|immunoprecipitate|ligate/ & tag=/^V/]
       theme1:BioChemicalEntity+ = (<amod nn{,2} >prep_of? >appos?) | nsubj
@@ -76,7 +76,7 @@
 - name: binding7a
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
       theme1:BioChemicalEntity+ = nn conj_and?
@@ -85,7 +85,7 @@
 - name: binding7b
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
       theme1:BioChemicalEntity* = nn conj_and?
@@ -94,7 +94,7 @@
 - name: binding7c
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
       theme1:BioChemicalEntity+ = nn conj_and?
@@ -103,7 +103,7 @@
 - name: binding9
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = interaction
       theme1:BioChemicalEntity+ = nn | prep_of
@@ -112,7 +112,7 @@
 - name: binding10
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = [lemma=/bind|associate|interact|immunoprecipitate|ligate/ & tag=/^V/]
       theme1:BioChemicalEntity+ = <vmod <prep_with?
@@ -120,7 +120,7 @@
 - name: binding10b
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = [lemma=/bind|associate|interact|immunoprecipitate|ligate/ & tag=/^V/]
       theme1:BioChemicalEntity = <vmod
@@ -129,7 +129,7 @@
 - name: binding11
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = /cooperation|affinity|association|interaction/
       theme1:BioChemicalEntity+ = prep_between conj_and?
@@ -137,7 +137,7 @@
 - name: binding12
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = formation (?= of /complex|rings/) #dummy: prep_of [word=/complex|rings/]
       theme1:BioChemicalEntity+ = prep_of
@@ -145,7 +145,7 @@
 - name: binding13
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = /interact(s|ed)?/
       theme1:BioChemicalEntity+ = (nsubj <conj_and{,2} | >conj_and <ccomp >nsubjpass)
@@ -154,7 +154,7 @@
 - name: binding14
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
       trigger = /interactions?/
       theme1:BioChemicalEntity+ = <dobj <rcmod >dep >conj_and?
@@ -162,7 +162,7 @@
 - name: binding_16
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [word=/ligate(s|d)?/ & tag=/^V/]
     theme1:BioChemicalEntity+ = <vmod | nsubj
@@ -171,7 +171,7 @@
 - name: binding_17
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [lemma=/bind|associate|interact|immunoprecipitate|ligate/ & tag=/^V/]
     theme1:BioChemicalEntity+ = nsubjpass | <rcmod <appos?
@@ -180,7 +180,7 @@
 - name: binding_18
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = binding (?! [lemma="site"])
     theme1:BioChemicalEntity+ = <conj_and{,2} prep dep{1,2} (/prep_(to|with)/)?
@@ -189,7 +189,7 @@
 - name: binding_19
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] partner
     theme1:BioChemicalEntity+ = <appos
@@ -198,7 +198,7 @@
 - name: binding_20
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = rcmod{,2} prep_between
@@ -206,7 +206,7 @@
 - name: binding_21
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = oligomerization (?! [lemma="site"])
     theme1:BioChemicalEntity+ = <prep_through nsubj
@@ -214,7 +214,7 @@
 - name: binding_22
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [lemma=target & tag=/^N/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = <nn{,2} nn{,2} | nsubj
@@ -224,7 +224,7 @@
   example: "RBD of PI3KC2β binds nucleotide-free Ra"
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [lemma="bind" & tag=/^V/]
     theme1:BioChemicalEntity+ = nsubj /prep_of|nn|conj_|cc/{,2}
@@ -236,7 +236,7 @@
   example: "Even more than Ras, ASPP2 is common, as is their binding to Mek."
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = poss
@@ -246,7 +246,7 @@
   example: "IKKgamma appears capable of binding linear polyubiquitin."
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [word=binding & tag=VBG] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = <amod <prep_of <acomp{,2} nsubj
@@ -256,7 +256,7 @@
   example: "Only Smad3LC and Smad3C exhibited the ability to bind APC10."
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [word=bind & tag=VB]
     theme1:BioChemicalEntity+ = <vmod [lemma="ability"] <dobj [lemma=/exhibit|have|show|display/] nsubj
@@ -266,7 +266,7 @@
   example: "Only Smad3LC and Smad3C were able to bind APC10."
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = [word=bind & tag=VB]
     theme1:BioChemicalEntity+ = <xcomp [lemma="able"] nsubj
@@ -277,7 +277,7 @@
 - name: binding_token_1
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   type: token
   pattern: |
     (@theme1:BioChemicalEntity)
@@ -287,7 +287,7 @@
 #- name: binding_token_2
 #  label: Binding
 #  action: mkBinding
-#  priority: 5
+#  priority: ${ priority }
 #  type: token
 #  pattern: |
 #    (?<trigger> binding) to (@theme2:BioChemicalEntity)
@@ -295,7 +295,7 @@
 - name: binding_token_3
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   type: token
   pattern: |
     (@theme1:BioChemicalEntity)
@@ -306,7 +306,7 @@
 - name: binding_token_4
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   type: token
   pattern: |
     (?<trigger> binding) of (@theme1:BioChemicalEntity) (to|with) (@theme2:BioChemicalEntity)
@@ -314,7 +314,7 @@
 - name: binding_token_5
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   type: token
   pattern: |
     [tag=DT] @theme1:BioChemicalEntity and @theme2:BioChemicalEntity (?<trigger> complex)
@@ -322,7 +322,7 @@
 - name: binding_coexist
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   example: "To confirm whether XRCC1 and DNA-PK coexist in a common complex..."
   pattern: |
       trigger = [lemma=/coexist|present/] in [tag=/DT|JJ/]* [lemma=/complex|dimer|heterodimer/]
@@ -331,7 +331,7 @@
 - name: binding_oncebound
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   type: token
   example: "Once bound to the DSB, the DNA-PK holoenzyme facilitates the recruitment of MEK."
   pattern: |
@@ -340,7 +340,7 @@
 - name: binding_thatisbound
   label: Binding
   action: mkBinding
-  priority: 4
+  priority: ${ priority }
   example: "Src tyrosyl phosphorylates Ras that is GTP bound"
   pattern: |
     trigger = [word=bound & tag=/^VB(D|N)$/]
@@ -351,7 +351,7 @@
 - name: binding_complex_A_B
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   type: token
   pattern: |
     (?<trigger> [lemma=/^(complex|heterodimer)/]) @theme1:BioChemicalEntity and @theme2:BioChemicalEntity # TODO: add a better lookahead constraint.
@@ -361,7 +361,7 @@
 - name: binding_activity
   label: Binding
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = binding activity
     theme1:BioChemicalEntity+ = nn+
@@ -371,7 +371,7 @@
   label: Binding 
   example: "Complex formation between Gab1 and the protein tyrosine phosphatase Shp2 negatively regulates something."
   action: mkBinding
-  priority: 5
+  priority: ${ priority }
   pattern: |
     trigger = /(?i)complex/ formation
     theme1:BioChemicalEntity+ = prep_between

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/bind_events.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/bind_events.yml
@@ -4,7 +4,7 @@
 - name: binding1a
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [lemma=/bind|associate|immunoprecipitate|ligate/ & tag=/^V/ & !outgoing=/prep_(to|with)|dobj|acomp/]
     theme1:BioChemicalEntity+ = <rcmod conj_and{,2} | nsubj /nn|conj_|cc/{,2} | <prep_by{,2} nsubj
@@ -12,7 +12,7 @@
 - name: binding1b
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [lemma=/bind|associate|immunoprecipitate|ligate/ & tag=/^V/]
     theme1:BioChemicalEntity+ = <rcmod conj_and{,2} | nsubj /nn|conj_|cc/{,2} | <prep_by{,2} nsubj
@@ -21,7 +21,7 @@
 - name: binding1forms
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = /form(ed|s)?/ (a)? /complex(es)?|dimers?|heteromultimers?/
     theme1:BioChemicalEntity+ = nsubj /nn|conj_|cc/{,2}
@@ -30,7 +30,7 @@
 - name: binding2
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = binding (?! [lemma="site"])
     theme1:BioChemicalEntity+ = <prep_by nsubj /nn|conj_|cc/{,2}
@@ -39,7 +39,7 @@
 - name: binding3
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = /conj_(and|or)/{,2} /prep_(with|to)/? /prep_of/{1,2} /conj_(and|or)/{,2}
@@ -48,7 +48,7 @@
 - name: binding3wrong
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = /conj_(and|or)/{,2} (<agent)? /prep_of/{1,2}
@@ -57,7 +57,7 @@
 - name: binding5
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
       theme1:BioChemicalEntity* = poss
@@ -67,7 +67,7 @@
 - name: binding6
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = [lemma=/bind|associate|interact|immunoprecipitate|ligate/ & tag=/^V/]
       theme1:BioChemicalEntity+ = (<amod nn{,2} >prep_of? >appos?) | nsubj
@@ -76,7 +76,7 @@
 - name: binding7a
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
       theme1:BioChemicalEntity+ = nn conj_and?
@@ -85,7 +85,7 @@
 - name: binding7b
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
       theme1:BioChemicalEntity* = nn conj_and?
@@ -94,7 +94,7 @@
 - name: binding7c
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
       theme1:BioChemicalEntity+ = nn conj_and?
@@ -103,7 +103,7 @@
 - name: binding9
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = interaction
       theme1:BioChemicalEntity+ = nn | prep_of
@@ -112,7 +112,7 @@
 - name: binding10
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = [lemma=/bind|associate|interact|immunoprecipitate|ligate/ & tag=/^V/]
       theme1:BioChemicalEntity+ = <vmod <prep_with?
@@ -120,7 +120,7 @@
 - name: binding10b
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = [lemma=/bind|associate|interact|immunoprecipitate|ligate/ & tag=/^V/]
       theme1:BioChemicalEntity = <vmod
@@ -129,7 +129,7 @@
 - name: binding11
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = /cooperation|affinity|association|interaction/
       theme1:BioChemicalEntity+ = prep_between conj_and?
@@ -137,7 +137,7 @@
 - name: binding12
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = formation (?= of /complex|rings/) #dummy: prep_of [word=/complex|rings/]
       theme1:BioChemicalEntity+ = prep_of
@@ -145,7 +145,7 @@
 - name: binding13
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = /interact(s|ed)?/
       theme1:BioChemicalEntity+ = (nsubj <conj_and{,2} | >conj_and <ccomp >nsubjpass)
@@ -154,7 +154,7 @@
 - name: binding14
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
       trigger = /interactions?/
       theme1:BioChemicalEntity+ = <dobj <rcmod >dep >conj_and?
@@ -162,7 +162,7 @@
 - name: binding_16
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [word=/ligate(s|d)?/ & tag=/^V/]
     theme1:BioChemicalEntity+ = <vmod | nsubj
@@ -171,7 +171,7 @@
 - name: binding_17
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [lemma=/bind|associate|interact|immunoprecipitate|ligate/ & tag=/^V/]
     theme1:BioChemicalEntity+ = nsubjpass | <rcmod <appos?
@@ -180,7 +180,7 @@
 - name: binding_18
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = binding (?! [lemma="site"])
     theme1:BioChemicalEntity+ = <conj_and{,2} prep dep{1,2} (/prep_(to|with)/)?
@@ -189,7 +189,7 @@
 - name: binding_19
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] partner
     theme1:BioChemicalEntity+ = <appos
@@ -198,7 +198,7 @@
 - name: binding_20
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = rcmod{,2} prep_between
@@ -206,7 +206,7 @@
 - name: binding_21
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = oligomerization (?! [lemma="site"])
     theme1:BioChemicalEntity+ = <prep_through nsubj
@@ -214,7 +214,7 @@
 - name: binding_22
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [lemma=target & tag=/^N/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = <nn{,2} nn{,2} | nsubj
@@ -224,7 +224,7 @@
   example: "RBD of PI3KC2β binds nucleotide-free Ra"
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [lemma="bind" & tag=/^V/]
     theme1:BioChemicalEntity+ = nsubj /prep_of|nn|conj_|cc/{,2}
@@ -236,7 +236,7 @@
   example: "Even more than Ras, ASPP2 is common, as is their binding to Mek."
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = poss
@@ -246,7 +246,7 @@
   example: "IKKgamma appears capable of binding linear polyubiquitin."
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [word=binding & tag=VBG] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = <amod <prep_of <acomp{,2} nsubj
@@ -256,7 +256,7 @@
   example: "Only Smad3LC and Smad3C exhibited the ability to bind APC10."
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [word=bind & tag=VB]
     theme1:BioChemicalEntity+ = <vmod [lemma="ability"] <dobj [lemma=/exhibit|have|show|display/] nsubj
@@ -266,7 +266,7 @@
   example: "Only Smad3LC and Smad3C were able to bind APC10."
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = [word=bind & tag=VB]
     theme1:BioChemicalEntity+ = <xcomp [lemma="able"] nsubj
@@ -277,7 +277,7 @@
 - name: binding_token_1
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   type: token
   pattern: |
     (@theme1:BioChemicalEntity)
@@ -287,7 +287,7 @@
 #- name: binding_token_2
 #  label: Binding
 #  action: mkBinding
-#  priority: ${ priority }
+#  priority: 5
 #  type: token
 #  pattern: |
 #    (?<trigger> binding) to (@theme2:BioChemicalEntity)
@@ -295,7 +295,7 @@
 - name: binding_token_3
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   type: token
   pattern: |
     (@theme1:BioChemicalEntity)
@@ -306,7 +306,7 @@
 - name: binding_token_4
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   type: token
   pattern: |
     (?<trigger> binding) of (@theme1:BioChemicalEntity) (to|with) (@theme2:BioChemicalEntity)
@@ -314,7 +314,7 @@
 - name: binding_token_5
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   type: token
   pattern: |
     [tag=DT] @theme1:BioChemicalEntity and @theme2:BioChemicalEntity (?<trigger> complex)
@@ -322,7 +322,7 @@
 - name: binding_coexist
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   example: "To confirm whether XRCC1 and DNA-PK coexist in a common complex..."
   pattern: |
       trigger = [lemma=/coexist|present/] in [tag=/DT|JJ/]* [lemma=/complex|dimer|heterodimer/]
@@ -331,7 +331,7 @@
 - name: binding_oncebound
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   type: token
   example: "Once bound to the DSB, the DNA-PK holoenzyme facilitates the recruitment of MEK."
   pattern: |
@@ -340,7 +340,7 @@
 - name: binding_thatisbound
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 4
   example: "Src tyrosyl phosphorylates Ras that is GTP bound"
   pattern: |
     trigger = [word=bound & tag=/^VB(D|N)$/]
@@ -351,7 +351,7 @@
 - name: binding_complex_A_B
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   type: token
   pattern: |
     (?<trigger> [lemma=/^(complex|heterodimer)/]) @theme1:BioChemicalEntity and @theme2:BioChemicalEntity # TODO: add a better lookahead constraint.
@@ -361,7 +361,7 @@
 - name: binding_activity
   label: Binding
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = binding activity
     theme1:BioChemicalEntity+ = nn+
@@ -371,7 +371,7 @@
   label: Binding 
   example: "Complex formation between Gab1 and the protein tyrosine phosphatase Shp2 negatively regulates something."
   action: mkBinding
-  priority: ${ priority }
+  priority: 5
   pattern: |
     trigger = /(?i)complex/ formation
     theme1:BioChemicalEntity+ = prep_between

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/hydrolysis_events.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/hydrolysis_events.yml
@@ -6,7 +6,7 @@
 
 - name: hydrolysis_1
   label: Hydrolysis
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "We compared the rate of GTP hydrolysis for Ras and mUbRas in the presence of the catalytic domains of two GAPs."
   pattern: |
@@ -17,7 +17,7 @@
 
 - name: hydrolysis_2
   label: Hydrolysis
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "Here we show that monoubiquitination decreases the sensitivity of Ras to GAP-mediated hydrolysis"
   pattern: |
@@ -27,7 +27,7 @@
 
 - name: hydrolysis_2wrong
   label: Hydrolysis
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "Here we show that monoubiquitination decreases the sensitivity of Ras to GAP-mediated hydrolysis"
   pattern: |
@@ -38,7 +38,7 @@
 
 - name: hydrolysis_3
   label: Hydrolysis
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "No increase in the rate of GTP hydrolysis was observed for mUbRas"
   pattern: |
@@ -48,7 +48,7 @@
 
 - name: hydrolysis_4
   label: Hydrolysis
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "RasPDZ2UL retains intrinsic GTP hydrolysis activity"
   pattern: |
@@ -58,7 +58,7 @@
 
 - name: hydrolysis_token_1
   label: Hydrolysis
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "We measured the rate of GAP-mediated GTP hydrolysis"
   type: token
@@ -68,7 +68,7 @@
 
 - name: hydrolysis_token_2
   label: Hydrolysis
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "Renin is an enzyme that hydrolyzes Ras-GTP."
   type: token
@@ -78,7 +78,7 @@
 
 - name: hydrolysis_decl1
   label: Hydrolysis
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "RasGAP hydrolyzes GTP to GDP"
   pattern: |
@@ -88,7 +88,7 @@
 
 - name: hydrolysis_pass1
   label: Hydrolysis
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "Ras-GDP is hydrolyzed by 26S proteasome without ubiquitination"
   pattern: |
@@ -98,7 +98,7 @@
 
 - name: hydrolysis_subjnom1
   label: Hydrolysis
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "MEK hydrolysis of Ras-GDP increased."
   pattern: |

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/hydrolysis_events.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/hydrolysis_events.yml
@@ -6,7 +6,7 @@
 
 - name: hydrolysis_1
   label: Hydrolysis
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "We compared the rate of GTP hydrolysis for Ras and mUbRas in the presence of the catalytic domains of two GAPs."
   pattern: |
@@ -17,7 +17,7 @@
 
 - name: hydrolysis_2
   label: Hydrolysis
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "Here we show that monoubiquitination decreases the sensitivity of Ras to GAP-mediated hydrolysis"
   pattern: |
@@ -27,7 +27,7 @@
 
 - name: hydrolysis_2wrong
   label: Hydrolysis
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "Here we show that monoubiquitination decreases the sensitivity of Ras to GAP-mediated hydrolysis"
   pattern: |
@@ -38,7 +38,7 @@
 
 - name: hydrolysis_3
   label: Hydrolysis
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "No increase in the rate of GTP hydrolysis was observed for mUbRas"
   pattern: |
@@ -48,7 +48,7 @@
 
 - name: hydrolysis_4
   label: Hydrolysis
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "RasPDZ2UL retains intrinsic GTP hydrolysis activity"
   pattern: |
@@ -58,7 +58,7 @@
 
 - name: hydrolysis_token_1
   label: Hydrolysis
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "We measured the rate of GAP-mediated GTP hydrolysis"
   type: token
@@ -68,7 +68,7 @@
 
 - name: hydrolysis_token_2
   label: Hydrolysis
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "Renin is an enzyme that hydrolyzes Ras-GTP."
   type: token
@@ -78,7 +78,7 @@
 
 - name: hydrolysis_decl1
   label: Hydrolysis
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "RasGAP hydrolyzes GTP to GDP"
   pattern: |
@@ -88,7 +88,7 @@
 
 - name: hydrolysis_pass1
   label: Hydrolysis
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "Ras-GDP is hydrolyzed by 26S proteasome without ubiquitination"
   pattern: |
@@ -98,7 +98,7 @@
 
 - name: hydrolysis_subjnom1
   label: Hydrolysis
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "MEK hydrolysis of Ras-GDP increased."
   pattern: |

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -1,7 +1,6 @@
 # SimpleEvent tempate covers: Phosphorylation, Hydroxylation, Ubiquitination?, Ribosylation, Farnesylation, Acetylation, Glycosylation, Methylation, Sumoylation
 
 ######## variables (examples) ###################
-# priority (example) = 5
 # verbalTriggerLemma (example) = phosphorylate
 # nominalTriggerLemma (example) = phosphorylation
 # labels (example) = Phosphorylation
@@ -11,7 +10,7 @@
 
 
 - name: ${ eventName }_syntax_1_verb
-  priority: ${ priority }
+  priority: 5
   example: "We further showed, in a combined enzymatic assay, that human deoxycytidine kinase and UMP-CMP kinase together ${ verbalTriggerLemma }d araC, dFdC, and 2',3'-dideoxycytidine to their diphosphate forms."
   label: ${ label }
   action: ${ actionFlow }
@@ -23,7 +22,7 @@
 
 
 - name: ${ eventName }_syntax_2_verb
-  priority: ${ priority }
+  priority: 5
   example: "Human deoxycytidine kinase is ${ verbalTriggerLemma }d by ASPP2 on serine 128. The BRCT1 domain of XRCC1 is ${ verbalTriggerLemma }d in vitro by DNA-PK. ... reveals that XRCC1 is ${ verbalTriggerLemma }d by the co-immunoprecipitated DNA-PK"
   label: ${ label }
   action: ${ actionFlow }
@@ -35,7 +34,7 @@
 
 
 - name: ${ eventName }_syntax_3_verb
-  priority: ${ priority }
+  priority: 5
   example: ""
   label: ${ label }
   action: ${ actionFlow }
@@ -47,7 +46,7 @@
 
 
 - name: ${ eventName }_syntax_4_verb
-  priority: ${ priority }
+  priority: 5
   example: "Hence ASPP2 can be ${ verbalTriggerLemma }d at serine 827 by MAPK1 in vitro."
   label: ${ label }
   action: ${ actionFlow }
@@ -59,7 +58,7 @@
 
 
 - name: ${ eventName }_syntax_5_verb
-  priority: ${ priority }
+  priority: 5
   example: "IKK contains two catalytic subunits, IKKalpha and IKKbeta, both of which are able to correctly ${ verbalTriggerLemma } IkappaB.  Its many abnormal phenotypes can be rescued via overexpressing Ras, an XXX that specifically ${ verbalTriggerLemma }s ASPP2."
   label: ${ label }
   action: ${ actionFlow }
@@ -71,7 +70,7 @@
 
 
 - name: ${ eventName }_syntax_6_verb
-  priority: ${ priority }
+  priority: 5
   example: "We measured transcription activation in the presence of ASPP2, which is phosphorylated by Ras."
   label: ${ label }
   action: ${ actionFlow }
@@ -83,7 +82,7 @@
 
 
 - name: ${ eventName }_syntax_verb_underwent
-  priority: ${ priority }
+  priority: 5
   example: "We found that endogenous K-Ras and H-Ras underwent mono-ubiquitination in HEK293T cells."
   label: ${ label }
   action: ${ actionFlow }
@@ -95,7 +94,7 @@
 
 
 - name: ${ eventName }_syntax_1_noun
-  priority: ${ priority }
+  priority: 5
   example: "... which includes ${ nominalTriggerLemma } of PKC isozymes by phosphoinositide-dependent protein kinases.  Ras ${ nominalTriggerLemma } of ASPP2 increased."
   label: ${ label }
   action: ${ actionFlow }
@@ -107,7 +106,7 @@
 
 
 - name: ${ eventName }_syntax_2_noun
-  priority: ${ priority }
+  priority: 5
   example: "Overexpressed PRAS40 suppressed the ${ nominalTriggerLemma } of S6K1 and 4E-BP1 at their rapamycin-sensitive ${ nominalTriggerLemma } sites, and reciprocally, overexpression of S6K1 or 4E-BP1 suppressed ${ nominalTriggerLemma } of PRAS40 (Ser(183)) and its binding to raptor."
   label: ${ label }
   action: ${ actionFlow }
@@ -119,7 +118,7 @@
 
 
 - name: ${ eventName }_syntax_3_noun
-  priority: ${ priority }
+  priority: 5
   example: "ERK- mediated serine ${ nominalTriggerLemma } of the GAB1 adaptor has been shown to ..."
   label: ${ label }
   action: ${ actionFlow }
@@ -131,7 +130,7 @@
 
 # Site pattern motivated by: "In contrast, the EGFR T669A mutant increased both basal EGFR and ERBB3 tyrosine phosphorylation that was not augmented by MEK inhibition."
 - name: ${ eventName }_syntax_4_noun
-  priority: ${ priority }
+  priority: 5
   example: " ... mediated by inter-Rad53 ${ nominalTriggerLemma }.  ASPP1 and ASPP2 have two conserved putative MAPK2 ${ nominalTriggerLemma } sites in their C-terminus."
   label: ${ label }
   action: ${ actionFlow }
@@ -142,7 +141,7 @@
 
 
 - name: ${ eventName }_syntax_5_noun
-  priority: ${ priority }
+  priority: 5
   example: "Interestingly, we observed two conserved putative MAPK ${ nominalTriggerLemma } sites in ASPP1 and ASPP2."
   label: ${ label }
   action: ${ actionFlow }
@@ -153,7 +152,7 @@
 
 
 - name: ${ eventName }_syntax_6_noun
-  priority: ${ priority }
+  priority: 5
   example: "... the transcriptional cofactor beta-catenin is destabilized via ${ nominalTriggerLemma } of ASPP1 by protein kinase GSK3beta in complex with Axin family members"
   label: ${ label }
   action: ${ actionFlow }
@@ -165,7 +164,7 @@
 
 
 - name: ${ eventName }_syntax_7_noun
-  priority: ${ priority }
+  priority: 5
   example: ""
   label: ${ label }
   action: ${ actionFlow }
@@ -174,7 +173,7 @@
     theme:BioChemicalEntity = < nsubj dobj prep_of appos? /nn|cc|conj/{,2}
 
 - name: ${ eventName }_syntax_8_noun
-  priority: ${ priority }
+  priority: 5
   example: "RAS plays no role in the ${ nominalTriggerLemma } of Mek."
   label: ${ label }
   action: ${ actionFlow }
@@ -189,7 +188,7 @@
 ##################
 
 - name: ${ eventName }_token_1_noun
-  priority: ${ priority }
+  priority: 5
   example: " ... which blocks an inhibitory threonine ${ nominalTriggerLemma } on the JM domains of EGFR and HER2"
   type: token
   label: ${ label }
@@ -200,7 +199,7 @@
 
 # verbose, but nec. to handle coordination
 - name: ${ eventName }_token_2_noun
-  priority: ${ priority }
+  priority: 5
   example: " ... which blocks an inhibitory threonine ${ nominalTriggerLemma } on the JM domains of EGFR and HER2"
   type: token
   label: ${ label }
@@ -210,7 +209,7 @@
 
 
 - name: ${ eventName }_token_3_noun
-  priority: ${ priority }
+  priority: 5
   example: " ... , thereby increasing ERBB3 ${ nominalTriggerLemma }."
   type: token
   label: ${ label }
@@ -221,7 +220,7 @@
 
 # relies on EventSite modifications
 - name: ${ eventName }_token_4_noun
-  priority: ${ priority }
+  priority: 5
   example: "Experiments revealed ${ nominalTriggerLemma } at Lys residues 104 and 147 of K-Ras."
   type: token
   label: ${ label }
@@ -232,7 +231,7 @@
 
 # FIXME wait until the thread bundle bug is fixed
 - name: ${ eventName }_token_5_noun
-  priority: ${ priority }
+  priority: 5
   example: "We hypothesized that MEK inhibition activates AKT by inhibiting ERK activity, which blocks an inhibitory threonine ${ nominalTriggerLemma } on the JM domains of EGFR and HER2, thereby increasing ERBB3 phosphorylation."
   type: token
   label: ${ label }
@@ -242,7 +241,7 @@
 
 # FIXME the additional pattern will go away when the odin bug related to thread bundles is truly fixed
 - name: ${ eventName }_token_6_noun
-  priority: ${ priority }
+  priority: 5
   example: "We hypothesized that MEK inhibition activates AKT by inhibiting ERK activity, which blocks an inhibitory threonine ${ nominalTriggerLemma } on the JM domains of EGFR and HER2, thereby increasing ERBB3 phosphorylation."
   type: token
   label: ${ label }
@@ -252,7 +251,7 @@
 
 # effects of patterns
 - name: ${ eventName }_token_7_noun
-  priority: ${ priority }
+  priority: 5
   example: "The effects of ${ nominalTriggerLemma } on Ras are not isoform-specific."
   type: token
   label: ${ label }
@@ -262,7 +261,7 @@
 
 # too specific?
 - name: ${ eventName }_token_8a_noun
-  priority: ${ priority }
+  priority: 5
   example: "ERK(K156/H204) ${ nominalTriggerLemma } (Fig. 2)."
   type: token
   label: ${ label }
@@ -273,7 +272,7 @@
 
 # too specific?
 - name: ${ eventName }_token_8b_noun
-  priority: ${ priority }
+  priority: 5
   example: "ERK(K156M/H204M) ${ nominalTriggerLemma } (Fig. 2)."
   type: token
   label: ${ label }
@@ -283,7 +282,7 @@
 
 
 - name: ${ eventName }_token_4_verb
-  priority: ${ priority }
+  priority: 5
   example: "Under the same conditions, ASPP2 (693-1128) fragment ${ verbalTriggerLemma }d by p38 SAPK had very low levels of incorporated 32P."
   type: token
   label: ${ label }
@@ -293,7 +292,7 @@
 
 
 - name: ${ eventName }_token_5_verb
-  priority: ${ priority }
+  priority: 5
   example: ""
   type: token
   label: ${ label }
@@ -307,7 +306,7 @@
 
 # relies on EventSite modifications
 - name: ${ eventName }_token_7_verb
-  priority: ${ priority }
+  priority: 5
   example: "JAK3 ${ verbalTriggerLemma }s three HuR residues (Y63, Y68, Y200)"
   type: token
   label: ${ label }

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -1,6 +1,7 @@
 # SimpleEvent tempate covers: Phosphorylation, Hydroxylation, Ubiquitination?, Ribosylation, Farnesylation, Acetylation, Glycosylation, Methylation, Sumoylation
 
 ######## variables (examples) ###################
+# priority (example) = 5
 # verbalTriggerLemma (example) = phosphorylate
 # nominalTriggerLemma (example) = phosphorylation
 # labels (example) = Phosphorylation
@@ -10,7 +11,7 @@
 
 
 - name: ${ eventName }_syntax_1_verb
-  priority: 5
+  priority: ${ priority }
   example: "We further showed, in a combined enzymatic assay, that human deoxycytidine kinase and UMP-CMP kinase together ${ verbalTriggerLemma }d araC, dFdC, and 2',3'-dideoxycytidine to their diphosphate forms."
   label: ${ label }
   action: ${ actionFlow }
@@ -22,7 +23,7 @@
 
 
 - name: ${ eventName }_syntax_2_verb
-  priority: 5
+  priority: ${ priority }
   example: "Human deoxycytidine kinase is ${ verbalTriggerLemma }d by ASPP2 on serine 128. The BRCT1 domain of XRCC1 is ${ verbalTriggerLemma }d in vitro by DNA-PK. ... reveals that XRCC1 is ${ verbalTriggerLemma }d by the co-immunoprecipitated DNA-PK"
   label: ${ label }
   action: ${ actionFlow }
@@ -34,7 +35,7 @@
 
 
 - name: ${ eventName }_syntax_3_verb
-  priority: 5
+  priority: ${ priority }
   example: ""
   label: ${ label }
   action: ${ actionFlow }
@@ -46,7 +47,7 @@
 
 
 - name: ${ eventName }_syntax_4_verb
-  priority: 5
+  priority: ${ priority }
   example: "Hence ASPP2 can be ${ verbalTriggerLemma }d at serine 827 by MAPK1 in vitro."
   label: ${ label }
   action: ${ actionFlow }
@@ -58,7 +59,7 @@
 
 
 - name: ${ eventName }_syntax_5_verb
-  priority: 5
+  priority: ${ priority }
   example: "IKK contains two catalytic subunits, IKKalpha and IKKbeta, both of which are able to correctly ${ verbalTriggerLemma } IkappaB.  Its many abnormal phenotypes can be rescued via overexpressing Ras, an XXX that specifically ${ verbalTriggerLemma }s ASPP2."
   label: ${ label }
   action: ${ actionFlow }
@@ -70,7 +71,7 @@
 
 
 - name: ${ eventName }_syntax_6_verb
-  priority: 5
+  priority: ${ priority }
   example: "We measured transcription activation in the presence of ASPP2, which is phosphorylated by Ras."
   label: ${ label }
   action: ${ actionFlow }
@@ -82,7 +83,7 @@
 
 
 - name: ${ eventName }_syntax_verb_underwent
-  priority: 5
+  priority: ${ priority }
   example: "We found that endogenous K-Ras and H-Ras underwent mono-ubiquitination in HEK293T cells."
   label: ${ label }
   action: ${ actionFlow }
@@ -94,7 +95,7 @@
 
 
 - name: ${ eventName }_syntax_1_noun
-  priority: 5
+  priority: ${ priority }
   example: "... which includes ${ nominalTriggerLemma } of PKC isozymes by phosphoinositide-dependent protein kinases.  Ras ${ nominalTriggerLemma } of ASPP2 increased."
   label: ${ label }
   action: ${ actionFlow }
@@ -106,7 +107,7 @@
 
 
 - name: ${ eventName }_syntax_2_noun
-  priority: 5
+  priority: ${ priority }
   example: "Overexpressed PRAS40 suppressed the ${ nominalTriggerLemma } of S6K1 and 4E-BP1 at their rapamycin-sensitive ${ nominalTriggerLemma } sites, and reciprocally, overexpression of S6K1 or 4E-BP1 suppressed ${ nominalTriggerLemma } of PRAS40 (Ser(183)) and its binding to raptor."
   label: ${ label }
   action: ${ actionFlow }
@@ -118,7 +119,7 @@
 
 
 - name: ${ eventName }_syntax_3_noun
-  priority: 5
+  priority: ${ priority }
   example: "ERK- mediated serine ${ nominalTriggerLemma } of the GAB1 adaptor has been shown to ..."
   label: ${ label }
   action: ${ actionFlow }
@@ -130,7 +131,7 @@
 
 # Site pattern motivated by: "In contrast, the EGFR T669A mutant increased both basal EGFR and ERBB3 tyrosine phosphorylation that was not augmented by MEK inhibition."
 - name: ${ eventName }_syntax_4_noun
-  priority: 5
+  priority: ${ priority }
   example: " ... mediated by inter-Rad53 ${ nominalTriggerLemma }.  ASPP1 and ASPP2 have two conserved putative MAPK2 ${ nominalTriggerLemma } sites in their C-terminus."
   label: ${ label }
   action: ${ actionFlow }
@@ -141,7 +142,7 @@
 
 
 - name: ${ eventName }_syntax_5_noun
-  priority: 5
+  priority: ${ priority }
   example: "Interestingly, we observed two conserved putative MAPK ${ nominalTriggerLemma } sites in ASPP1 and ASPP2."
   label: ${ label }
   action: ${ actionFlow }
@@ -152,7 +153,7 @@
 
 
 - name: ${ eventName }_syntax_6_noun
-  priority: 5
+  priority: ${ priority }
   example: "... the transcriptional cofactor beta-catenin is destabilized via ${ nominalTriggerLemma } of ASPP1 by protein kinase GSK3beta in complex with Axin family members"
   label: ${ label }
   action: ${ actionFlow }
@@ -164,7 +165,7 @@
 
 
 - name: ${ eventName }_syntax_7_noun
-  priority: 5
+  priority: ${ priority }
   example: ""
   label: ${ label }
   action: ${ actionFlow }
@@ -173,7 +174,7 @@
     theme:BioChemicalEntity = < nsubj dobj prep_of appos? /nn|cc|conj/{,2}
 
 - name: ${ eventName }_syntax_8_noun
-  priority: 5
+  priority: ${ priority }
   example: "RAS plays no role in the ${ nominalTriggerLemma } of Mek."
   label: ${ label }
   action: ${ actionFlow }
@@ -188,7 +189,7 @@
 ##################
 
 - name: ${ eventName }_token_1_noun
-  priority: 5
+  priority: ${ priority }
   example: " ... which blocks an inhibitory threonine ${ nominalTriggerLemma } on the JM domains of EGFR and HER2"
   type: token
   label: ${ label }
@@ -199,7 +200,7 @@
 
 # verbose, but nec. to handle coordination
 - name: ${ eventName }_token_2_noun
-  priority: 5
+  priority: ${ priority }
   example: " ... which blocks an inhibitory threonine ${ nominalTriggerLemma } on the JM domains of EGFR and HER2"
   type: token
   label: ${ label }
@@ -209,7 +210,7 @@
 
 
 - name: ${ eventName }_token_3_noun
-  priority: 5
+  priority: ${ priority }
   example: " ... , thereby increasing ERBB3 ${ nominalTriggerLemma }."
   type: token
   label: ${ label }
@@ -220,7 +221,7 @@
 
 # relies on EventSite modifications
 - name: ${ eventName }_token_4_noun
-  priority: 5
+  priority: ${ priority }
   example: "Experiments revealed ${ nominalTriggerLemma } at Lys residues 104 and 147 of K-Ras."
   type: token
   label: ${ label }
@@ -231,7 +232,7 @@
 
 # FIXME wait until the thread bundle bug is fixed
 - name: ${ eventName }_token_5_noun
-  priority: 5
+  priority: ${ priority }
   example: "We hypothesized that MEK inhibition activates AKT by inhibiting ERK activity, which blocks an inhibitory threonine ${ nominalTriggerLemma } on the JM domains of EGFR and HER2, thereby increasing ERBB3 phosphorylation."
   type: token
   label: ${ label }
@@ -241,7 +242,7 @@
 
 # FIXME the additional pattern will go away when the odin bug related to thread bundles is truly fixed
 - name: ${ eventName }_token_6_noun
-  priority: 5
+  priority: ${ priority }
   example: "We hypothesized that MEK inhibition activates AKT by inhibiting ERK activity, which blocks an inhibitory threonine ${ nominalTriggerLemma } on the JM domains of EGFR and HER2, thereby increasing ERBB3 phosphorylation."
   type: token
   label: ${ label }
@@ -251,7 +252,7 @@
 
 # effects of patterns
 - name: ${ eventName }_token_7_noun
-  priority: 5
+  priority: ${ priority }
   example: "The effects of ${ nominalTriggerLemma } on Ras are not isoform-specific."
   type: token
   label: ${ label }
@@ -261,7 +262,7 @@
 
 # too specific?
 - name: ${ eventName }_token_8a_noun
-  priority: 5
+  priority: ${ priority }
   example: "ERK(K156/H204) ${ nominalTriggerLemma } (Fig. 2)."
   type: token
   label: ${ label }
@@ -272,7 +273,7 @@
 
 # too specific?
 - name: ${ eventName }_token_8b_noun
-  priority: 5
+  priority: ${ priority }
   example: "ERK(K156M/H204M) ${ nominalTriggerLemma } (Fig. 2)."
   type: token
   label: ${ label }
@@ -282,7 +283,7 @@
 
 
 - name: ${ eventName }_token_4_verb
-  priority: 5
+  priority: ${ priority }
   example: "Under the same conditions, ASPP2 (693-1128) fragment ${ verbalTriggerLemma }d by p38 SAPK had very low levels of incorporated 32P."
   type: token
   label: ${ label }
@@ -292,7 +293,7 @@
 
 
 - name: ${ eventName }_token_5_verb
-  priority: 5
+  priority: ${ priority }
   example: ""
   type: token
   label: ${ label }
@@ -306,7 +307,7 @@
 
 # relies on EventSite modifications
 - name: ${ eventName }_token_7_verb
-  priority: 5
+  priority: ${ priority }
   example: "JAK3 ${ verbalTriggerLemma }s three HuR residues (Y63, Y68, Y200)"
   type: token
   label: ${ label }

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/translocation_events.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/translocation_events.yml
@@ -4,7 +4,7 @@
 
 
 - name: translocation_1a_noun
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "We show here that ASPP2 is phosphorylated by the RAS/Raf/MAPK pathway and that this phosphorylation leads to its increased translocation from the cytosol/nucleus and increased binding to p53"
   label: Translocation
@@ -16,7 +16,7 @@
 
 
 - name: translocation_1b_noun
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "We show here that ASPP2 is phosphorylated by the RAS/Raf/MAPK pathway and that this phosphorylation leads to its increased translocation to the cytosol/nucleus and increased binding to p53"
   label: Translocation
@@ -28,7 +28,7 @@
 
 
 - name: translocation_2a_verb_apposition
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "ASPP2, a protein which translocates Pde2 to the nucleus, is subsequently phosphorylated."
   label: Translocation
@@ -41,7 +41,7 @@
 
 
 - name: translocation_2b_verb_apposition
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "ASPP2, a protein which releases Pde2 from the membrane, is subsequently phosphorylated."
   label: Translocation
@@ -54,7 +54,7 @@
 
 
 - name: translocation_3a_verb_passive
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "ASPP2, a protein which is translocated from the membrane by ASPP1, is subsequently phosphorylated"
   label: Translocation
@@ -67,7 +67,7 @@
 
 
 - name: translocation_3b_verb_passive
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "ASPP2, a protein which is translocated to the nucleus by ASPP1, is subsequently phosphorylated"
   label: Translocation
@@ -80,7 +80,7 @@
 
 
 - name: translocation_4a_noun_with_cause
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "Recruitment of p53 to the plasma membrane increases with phosphorylation"
   label: Translocation
@@ -93,7 +93,7 @@
 
 
 - name: translocation_4b_noun_with_cause
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "Release of p53 from the cytosol increases with phosphorylation"
   label: Translocation
@@ -106,7 +106,7 @@
 
 
 - name: translocation_5_verb_infinitive_with_cause
-  priority: ${ priority }
+  priority: 5
   example: "Phosphorylation leads the plasma membrane to release p53 to the cytosol."
   action: mkBioMention
   label: Translocation
@@ -118,7 +118,7 @@
 
 
 - name: translocation_6_verb_active
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "After the introduction of ASPP1, the plasma membrane releases p53 to the cytosol."
   label: Translocation
@@ -130,7 +130,7 @@
 
 
 - name: translocation_7a_noun_no_cause
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "ASPP1 is common, and its recruitment to the plasma membrane increases with its phosphorylation"
   label: Translocation
@@ -142,7 +142,7 @@
 
 
 - name: translocation_7b_noun_no_cause
-  priority: ${ priority }
+  priority: 5
   action: mkBioMention
   example: "ASPP1 is common, and its release from the cytosol increases with its phosphorylation"
   label: Translocation

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/translocation_events.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/translocation_events.yml
@@ -4,7 +4,7 @@
 
 
 - name: translocation_1a_noun
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "We show here that ASPP2 is phosphorylated by the RAS/Raf/MAPK pathway and that this phosphorylation leads to its increased translocation from the cytosol/nucleus and increased binding to p53"
   label: Translocation
@@ -16,7 +16,7 @@
 
 
 - name: translocation_1b_noun
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "We show here that ASPP2 is phosphorylated by the RAS/Raf/MAPK pathway and that this phosphorylation leads to its increased translocation to the cytosol/nucleus and increased binding to p53"
   label: Translocation
@@ -28,7 +28,7 @@
 
 
 - name: translocation_2a_verb_apposition
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "ASPP2, a protein which translocates Pde2 to the nucleus, is subsequently phosphorylated."
   label: Translocation
@@ -41,7 +41,7 @@
 
 
 - name: translocation_2b_verb_apposition
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "ASPP2, a protein which releases Pde2 from the membrane, is subsequently phosphorylated."
   label: Translocation
@@ -54,7 +54,7 @@
 
 
 - name: translocation_3a_verb_passive
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "ASPP2, a protein which is translocated from the membrane by ASPP1, is subsequently phosphorylated"
   label: Translocation
@@ -67,7 +67,7 @@
 
 
 - name: translocation_3b_verb_passive
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "ASPP2, a protein which is translocated to the nucleus by ASPP1, is subsequently phosphorylated"
   label: Translocation
@@ -80,7 +80,7 @@
 
 
 - name: translocation_4a_noun_with_cause
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "Recruitment of p53 to the plasma membrane increases with phosphorylation"
   label: Translocation
@@ -93,7 +93,7 @@
 
 
 - name: translocation_4b_noun_with_cause
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "Release of p53 from the cytosol increases with phosphorylation"
   label: Translocation
@@ -106,7 +106,7 @@
 
 
 - name: translocation_5_verb_infinitive_with_cause
-  priority: 5
+  priority: ${ priority }
   example: "Phosphorylation leads the plasma membrane to release p53 to the cytosol."
   action: mkBioMention
   label: Translocation
@@ -118,7 +118,7 @@
 
 
 - name: translocation_6_verb_active
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "After the introduction of ASPP1, the plasma membrane releases p53 to the cytosol."
   label: Translocation
@@ -130,7 +130,7 @@
 
 
 - name: translocation_7a_noun_no_cause
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "ASPP1 is common, and its recruitment to the plasma membrane increases with its phosphorylation"
   label: Translocation
@@ -142,7 +142,7 @@
 
 
 - name: translocation_7b_noun_no_cause
-  priority: 5
+  priority: ${ priority }
   action: mkBioMention
   example: "ASPP1 is common, and its release from the cytosol increases with its phosphorylation"
   label: Translocation

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events_master.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events_master.yml
@@ -7,17 +7,26 @@ vars:
 
 rules:
   - import: edu/arizona/sista/reach/biogrammar/events/bind_events.yml
+    vars:
+      priority: "5"
+
   - import: edu/arizona/sista/reach/biogrammar/events/hydrolysis_events.yml
+    vars:
+      priority: "5"
+
   - import: edu/arizona/sista/reach/biogrammar/events/translocation_events.yml
+    vars:
+      priority: "5"
 
   # Phosphorylations
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
     vars:
-      eventName: "Phosphorylation"
-      actionFlow: "mkBioMention"
-      label: "Phosphorylation"
-      verbalTriggerLemma: "phosphorylate"
-      nominalTriggerLemma: "phosphorylation"
+     eventName: "Phosphorylation"
+     actionFlow: "mkBioMention"
+     label: "Phosphorylation"
+     verbalTriggerLemma: "phosphorylate"
+     nominalTriggerLemma: "phosphorylation"
+     priority: "5"
 
   # Ubiquitination
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -27,6 +36,7 @@ rules:
       label: "Ubiquitination"
       verbalTriggerLemma: "ubiquitinate"
       nominalTriggerLemma: "ubiquitination"
+      priority: "5"
 
   # Hydroxylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -36,6 +46,7 @@ rules:
       label: "Hydroxylation"
       verbalTriggerLemma: "hydroxylate"
       nominalTriggerLemma: "hydroxylation"
+      priority: "5"
 
   # Sumoylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -45,6 +56,7 @@ rules:
       label: "Sumoylation"
       verbalTriggerLemma: "sumoylate"
       nominalTriggerLemma: "sumoylation"
+      priority: "5"
 
   # Glycosylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -54,6 +66,7 @@ rules:
       label: "Glycosylation"
       verbalTriggerLemma: "glycosylate"
       nominalTriggerLemma: "glycosylation"
+      priority: "5"
 
   # Acetylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -63,6 +76,7 @@ rules:
       label: "Acetylation"
       verbalTriggerLemma: "acetylate"
       nominalTriggerLemma: "acetylation"
+      priority: "5"
 
   # Farnesylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -72,6 +86,7 @@ rules:
       label: "Farnesylation"
       verbalTriggerLemma: "farnesylate"
       nominalTriggerLemma: "farnesylation"
+      priority: "5"
 
   # Ribosylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -81,6 +96,7 @@ rules:
       label: "Ribosylation"
       verbalTriggerLemma: "ribosylate"
       nominalTriggerLemma: "ribosylation"
+      priority: "5"
 
   # Methylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -90,12 +106,13 @@ rules:
       label: "Methylation"
       verbalTriggerLemma: "methylate"
       nominalTriggerLemma: "methylation"
+      priority: "5"
 
   # Generic (incomplete) events
   - import: edu/arizona/sista/reach/biogrammar/coref/generic_events.yml
     vars:
-      priority: "6"
       actionFlow: "mkBioMention"
+      priority: "6"
 
   # Positive Regulation
   - import: edu/arizona/sista/reach/biogrammar/events/pos-reg_template.yml

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events_master.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events_master.yml
@@ -7,26 +7,17 @@ vars:
 
 rules:
   - import: edu/arizona/sista/reach/biogrammar/events/bind_events.yml
-    vars:
-      priority: "5"
-
   - import: edu/arizona/sista/reach/biogrammar/events/hydrolysis_events.yml
-    vars:
-      priority: "5"
-
   - import: edu/arizona/sista/reach/biogrammar/events/translocation_events.yml
-    vars:
-      priority: "5"
 
   # Phosphorylations
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
     vars:
-     eventName: "Phosphorylation"
-     actionFlow: "mkBioMention"
-     label: "Phosphorylation"
-     verbalTriggerLemma: "phosphorylate"
-     nominalTriggerLemma: "phosphorylation"
-     priority: "5"
+      eventName: "Phosphorylation"
+      actionFlow: "mkBioMention"
+      label: "Phosphorylation"
+      verbalTriggerLemma: "phosphorylate"
+      nominalTriggerLemma: "phosphorylation"
 
   # Ubiquitination
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -36,7 +27,6 @@ rules:
       label: "Ubiquitination"
       verbalTriggerLemma: "ubiquitinate"
       nominalTriggerLemma: "ubiquitination"
-      priority: "5"
 
   # Hydroxylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -46,7 +36,6 @@ rules:
       label: "Hydroxylation"
       verbalTriggerLemma: "hydroxylate"
       nominalTriggerLemma: "hydroxylation"
-      priority: "5"
 
   # Sumoylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -56,7 +45,6 @@ rules:
       label: "Sumoylation"
       verbalTriggerLemma: "sumoylate"
       nominalTriggerLemma: "sumoylation"
-      priority: "5"
 
   # Glycosylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -66,7 +54,6 @@ rules:
       label: "Glycosylation"
       verbalTriggerLemma: "glycosylate"
       nominalTriggerLemma: "glycosylation"
-      priority: "5"
 
   # Acetylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -76,7 +63,6 @@ rules:
       label: "Acetylation"
       verbalTriggerLemma: "acetylate"
       nominalTriggerLemma: "acetylation"
-      priority: "5"
 
   # Farnesylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -86,7 +72,6 @@ rules:
       label: "Farnesylation"
       verbalTriggerLemma: "farnesylate"
       nominalTriggerLemma: "farnesylation"
-      priority: "5"
 
   # Ribosylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -96,7 +81,6 @@ rules:
       label: "Ribosylation"
       verbalTriggerLemma: "ribosylate"
       nominalTriggerLemma: "ribosylation"
-      priority: "5"
 
   # Methylation
   - import: edu/arizona/sista/reach/biogrammar/events/simple-event_template.yml
@@ -106,13 +90,12 @@ rules:
       label: "Methylation"
       verbalTriggerLemma: "methylate"
       nominalTriggerLemma: "methylation"
-      priority: "5"
 
   # Generic (incomplete) events
   - import: edu/arizona/sista/reach/biogrammar/coref/generic_events.yml
     vars:
-      actionFlow: "mkBioMention"
       priority: "6"
+      actionFlow: "mkBioMention"
 
   # Positive Regulation
   - import: edu/arizona/sista/reach/biogrammar/events/pos-reg_template.yml

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/modifications_master.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/modifications_master.yml
@@ -4,5 +4,3 @@ rules:
   - import: edu/arizona/sista/reach/biogrammar/modifications/modifications.yml
   - import: edu/arizona/sista/reach/biogrammar/modifications/mutants.yml
   - import: edu/arizona/sista/reach/biogrammar/coref/alias.yml
-    vars:
-      priority: "4"

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/modifications_master.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/modifications_master.yml
@@ -4,3 +4,5 @@ rules:
   - import: edu/arizona/sista/reach/biogrammar/modifications/modifications.yml
   - import: edu/arizona/sista/reach/biogrammar/modifications/mutants.yml
   - import: edu/arizona/sista/reach/biogrammar/coref/alias.yml
+    vars:
+      priority: "4"


### PR DESCRIPTION
This should resolve #99 by using variables for priorities in all the easy cases. I left entities and modifications alone for now, since those use multiple priorities per .yml file. I doubt it's worth changing those, because they will probably remain custom.