### PR TITLE
Make ubiquitination filter more discriminative

### DIFF
--- a/src/main/scala/edu/arizona/sista/reach/DarpaActions.scala
+++ b/src/main/scala/edu/arizona/sista/reach/DarpaActions.scala
@@ -123,9 +123,9 @@ class DarpaActions extends Actions {
   def mkUbiquitination(mentions: Seq[Mention], state: State): Seq[Mention] = {
     val filteredMentions = mentions.filterNot { ev =>
       // Only keep mentions that don't have ubiquitin as a theme
-      ev.arguments("theme").exists(_.text.toLowerCase.contains("ubiq")) ||
+      ev.arguments("theme").exists(_.text.toLowerCase == "ubiquitin") ||
       // mention shouldn't have ubiquitin as a cause either, if there is a cause
-      ev.arguments.get("cause").map(_.exists(_.text.toLowerCase.contains("ubiq"))).getOrElse(false)
+      ev.arguments.get("cause").exists(_.exists(_.text.toLowerCase == "ubiquitin"))
     }
     // return biomentions
     filteredMentions.map(_.toBioMention)

--- a/src/test/scala/edu/arizona/sista/reach/TestTemplaticSimpleEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestTemplaticSimpleEvents.scala
@@ -505,4 +505,25 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
     // TODO: this fails because the *_token_8_noun rule over matches. Please fix
     hasEventWithArguments("Phosphorylation", List("p35"), mentions) should be (false)
   }
+
+  val sent35a = "E3 ubiquitin ligase ubiquitinates beta-catenin."
+  sent35a should "contain a ubiquitination with cause" in {
+    val mentions = getBioMentions(sent35a)
+    hasPositiveRegulationByEntity("E3 ubiquitin ligase", "Ubiquitination", List("beta-catenin"), mentions) should be (true)
+  }
+  val sent35b = "Beta-catenin ubiquitinates E3 ubiquitin ligase."
+  sent35b should "contain a ubiquitination with cause" in {
+    val mentions = getBioMentions(sent35b)
+    hasPositiveRegulationByEntity("Beta-catenin", "Ubiquitination", List("E3 ubiquitin ligase"), mentions) should be (true)
+  }
+  val sent35c = "Ubiquitin ubiquitinates beta-catenin."
+  sent35c should "not contain a ubiquitination" in {
+    val mentions = getBioMentions(sent35c)
+    hasPositiveRegulationByEntity("E3 ubiquitin ligase", "Ubiquitination", List("beta-catenin"), mentions) should be (false)
+  }
+  val sent35d = "Beta-catenin ubiquitinates ubiquitin."
+  sent35d should "not contain a ubiquitination" in {
+    val mentions = getBioMentions(sent35d)
+    hasPositiveRegulationByEntity("Beta-catenin", "Ubiquitination", List("E3 ubiquitin ligase"), mentions) should be (false)
+  }
 }


### PR DESCRIPTION
This request fixes issue #223 in which an entity containing the (case-insensitive) string `ubiq` was blocked from being an argument of a (regulation of a) ubiquitination. I changed the filter to only filter out cases in which the entire entity is "ubiquitin", and wrote accompanying tests.

To be clear, this does _not_ solve the problem in which `E3 ubiquitin protein` is not matched, because this is not a protein name in our dictionaries.