### PR TITLE
Remove spurious debugging output in TestReachGrounder.

### DIFF
--- a/src/test/scala/edu/arizona/sista/reach/TestReachGrounder.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestReachGrounder.scala
@@ -24,7 +24,6 @@ class TestReachGrounder extends FlatSpec with Matchers {
   val resols: Resolutions = Some(Seq(kbrC, kbrH, kbrM, kbrR))
 
   text1 should "produce 7 entities mentions" in {
-    printMentions(Try(mentions), true)      // DEBUGGING
     mentions should have size (7)
   }
 


### PR DESCRIPTION
Remove one line of leftover debugging output which generates lots of unnecessary test output.
