### PR TITLE
Change Reach to use PFAM protein family KB

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ pomExtra := (
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.3",
+  "org.clulab" % "bioresources" % "1.1.4",
   "org.clulab" %% "processors" % "5.8.2",
   "org.clulab" %% "processors" % "5.8.2" classifier "models",
   "com.typesafe" % "config" % "1.2.1",

--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/entities/entities.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/entities/entities.yml
@@ -20,7 +20,7 @@
   type: token
   action: mkBioMention
   pattern: |
-    (?<! [word=/(?i)^(table|figure)/]) [word=/(?i)^[ACDEFGHIKLMNQRSTVWY]\d+$/ & !mention=/^(Gene_or_gene_product|Simple_chemical)$/]
+    (?<! [word=/(?i)^(table|figure)/]) [word=/(?i)^[ACDEFGHIKLMNQRSTVWY]\d+$/ & !mention=/^(Family|Gene_or_gene_product|Simple_chemical)$/]
   # old alt. pattern /^P\d+$/
 
 - name: site_3letter

--- a/src/main/scala/edu/arizona/sista/reach/grounding/EntityChecker.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/EntityChecker.scala
@@ -14,7 +14,7 @@ import edu.arizona.sista.reach.grounding.ReachKBConstants._
 /**
   * Program to lookup/check incoming BioPax model entities against local knowledge bases.
   *   Author: by Tom Hicks. 5/14/2015.
-  *   Last Modified: Update for singleton KBL creator.
+  *   Last Modified: Update for addition of PFAM protein family KB.
   */
 object EntityChecker extends App {
 
@@ -22,6 +22,7 @@ object EntityChecker extends App {
 
   /** Search sequence for resolving proteins. */
   protected val proteinSearcher = Seq( staticProteinFamilyKBLookup,
+                                       staticProteinFamily2KBLookup,
                                        staticProteinKBLookup )
 
   /** Search sequence for small molecules. */

--- a/src/main/scala/edu/arizona/sista/reach/grounding/ReachEntityLookup.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/ReachEntityLookup.scala
@@ -15,7 +15,7 @@ import edu.arizona.sista.reach.grounding.ReachIMKBMentionLookups._
 /**
   * Class which implements project internal methods to ground entities.
   *   Written by Tom Hicks. 11/9/2015.
-  *   Last Modified: Restrict to bio mentions. Remove unused state arguments. Fix: bioprocess label.
+  *   Last Modified: Update for addition of PFAM protein family KB.
   */
 class ReachEntityLookup {
 
@@ -101,6 +101,7 @@ class ReachEntityLookup {
 
   val familySeq: KBSearchSequence = extraKBs ++ Seq(
     StaticProteinFamily,
+    StaticProteinFamily2,
     ManualProteinFamily,
     ModelGendProteinAndFamily
   )

--- a/src/main/scala/edu/arizona/sista/reach/grounding/ReachIMKBLookups.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/ReachIMKBLookups.scala
@@ -5,7 +5,7 @@ import edu.arizona.sista.reach.grounding.ReachKBConstants._
 /**
   * Object which implements all Reach KB Lookup instances.
   *   Written by: Tom Hicks. 10/23/2015.
-  *   Last Modified: Add family and protein meta info to appropriate KBs.
+  *   Last Modified: Update for addition of PFAM protein family KB.
   */
 object ReachIMKBLookups {
 
@@ -44,10 +44,18 @@ object ReachIMKBLookups {
 
   /** KB lookup to resolve protein family names via static KBs with alternate lookups. */
   def staticProteinFamilyKBLookup: IMKBFamilyLookup = {
-    val metaInfo = new IMKBMetaInfo("http://identifiers.org/interpro/", "MIR:00000011")
+    val metaInfo = new IMKBMetaInfo("http://identifiers.org/pfam/", "MIR:00000028")
     metaInfo.put("file", StaticProteinFamilyFilename)
     metaInfo.put("family", "true")          // mark as from a protein family KB
-    new IMKBFamilyLookup(tsvIMKBFactory.make("interpro", StaticProteinFamilyFilename, true, metaInfo))
+    new IMKBFamilyLookup(tsvIMKBFactory.make("pfam", StaticProteinFamilyFilename, metaInfo))
+  }
+
+  /** KB lookup to resolve protein family names via static KBs with alternate lookups. */
+  def staticProteinFamily2KBLookup: IMKBFamilyLookup = {
+    val metaInfo = new IMKBMetaInfo("http://identifiers.org/interpro/", "MIR:00000011")
+    metaInfo.put("file", StaticProteinFamily2Filename)
+    metaInfo.put("family", "true")          // mark as from a protein family KB
+    new IMKBFamilyLookup(tsvIMKBFactory.make("interpro", StaticProteinFamily2Filename, true, metaInfo))
   }
 
   /** KB lookup to resolve tissue type names via static KB. */

--- a/src/main/scala/edu/arizona/sista/reach/grounding/ReachIMKBMentionLookups.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/ReachIMKBMentionLookups.scala
@@ -6,7 +6,7 @@ import edu.arizona.sista.reach.grounding.ReachKBConstants._
 /**
   * Object which implements all Reach KB Mention Lookup creators and instances.
   *   Written by: Tom Hicks. 10/28/2015.
-  *   Last Modified: Refactor singleton instances of KBMLs here.
+  *   Last Modified: Update for addition of PFAM protein family KB.
   */
 object ReachIMKBMentionLookups {
 
@@ -30,6 +30,7 @@ object ReachIMKBMentionLookups {
   val StaticMetabolite = staticMetaboliteKBML
   val StaticProtein = staticProteinKBML
   val StaticProteinFamily = staticProteinFamilyKBML
+  val StaticProteinFamily2 = staticProteinFamily2KBML
   // val StaticTissueType = staticTissueTypeKBML()   // CURRENTLY UNUSED
 
   val ManualCellLocation = manualCellLocationKBML
@@ -169,11 +170,19 @@ object ReachIMKBMentionLookups {
 
   /** KB accessor to resolve protein family names via static KB. */
   def staticProteinFamilyKBML: IMKBFamilyMentionLookup = {
-    val metaInfo = new IMKBMetaInfo("http://identifiers.org/interpro/", "MIR:00000011")
+    val metaInfo = new IMKBMetaInfo("http://identifiers.org/pfam/", "MIR:00000028")
     metaInfo.put("file", StaticProteinFamilyFilename)
     metaInfo.put("family", "true")          // mark as from a protein family KB
+    new IMKBFamilyMentionLookup(TsvIMKBFactory.make("pfam", StaticProteinFamilyFilename, metaInfo))
+  }
+
+  /** KB accessor to resolve protein family names via static KB. */
+  def staticProteinFamily2KBML: IMKBFamilyMentionLookup = {
+    val metaInfo = new IMKBMetaInfo("http://identifiers.org/interpro/", "MIR:00000011")
+    metaInfo.put("file", StaticProteinFamily2Filename)
+    metaInfo.put("family", "true")          // mark as from a protein family KB
     new IMKBFamilyMentionLookup(TsvIMKBFactory.make("interpro",
-                                                    StaticProteinFamilyFilename, true, metaInfo))
+                                                    StaticProteinFamily2Filename, true, metaInfo))
   }
 
   //

--- a/src/main/scala/edu/arizona/sista/reach/grounding/ReachKBConstants.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/ReachKBConstants.scala
@@ -3,7 +3,7 @@ package edu.arizona.sista.reach.grounding
 /**
   * Trait for defining constants used by grounding and entity checking code.
   *   Written by Tom Hicks. 10/22/2015.
-  *   Last Modified: Update for a couple of context file renames.
+  *   Last Modified: Update for addition of PFAM protein family KB.
   */
 object ReachKBConstants {
 
@@ -82,7 +82,10 @@ object ReachKBConstants {
   val StaticProteinFilename = "uniprot-proteins.tsv.gz"
 
   /** Filename of the static protein family file. */
-  val StaticProteinFamilyFilename = "ProteinFamilies.tsv.gz"
+  val StaticProteinFamilyFilename = "PFAM-families.tsv.gz"
+
+  /** Filename of the secondary static protein family file. */
+  val StaticProteinFamily2Filename = "ProteinFamilies.tsv.gz"
 
   /** Filename of the static tissue type file. */
   val StaticTissueTypeFilename = "tissue-type.tsv.gz"

--- a/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestEntities.scala
@@ -134,7 +134,7 @@ class TestEntities extends FlatSpec with Matchers {
   sent8 should "not contain any sites and it should have 1 simple chemical" in {
     val mentions = getBioMentions(sent8)
     mentions.count(_ matches "Site") should be (0)
-    mentions.count(_ matches "Simple_chemical") should be (1)
+    mentions.count(_ matches "Family") should be (1)
   }
 
 }

--- a/src/test/scala/edu/arizona/sista/reach/TestFamilyResolutions.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestFamilyResolutions.scala
@@ -207,6 +207,6 @@ class TestFamilyResolutions extends FlatSpec with Matchers {
 class TestProtFamKBL extends IMKBFamilyLookup {
   val meta = new IMKBMetaInfo("http://identifiers.org/interpro/", "MIR:00000011")
   meta.put("family", "true")                // mark as from a protein family KB
-  memoryKB = (new TsvIMKBFactory).make("interpro", StaticProteinFamilyFilename, true, meta)
+  memoryKB = (new TsvIMKBFactory).make("interpro", StaticProteinFamily2Filename, true, meta)
   // println(s"IMKB.metaInfo=${memoryKB.metaInfo}")
 }

--- a/src/test/scala/edu/arizona/sista/reach/TestReachGrounder.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestReachGrounder.scala
@@ -18,7 +18,7 @@ class TestReachGrounder extends FlatSpec with Matchers {
   val mentions1 = getBioMentions(text1)
 
   text1 should "produce 4 mentions" in {
-    printMentions(Try(mentions1), true)      // DEBUGGING
+    // printMentions(Try(mentions1), true)      // DEBUGGING
     mentions1 should have size (4)
   }
 

--- a/src/test/scala/edu/arizona/sista/reach/TestTsvKBs.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestTsvKBs.scala
@@ -60,7 +60,7 @@ class TestTsvKBs extends FlatSpec with Matchers {
 
 
   // Tests of speciated (3-column) knowledge base
-  val imkbPF = (new TsvIMKBFactory).make("interpro", StaticProteinFamilyFilename, true,
+  val imkbPF = (new TsvIMKBFactory).make("interpro", StaticProteinFamily2Filename, true,
     new IMKBMetaInfo("http://identifiers.org/uazclu/", "MIR:00000000"))
 
   // test lookups directly in IMKB (remember: all test keys must be lowercased to succeed!)


### PR DESCRIPTION
*This release depends on Bioresources version 1.1.4 so tests will not pass until that is available.*

Added PFAM protein family KB with InterPro retained as secondary family KB. Modified lookups, updated tests, and fixed one site rule in entities.yml.