### PR TITLE
Issue130

### DIFF
--- a/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
@@ -1,5 +1,6 @@
 package edu.arizona.sista.reach
 
+import io.Source
 import edu.arizona.sista.reach.nxml.{NxmlReader, FriesEntry}
 import edu.arizona.sista.reach.display._
 import edu.arizona.sista.reach.extern.export.MentionManager
@@ -14,6 +15,27 @@ import edu.arizona.sista.reach.context.ContextEngineFactory.Engine._
  * Utility methods for the tests in this directory
  */
 object TestUtils {
+
+  // Inner object that contains the annotations to test context
+  object Context{
+    def nxml1 = Source.fromURL(getClass.getResource("/inputs/nxml/PMC2597732.nxml")).mkString
+    def nxml2 = Source.fromURL(getClass.getResource("/inputs/nxml/PMC3189917.nxml")).mkString
+    def nxml3 = Source.fromURL(getClass.getResource("/inputs/nxml/PMC1289294.nxml")).mkString
+
+    case class Annotation(friesEntries:Seq[FriesEntry], documents:Seq[Document], entitiesPerEntry:Seq[Seq[BioMention]], mentions:Seq[BioMention])
+
+    def annotatePaper(nxml:String):Annotation = {
+      val friesEntries = testReader.readNxml(nxml, "")
+      val documents = friesEntries map (e => testReach.mkDoc(e.text, e.name, e.chunkId))
+      val entitiesPerEntry =  for (doc <- documents) yield testReach.extractEntitiesFrom(doc)
+      val mentions = testReach.extractFrom(friesEntries, documents)
+
+      Annotation(friesEntries, documents, entitiesPerEntry, mentions)
+    }
+
+    val paperAnnotations = Map(1 -> annotatePaper(nxml1), 2 -> annotatePaper(nxml2), 3 -> annotatePaper(nxml3))
+  }
+
   val testReach = new ReachSystem(contextEngineType = Engine.withName("Policy4"), contextParams = Map("bound" -> "5")) // All tests should use this system!
   val testReader = new NxmlReader
   val bioproc = testReach.processor // quick access to a process, if needed.

--- a/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
@@ -33,7 +33,7 @@ object TestUtils {
       Annotation(friesEntries, documents, entitiesPerEntry, mentions)
     }
 
-    val paperAnnotations = Map(1 -> annotatePaper(nxml1), 2 -> annotatePaper(nxml2), 3 -> annotatePaper(nxml3))
+    val paperAnnotations = Map(1 -> annotatePaper(nxml1)/*, 2 -> annotatePaper(nxml2), 3 -> annotatePaper(nxml3)*/)
   }
 
   val testReach = new ReachSystem(contextEngineType = Engine.withName("Policy4"), contextParams = Map("bound" -> "5")) // All tests should use this system!

--- a/src/test/scala/edu/arizona/sista/reach/context/TestDeterministicPolicies.scala
+++ b/src/test/scala/edu/arizona/sista/reach/context/TestDeterministicPolicies.scala
@@ -148,16 +148,16 @@ class TestDeterministicPolicies extends FlatSpec with Matchers {
   it should behave like boundedPaddingBehavior(1)
   it should behave like bidirectionalPaddingBehavior(1)
 
-  behavior of "PMC3189917.nxml"
-
-  it should behave like contextAssignmentBehavior(2)
-  it should behave like boundedPaddingBehavior(2)
-  it should behave like bidirectionalPaddingBehavior(2)
-
-  behavior of "PMC1289294.nxml"
-
-  it should behave like contextAssignmentBehavior(3)
-  it should behave like boundedPaddingBehavior(3)
-  it should behave like bidirectionalPaddingBehavior(3)
+  // behavior of "PMC3189917.nxml"
+  //
+  // it should behave like contextAssignmentBehavior(2)
+  // it should behave like boundedPaddingBehavior(2)
+  // it should behave like bidirectionalPaddingBehavior(2)
+  //
+  // behavior of "PMC1289294.nxml"
+  //
+  // it should behave like contextAssignmentBehavior(3)
+  // it should behave like boundedPaddingBehavior(3)
+  // it should behave like bidirectionalPaddingBehavior(3)
 
 }

--- a/src/test/scala/edu/arizona/sista/reach/context/TestDeterministicPolicies.scala
+++ b/src/test/scala/edu/arizona/sista/reach/context/TestDeterministicPolicies.scala
@@ -4,21 +4,16 @@ import io.Source
 import edu.arizona.sista.reach.mentions._
 import edu.arizona.sista.reach.ReachSystem
 import edu.arizona.sista.reach.TestUtils._
+import edu.arizona.sista.reach.TestUtils.Context._
 import org.scalatest.{Matchers, FlatSpec}
