### PR TITLE
Issue167: Replaces ChEBI and HMDB with PubChem

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ pomExtra := (
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.4",
+  "org.clulab" % "bioresources" % "1.1.5",
   "org.clulab" %% "processors" % "5.8.3",
   "org.clulab" %% "processors" % "5.8.3" classifier "models",
   "com.typesafe" % "config" % "1.2.1",

--- a/src/main/scala/edu/arizona/sista/reach/grounding/EntityChecker.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/EntityChecker.scala
@@ -14,7 +14,7 @@ import edu.arizona.sista.reach.grounding.ReachKBConstants._
 /**
   * Program to lookup/check incoming BioPax model entities against local knowledge bases.
   *   Author: by Tom Hicks. 5/14/2015.
-  *   Last Modified: Update for addition of PFAM protein family KB.
+  *   Last Modified: Replace ChEBI and HMDB KBs with PubChem.
   */
 object EntityChecker extends App {
 
@@ -26,8 +26,7 @@ object EntityChecker extends App {
                                        staticProteinKBLookup )
 
   /** Search sequence for small molecules. */
-  protected val chemSearcher = Seq( staticChemicalKBLookup,
-                                    staticMetaboliteKBLookup )
+  protected val chemSearcher = Seq( staticChemicalKBLookup )
 
   /** Search sequence for sub cellular locations terms. */
   protected val cellLocationSearcher = Seq( staticCellLocationKBLookup )

--- a/src/main/scala/edu/arizona/sista/reach/grounding/ReachEntityLookup.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/ReachEntityLookup.scala
@@ -15,7 +15,7 @@ import edu.arizona.sista.reach.grounding.ReachIMKBMentionLookups._
 /**
   * Class which implements project internal methods to ground entities.
   *   Written by Tom Hicks. 11/9/2015.
-  *   Last Modified: Update for addition of PFAM protein family KB.
+  *   Last Modified: Replace ChEBI and HMDB KBs with PubChem.
   */
 class ReachEntityLookup {
 
@@ -94,7 +94,7 @@ class ReachEntityLookup {
 
   val chemicalSeq: KBSearchSequence = extraKBs ++ Seq(
     StaticChemical,
-    StaticMetabolite,
+    // StaticMetabolite,                    // REPLACED by PubChem
     ManualChemical,
     ModelGendChemical
   )

--- a/src/main/scala/edu/arizona/sista/reach/grounding/ReachIMKBLookups.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/ReachIMKBLookups.scala
@@ -5,7 +5,7 @@ import edu.arizona.sista.reach.grounding.ReachKBConstants._
 /**
   * Object which implements all Reach KB Lookup instances.
   *   Written by: Tom Hicks. 10/23/2015.
-  *   Last Modified: Update for addition of PFAM protein family KB.
+  *   Last Modified: Replace ChEBI and HMDB KBs with PubChem.
   */
 object ReachIMKBLookups {
 
@@ -29,10 +29,17 @@ object ReachIMKBLookups {
 
   /** KB lookup to resolve small molecule (chemical) names via static KB. */
   def staticChemicalKBLookup: IMKBLookup = {
-    val metaInfo = new IMKBMetaInfo("http://identifiers.org/chebi/", "MIR:00100009")
+    val metaInfo = new IMKBMetaInfo("http://identifiers.org/pubchem.compound/", "MIR:00000034")
     metaInfo.put("file", StaticChemicalFilename)
-    new IMKBLookup(tsvIMKBFactory.make("chebi", StaticChemicalFilename, metaInfo))
+    new IMKBLookup(tsvIMKBFactory.make("PubChem", StaticChemicalFilename, metaInfo))
   }
+
+  /** KB lookup to resolve small molecule (chemical) names via static KB. */
+  // def staticChemicalKBLookup: IMKBLookup = {
+  //   val metaInfo = new IMKBMetaInfo("http://identifiers.org/chebi/", "MIR:00100009")
+  //   metaInfo.put("file", StaticChemicalFilename)
+  //   new IMKBLookup(tsvIMKBFactory.make("chebi", StaticChemicalFilename, metaInfo))
+  // }
 
   /** KB accessor to resolve protein names via static KBs with alternate lookups. */
   def staticProteinKBLookup: IMKBProteinLookup = {

--- a/src/main/scala/edu/arizona/sista/reach/grounding/ReachIMKBMentionLookups.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/ReachIMKBMentionLookups.scala
@@ -6,7 +6,7 @@ import edu.arizona.sista.reach.grounding.ReachKBConstants._
 /**
   * Object which implements all Reach KB Mention Lookup creators and instances.
   *   Written by: Tom Hicks. 10/28/2015.
-  *   Last Modified: Update for addition of PFAM protein family KB.
+  *   Last Modified: Replace ChEBI and HMDB KBs with PubChem.
   */
 object ReachIMKBMentionLookups {
 
@@ -27,11 +27,11 @@ object ReachIMKBMentionLookups {
   val StaticCellLocation = staticCellLocationKBML   // GO subcellular KB
   val StaticCellLocation2 = staticCellLocationKBML2 // Uniprot subcellular KB
   val StaticChemical = staticChemicalKBML
-  val StaticMetabolite = staticMetaboliteKBML
+  // val StaticMetabolite = staticMetaboliteKBML    // REPLACED by PubChem
   val StaticProtein = staticProteinKBML
   val StaticProteinFamily = staticProteinFamilyKBML
   val StaticProteinFamily2 = staticProteinFamily2KBML
-  // val StaticTissueType = staticTissueTypeKBML()   // CURRENTLY UNUSED
+  // val StaticTissueType = staticTissueTypeKBML    // CURRENTLY UNUSED
 
   val ManualCellLocation = manualCellLocationKBML
   val ManualChemical = manualChemicalKBML
@@ -113,10 +113,18 @@ object ReachIMKBMentionLookups {
 
   /** KB accessor to resolve small molecule (chemical) names via static KB. */
   def staticChemicalKBML: IMKBMentionLookup = {
-    val metaInfo = new IMKBMetaInfo("http://identifiers.org/chebi/", "MIR:00100009")
+    val metaInfo = new IMKBMetaInfo("http://identifiers.org/pubchem.compound/", "MIR:00000034")
     metaInfo.put("file", StaticChemicalFilename)
-    new IMKBMentionLookup(TsvIMKBFactory.make("chebi", StaticChemicalFilename, metaInfo))
+    new IMKBMentionLookup(TsvIMKBFactory.make("PubChem", StaticChemicalFilename, metaInfo))
   }
+
+  /** KB accessor to resolve small molecule (chemical) names via static KB. */
+  // def staticChemicalKBML: IMKBMentionLookup = {
+  //   val metaInfo = new IMKBMetaInfo("http://identifiers.org/chebi/", "MIR:00100009")
+  //   metaInfo.put("file", StaticChemicalFilename)
+  //   new IMKBMentionLookup(TsvIMKBFactory.make("chebi", StaticChemicalFilename, metaInfo))
+  // }
+
 
   //
   // Protein Accessors

--- a/src/main/scala/edu/arizona/sista/reach/grounding/ReachKBConstants.scala
+++ b/src/main/scala/edu/arizona/sista/reach/grounding/ReachKBConstants.scala
@@ -3,7 +3,7 @@ package edu.arizona.sista.reach.grounding
 /**
   * Trait for defining constants used by grounding and entity checking code.
   *   Written by Tom Hicks. 10/22/2015.
-  *   Last Modified: Update for addition of PFAM protein family KB.
+  *   Last Modified: Replace ChEBI and HMDB KBs with PubChem.
   */
 object ReachKBConstants {
 
@@ -73,7 +73,7 @@ object ReachKBConstants {
   val StaticCellLocation2Filename = "uniprot-subcellular-locations.tsv.gz"
 
   /** Filename of the static small molecule (chemical) file. */
-  val StaticChemicalFilename = "chebi.tsv.gz"
+  val StaticChemicalFilename = "PubChem.tsv.gz"
 
   /** Filename of the static small molecule (metabolite) file. */
   val StaticMetaboliteFilename = "hmdb.tsv.gz"

--- a/src/test/scala/edu/arizona/sista/reach/TestApi.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestApi.scala
@@ -120,9 +120,9 @@ class TestApi extends FlatSpec with Matchers {
     hasEntity("ASPP2", results) should be (true)
   }
 
-  it should "return 3 positive activation and 3 phosphorylation results from NXML test" in {
+  it should "return 4 positive activation and 3 phosphorylation results from NXML test" in {
     val results = Api.runOnNxml(nxmlText)
-    results.filter(_.label == "Positive_activation") should have size (3)
+    results.filter(_.label == "Positive_activation") should have size (4)
     results.filter(_.label == "Phosphorylation") should have size (3)
   }
 


### PR DESCRIPTION
Note this branch updates Reach build to use the newly released Bioresources 1.1.5.
