### PR TITLE
deleted wrong pattern fragment

### DIFF
--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events/pos-reg_template.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events/pos-reg_template.yml
@@ -15,7 +15,7 @@
   action: ${ actionFlow }
   pattern: |
     trigger = [word=/(?i)^(${ triggers })/ & tag=/^V|RB/] [lemma=/^(${ auxtriggers })/ & tag=/^V/]?
-    controlled:${ controlledType } = prepc_by? (dobj | xcomp | ccomp) /conj|dep|dobj|cc|nn|prep_of|prep_in$|amod/{,2} (>> [word=by]){,2}
+    controlled:${ controlledType } = prepc_by? (dobj | xcomp | ccomp) /conj|dep|dobj|cc|nn|prep_of|prep_in$|amod/{,2}
     controller:${ controllerType } = <xcomp? (nsubj | agent | <vmod) /appos|nn|conj_|cc|prep_of|prep_in$/{,2}
 
 


### PR DESCRIPTION
Deleted a fragment of a pattern that isn't doing anything other than convoluting it.
The word "by" shouldn't be reachable using collapsed dependencies.
If it is reachable, it is probably not part of the controlled argument.
I'm not sure what was the intention of whoever wrote this, but I suspect it is not doing that.