### PR TITLE
Assembly foundby

### DIFF
--- a/src/main/scala/edu/arizona/sista/assembly/Assembler.scala
+++ b/src/main/scala/edu/arizona/sista/assembly/Assembler.scala
@@ -1,53 +1,60 @@
 package edu.arizona.sista.assembly
 
+import edu.arizona.sista.assembly.export.{Equivalence, CausalPrecedence}
 import edu.arizona.sista.odin.Mention
 
 
 /**
   * Assembler for reach output
-  * @param mentions a sequence of Odin-style Mentions
+  * @param mns a sequence of Odin-style Mentions
   *   Written by: Gus Hahn-Powell. 5/9/2016.
   *   Last Modified: Comment out extraneous outputs and anticipated methods.
   */
-class Assembler(val mentions: Seq[Mention]) {
-
+class Assembler(mns: Seq[Mention]) {
+  // keep only the valid mentions
+  val mentions = mns.filter(AssemblyManager.isValidMention)
   val am = AssemblyRunner.applySieves(mentions)
-  // println("finished assembly!")
 
-  val causalPredecessors: Map[Mention, Set[Mention]] = {
+  val causalPredecessors: Map[Mention, Set[CausalPrecedence]] = {
     val links = for {
       m <- mentions
-    } yield (m, am.distinctPredecessorsOf(m).flatMap(_.evidence))
-    links.toMap
+      eer = am.getEER(m)
+      eh = eer.equivalenceHash
+      pr <- am.getPrecedenceRelations(eh)
+      after = pr.after
+      // current mention should be the successor
+      if after == eh
+      e <- pr.evidence
+      // only consider links with well-formed evidence
+      if e.arguments.contains("before") && e.arguments.contains("after")
+      b <- e.arguments("before")
+      a <- e.arguments("after")
+    } yield CausalPrecedence(before = b, after = a, pr.foundBy)
+    // build map from pairs
+    links.groupBy(_.after).mapValues(_.toSet)
   }
-  // println("Built causalPredecedessors map")
 
-  def getCausalPredecessors(m: Mention): Set[Mention] =
-    causalPredecessors.getOrElse(m, Set.empty[Mention])
+  /**
+   * Returns the set of CausalPrecedence links where m is the [[CausalPrecedence.after]]
+   * @param m an Odin-style Mention
+   */
+  def getCausalPredecessors(m: Mention): Set[CausalPrecedence] =
+    causalPredecessors.getOrElse(m, Set.empty[CausalPrecedence])
 
-  // val causalSuccessors: Map[Mention, Set[Mention]] = {
-  //   val links = for {
-  //     m <- mentions
-  //   } yield (m, am.distinctSuccessorsOf(m).flatMap(_.evidence))
-  //   links.toMap
-  // }
-  // println("Built causalSuccessors map")
-
-  // def getCausalSuccessors(m: Mention): Set[Mention] =
-  //   causalSuccessors.getOrElse(m, Set.empty[Mention])
-
-  val equivalentMentions: Map[Mention, Set[Mention]] = {
+  val equivalenceLinks: Map[Mention, Set[Equivalence]] = {
     val links = for {
       m <- mentions
       if AssemblyManager.isValidMention(m)
       eer = am.getEER(m)
       equivMentions = am.getEvidence(eer)
       // remove m from its own equivalence set
-    } yield (m, equivMentions - m)
-    links.toMap
+      e <- equivMentions - m
+    } yield Equivalence(m, e, "AssemblyManager")
+    // build map from pairs
+    links.groupBy(_.m1).mapValues(_.toSet)
   }
-  // println("Built equivalentMentions map")
 
-  def getEquivalentMentions(m: Mention): Set[Mention] =
-    equivalentMentions.getOrElse(m, Set.empty[Mention])
+  def getEquivalenceLinks(m: Mention): Set[Equivalence] =
+    equivalenceLinks.getOrElse(m, Set.empty[Equivalence])
+
 }

--- a/src/main/scala/edu/arizona/sista/assembly/AssemblyManager.scala
+++ b/src/main/scala/edu/arizona/sista/assembly/AssemblyManager.scala
@@ -129,7 +129,10 @@ class AssemblyManager(
     before: Mention,
     after: Mention,
     foundBy: String
-  ): Unit = storePrecedenceRelation(before, after, Set.empty[Mention], foundBy)
+  ): Unit = {
+    val evidence = sieves.SieveUtils.createEvidenceForCPR(before, after, foundBy)
+    storePrecedenceRelation(before, after, evidence, foundBy)
+  }
 
   /**
    * Stores a PrecedenceRelation in [[idToPrecedenceRelations]] for the EERs corresponding to "before" and "after"

--- a/src/main/scala/edu/arizona/sista/assembly/export/AssemblyLink.scala
+++ b/src/main/scala/edu/arizona/sista/assembly/export/AssemblyLink.scala
@@ -1,0 +1,14 @@
+package edu.arizona.sista.assembly.export
+
+import edu.arizona.sista.odin.Mention
+
+
+trait AssemblyLink{
+  val foundBy: String
+}
+
+case class CausalPrecedence(before: Mention, after: Mention, foundBy: String) extends AssemblyLink
+
+case class Equivalence(m1: Mention, m2: Mention, foundBy: String) extends AssemblyLink
+
+case class Subsumption(general: Mention, specific: Mention, foundBy: String) extends AssemblyLink

--- a/src/main/scala/edu/arizona/sista/reach/extern/export/fries/FriesOutput.scala
+++ b/src/main/scala/edu/arizona/sista/reach/extern/export/fries/FriesOutput.scala
@@ -643,7 +643,7 @@ class FriesOutput extends JsonOutputter {
         }
       // an unknown link
       case unknown =>
-        println(s"Cannot create link for type '${unknown.getClass}'")
+        System.err.println(s"Cannot create link for type '${unknown.getClass}'")
     }
     frames.toList
   }


### PR DESCRIPTION
## Changes 
- minor cleanup to evidence creation and storage for causal precedence links
- changes to `Assembler` and `FriesOutput` that resolve #177 (inclusion of `found-by` field in `JSON` links)  