### PR TITLE
Log paper ID when starting processing.

### DIFF
--- a/src/main/scala/edu/arizona/sista/reach/ReachCLI.scala
+++ b/src/main/scala/edu/arizona/sista/reach/ReachCLI.scala
@@ -52,6 +52,8 @@ class ReachCLI(
       val startTime = ReachCLI.now // start measuring time here
       val startNS = System.nanoTime
 
+      FileUtils.writeStringToFile(logFile, s"Starting $paperId (${startTime})\n", true)
+
       // Process individual sections and collect all mentions
       val entries = Try(nxmlReader.readNxml(file)) match {
         case Success(v) => v


### PR DESCRIPTION
Trivial change to ReachCLI. But very useful to monitor multiple running files.