### PR TITLE
New token rule for 'interaction of X and Y'

### DIFF
--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/bind_events.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/bind_events.yml
@@ -132,7 +132,20 @@
   priority: ${ priority }
   pattern: |
       trigger = /cooperation|affinity|association|interaction/
-      theme1:BioChemicalEntity+ = prep_between conj_and?
+      theme1:BioChemicalEntity+ = </prep_(of|to)/{,2} acomp? prep_between conj_and?
+
+- name: binding11_token
+  label: Binding
+  action: mkBinding
+  priority: ${ priority }
+  type: token
+  pattern: |
+      (?<trigger> /cooperation|affinity|association|interaction/ )
+      "between"
+      [tag="DT"]?
+      @theme1:BioChemicalEntity
+      "and"
+      @theme2:BioChemicalEntity
 
 - name: binding12
   label: Binding


### PR DESCRIPTION
I noticed that I was failing to get the interaction in the sentence.

> The competition of hGR G567A for RU 486 could not be determined due to an absence of interaction between this substitution mutant and dexamethasone.

This should have been handled by `binding11`, but the parse had the wrong attachment, so `interaction` was too distant from the participants. The token rule shortcuts this problem.