-trait Fixtures {
-  // Set up the fixtures
-  def nxml1 = Source.fromURL(getClass.getResource("/inputs/nxml/PMC2597732.nxml")).mkString
-  def nxml2 = Source.fromURL(getClass.getResource("/inputs/nxml/PMC3189917.nxml")).mkString
-  def nxml3 = Source.fromURL(getClass.getResource("/inputs/nxml/PMC1289294.nxml")).mkString
-}
 
-class TestDeterministicPolicies extends FlatSpec with Matchers with Fixtures {
 
-  def contextAssignmentBehavior(nxml:String){
+class TestDeterministicPolicies extends FlatSpec with Matchers {
+
+  def contextAssignmentBehavior(paperNum:Int){
     info("Testing context assignment")
-    val entries = testReader.readNxml(nxml, nxml)
 
-    val x = testReach.extractFrom(entries)
+    val x = paperAnnotations(paperNum).mentions
 
     val tbMentions:Seq[BioTextBoundMention] = x.filter{
       case tm:BioTextBoundMention => true
@@ -66,13 +61,14 @@ class TestDeterministicPolicies extends FlatSpec with Matchers with Fixtures {
     }
   }
 
-  def boundedPaddingBehavior(nxml:String){
+  def boundedPaddingBehavior(paperNum:Int){
     info(s"Testing bounding padding context")
-    // Extract context for the sentences of a doc, not to the attached mentions
-    val friesEntries = testReader.readNxml(nxml, "")
-    val documents = friesEntries map (e => testReach.mkDoc(e.text, e.name, e.chunkId))
-    val entitiesPerEntry =  for (doc <- documents) yield testReach.extractEntitiesFrom(doc)
 
+    val annotation = paperAnnotations(paperNum)
+
+    val friesEntries = annotation.friesEntries
+    val documents = annotation.documents
+    val entitiesPerEntry = annotation.entitiesPerEntry
 
     val bound = 5
     val boundedPaddingEngine = new BoundedPaddingContext(bound)
@@ -105,14 +101,15 @@ class TestDeterministicPolicies extends FlatSpec with Matchers with Fixtures {
     }
   }
 
-  def bidirectionalPaddingBehavior(nxml:String){
+  def bidirectionalPaddingBehavior(paperNum:Int){
     info(s"Testing bidirectional bounding padding context")
-    // Extract context for the sentences of a doc, not to the attached mentions
-    val friesEntries = testReader.readNxml(nxml, "")
-    val documents = friesEntries map (e => testReach.mkDoc(e.text, e.name, e.chunkId))
-    val entitiesPerEntry =  for (doc <- documents) yield testReach.extractEntitiesFrom(doc)
 
+    val annotation = paperAnnotations(paperNum)
 
+    val friesEntries = annotation.friesEntries
+    val documents = annotation.documents
+    val entitiesPerEntry = annotation.entitiesPerEntry
+    val paperMentions = annotation.mentions
 
     val boundedPaddingEngine = new BidirectionalPaddingContext(bound=5)
     boundedPaddingEngine.infer(friesEntries, documents, entitiesPerEntry)
@@ -147,20 +144,20 @@ class TestDeterministicPolicies extends FlatSpec with Matchers with Fixtures {
   // Tests
   behavior of "PMC2597732.nxml"
 
-  it should behave like contextAssignmentBehavior(nxml1)
-  it should behave like boundedPaddingBehavior(nxml1)
-  it should behave like bidirectionalPaddingBehavior(nxml1)
+  it should behave like contextAssignmentBehavior(1)
+  it should behave like boundedPaddingBehavior(1)
+  it should behave like bidirectionalPaddingBehavior(1)
 
   behavior of "PMC3189917.nxml"
 
-  it should behave like contextAssignmentBehavior(nxml2)
-  it should behave like boundedPaddingBehavior(nxml2)
-  it should behave like bidirectionalPaddingBehavior(nxml2)
+  it should behave like contextAssignmentBehavior(2)
+  it should behave like boundedPaddingBehavior(2)
+  it should behave like bidirectionalPaddingBehavior(2)
 
   behavior of "PMC1289294.nxml"
 
-  it should behave like contextAssignmentBehavior(nxml3)
-  it should behave like boundedPaddingBehavior(nxml3)
-  it should behave like bidirectionalPaddingBehavior(nxml3)
+  it should behave like contextAssignmentBehavior(3)
+  it should behave like boundedPaddingBehavior(3)
+  it should behave like bidirectionalPaddingBehavior(3)
 
 }


### PR DESCRIPTION
Significantly reduces context’s unit tests running time.

Refactors paper annotations on context’s unit tests to the TestUtil class to avoid redundant annotation.

Commented out two paper tests because paper annotation takes too long. I’d rather focus on a single paper and
make sure all features can be tested on it.