### PR TITLE
'is dependent on' precedence rule

### DIFF
--- a/src/main/resources/edu/arizona/sista/assembly/grammars/precedence.yml
+++ b/src/main/resources/edu/arizona/sista/assembly/grammars/precedence.yml
@@ -32,7 +32,7 @@ rules:
     label: ${mylabel}
     priority: ${deprulepriority}
     example: "BEF is ubiquitinated before the phosphorylation of AFT."
-    type: "token"
+    type: token
     pattern: |
       (?<before> ${before_type}) (before | prior to) [tag=/^(DT|CD|JJ)$/]* (?<after> ${after_type})
 
@@ -49,7 +49,7 @@ rules:
     label: ${mylabel}
     priority: ${surfacerulepriority}
     example: "AFT is ubiquitinated following the phosphorylation of BEF."
-    type: "token"
+    type: token
     pattern: |
       (?<after> ${after_type}) (after | [lemma=follow]) [tag=/^(DT|CD|JJ)$/]* (?<before> ${before_type})
 
@@ -66,7 +66,7 @@ rules:
     label: ${mylabel}
     priority: ${surfacerulepriority}
     example: "AFT is ubiquitinated due to the phosphorylation of BEF."
-    type: "token"
+    type: token
     pattern: |
       (?<after> ${after_type}) (due to | because of) [tag=/^(DT|CD|JJ)$/]* (?<before> ${before_type})
 
@@ -101,7 +101,7 @@ rules:
     label: ${mylabel}
     priority: ${surfacerulepriority}
     example: "The ubiquitination of BEF precedes the phosphorylation of AFT. The ubiquitination of BEF precipitates the phosphorylation of AFT."
-    type: "token"
+    type: token
     pattern: |
       (?<before> ${before_type}) [lemma=/^(precede|precipitat)/] [tag=/^(DT|CD|JJ)$/]* (?<after> ${after_type})
 
@@ -118,7 +118,7 @@ rules:
     label: ${mylabel}
     priority: ${surfacerulepriority}
     example: "AFT ubiquitination is a result of BEF phosphorylation."
-    type: "token"
+    type: token
     pattern: |
       (?<after> ${after_type}) [lemma=be] [tag=/^(DT|CD|JJ)$/] [lemma=result] of [tag=/^(DT|CD|JJ)$/]* (?<before> ${before_type})
 
@@ -126,7 +126,7 @@ rules:
     label: ${mylabel}
     priority: ${surfacerulepriority}
     example: "AFT ubiquitination results from BEF phosphorylation."
-    type: "token"
+    type: token
     pattern: |
       (?<after> ${after_type}) ","? [tag=RB]? [lemma=result & tag=/^VB/] from [tag=/^(DT|CD|JJ)$/]* (?<before> ${before_type})
 
@@ -143,7 +143,7 @@ rules:
     label: ${mylabel}
     priority: ${surfacerulepriority}
     example: "BEF is ubiquitinated, resulting in the phosphorylation of AFT."
-    type: "token"
+    type: token
     pattern: |
       (?<before> ${before_type}) ","? [tag=RB]? [lemma=result & tag=/^VB/] in [tag=/^(DT|CD|JJ)$/]* (?<after> ${after_type})
 
@@ -177,7 +177,7 @@ rules:
     label: ${mylabel}
     priority: ${surfacerulepriority}
     example: "The RBD of PI3KC2B binds HRAS , when HRAS is not bound to GTP . AFT binds HRAS, when BEF in not bound to GTP"
-    type: "token"
+    type: token
     pattern: |
       (?<before> ${before_type}) ","? when (?<after> ${after_type})
 
@@ -203,10 +203,26 @@ rules:
     priority: ${deprulepriority}
     example: "the ubiquitination of BEF is required for the phosphorylation of AFT.  The binding of p85 and Gab1 is required for Gab1 mediated activation of PI-3 kinase."
     pattern: |
-      before:${after_type}
+      before:${before_type}
       # describes a precondition
       # ... is required for AFT
-      after:${before_type} = <nsubjpass [lemma=require] prep_for
+      after:${after_type} = <nsubjpass [lemma=require] prep_for
+
+  - name: assembly-syntax-dependent-on
+    label: DirectConnection
+    priority: ${deprulepriority}
+    example: "Together these data demonstrate that E2-induced SRC-3 phosphorylation is dependent on a direct interaction between SRC-3 and ERα and can occur outside of the nucleus."
+    pattern: |
+      after:${after_type}
+      before:${before_type} = <nsubj dependent prep_on
+
+  - name: assembly-surface-dependent-on
+    label: DirectConnection
+    priority: ${surfacerulepriority}
+    example: "Together these data demonstrate that E2-induced SRC-3 phosphorylation is dependent on a direct interaction between SRC-3 and ERα and can occur outside of the nucleus."
+    type: token
+    pattern: |
+      @after:${after_type} [lemma=be] dependent on [tag=/^(DT|CD|JJ)/]* @before:${before_type}
 
   ############################
   # Surface rules

--- a/src/test/scala/edu/arizona/sista/assembly/TestAssemblyManager.scala
+++ b/src/test/scala/edu/arizona/sista/assembly/TestAssemblyManager.scala
@@ -1,6 +1,5 @@
 package edu.arizona.sista.assembly
 
-import edu.arizona.sista.assembly.AssemblyRunner._
 import edu.arizona.sista.assembly.representations.SimpleEntity
 import edu.arizona.sista.processors.Document
 import edu.arizona.sista.reach.TestUtils._
@@ -8,13 +7,6 @@ import org.scalatest.{Matchers, FlatSpec}
 
 
 class TestAssemblyManager extends FlatSpec with Matchers {
-
-  def createDoc(text: String, id: String): Document = {
-    val doc = bioproc.annotate(text)
-    doc.id = Some(id)
-    doc.text = Some(text)
-    doc
-  }
 
   val text1 = "Ras is phosphorylated."
   val text2 = "Ras was phosphorylated."
@@ -421,134 +413,4 @@ class TestAssemblyManager extends FlatSpec with Matchers {
     hasEquivalentEERs(am1, am3) should be(true)
     hasEquivalentEERs(am2, am3) should be(true)
   }
-
-  // Sieve tests
-
-  val tamSent1 = "Once BEF had been phosphorylated, AFT was ubiquitinated"
-
-  tamSent1 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(tamSent1, "tam1-test")
-    val mentions = testReach.extractFrom(doc)
-    val am = applySieves(mentions)
-
-    val uRep = am.distinctSimpleEvents("Ubiquitination").head
-    val pRep = am.distinctSimpleEvents("Phosphorylation").head
-
-    am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
-  }
-
-  val tamSent2 = "AFT will be ubiquitinated only if BEF is first phosphorylated"
-
-  tamSent2 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(tamSent2, "tam2-test")
-    val mentions = testReach.extractFrom(doc)
-    val am = applySieves(mentions)
-
-    val uRep = am.distinctSimpleEvents("Ubiquitination").head
-    val pRep = am.distinctSimpleEvents("Phosphorylation").head
-
-    am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
-  }
-
-  val tamSent3 = "AFT was ubiquitinated when BEF had been phosphorylated"
-
-  tamSent3 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(tamSent3, "tam3-test")
-    val mentions = testReach.extractFrom(doc)
-    val am = applySieves(mentions)
-
-    val uRep = am.distinctSimpleEvents("Ubiquitination").head
-    val pRep = am.distinctSimpleEvents("Phosphorylation").head
-
-    am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
-  }
-
-  val interSent1 = "BEF was phosphorylated. Then, AFT was ubiquitinated."
-
-  interSent1 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(interSent1, "inter1-test")
-    val mentions = testReach.extractFrom(doc)
-    val am = applySieves(mentions)
-
-    val uRep = am.distinctSimpleEvents("Ubiquitination").head
-    val pRep = am.distinctSimpleEvents("Phosphorylation").head
-
-    am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
-  }
-
-  val interSent2 = "BEF was phosphorylated. Subsequently AFT was ubiquitinated."
-
-  interSent2 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(interSent2, "inter2-test")
-    val mentions = testReach.extractFrom(doc)
-    val am = applySieves(mentions)
-
-    val uRep = am.distinctSimpleEvents("Ubiquitination").head
-    val pRep = am.distinctSimpleEvents("Phosphorylation").head
-
-    am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
-  }
-
-  val interSent3 = "AFT was ubiquitinated. Prior to this, BEF was phosphorylated."
-
-  interSent3 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(interSent3, "inter3-test")
-    val mentions = testReach.extractFrom(doc)
-    val am = applySieves(mentions)
-
-    val uRep = am.distinctSimpleEvents("Ubiquitination").head
-    val pRep = am.distinctSimpleEvents("Phosphorylation").head
-
-    am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
-  }
-
-  val interSent4 = "AFT was ubiquitinated. Previously, BEF was phosphorylated."
-
-  interSent4 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(interSent4, "inter4-test")
-    val mentions = testReach.extractFrom(doc)
-    val am = applySieves(mentions)
-
-    val uRep = am.distinctSimpleEvents("Ubiquitination").head
-    val pRep = am.distinctSimpleEvents("Phosphorylation").head
-
-    am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
-  }
-
-
-  // Play it safe by ignoring cues not at the beginning of the sentence.
-  val interSent5 = "AFT was ubiquitinated. There is intervening material and, previously, BEF was phosphorylated."
-
-  interSent5 should "have no precedence relations" in {
-    val doc = createDoc(interSent5, "inter5-test")
-    val mentions = testReach.extractFrom(doc)
-    val am = applySieves(mentions)
-
-    val uRep = am.distinctSimpleEvents("Ubiquitination").head
-    val pRep = am.distinctSimpleEvents("Phosphorylation").head
-
-    am.distinctPredecessorsOf(uRep).size should be(0)
-  }
-
 }

--- a/src/test/scala/edu/arizona/sista/assembly/TestAssemblySieves.scala
+++ b/src/test/scala/edu/arizona/sista/assembly/TestAssemblySieves.scala
@@ -1,0 +1,159 @@
+package edu.arizona.sista.assembly
+
+import edu.arizona.sista.assembly.AssemblyRunner._
+import edu.arizona.sista.reach.TestUtils._
+import org.scalatest.{Matchers, FlatSpec}
+
+
+/**
+  * Created by dane on 6/9/16.
+  */
+class TestAssemblySieves extends FlatSpec with Matchers {
+  val intraSent1 = "Together these data demonstrate that E2-induced SRC-3 phosphorylation is dependent on a direct " +
+    "interaction between SRC-3 and ERα and can occur outside of the nucleus."
+
+  intraSent1 should "be annotated with the binding preceding the phosphorylation" in {
+    val doc = createDoc(intraSent1, "intra1-test")
+    val mentions = testReach.extractFrom(doc)
+    val am = applySieves(mentions)
+
+    val bRep = am.distinctSimpleEvents("Binding").head
+    val pRep = am.distinctRegulations(AssemblyManager.positive).head
+
+    am.distinctPredecessorsOf(pRep).size should be(1)
+    val pr = am.getPrecedenceRelations(pRep).head
+    pr.before == bRep.equivalenceHash should be (true)
+    pr.after == pRep.equivalenceHash should be (true)
+
+  }
+
+  // Sieve tests
+
+  val tamSent1 = "Once BEF had been phosphorylated, AFT was ubiquitinated"
+
+  tamSent1 should "be annotated with the phosphorylation preceding the ubiquitination" in {
+    val doc = createDoc(tamSent1, "tam1-test")
+    val mentions = testReach.extractFrom(doc)
+    val am = applySieves(mentions)
+
+    val uRep = am.distinctSimpleEvents("Ubiquitination").head
+    val pRep = am.distinctSimpleEvents("Phosphorylation").head
+
+    am.distinctPredecessorsOf(uRep).size should be(1)
+    val pr = am.getPrecedenceRelations(uRep).head
+    pr.before == pRep.equivalenceHash should be (true)
+    pr.after == uRep.equivalenceHash should be (true)
+  }
+
+  val tamSent2 = "AFT will be ubiquitinated only if BEF is first phosphorylated"
+
+  tamSent2 should "be annotated with the phosphorylation preceding the ubiquitination" in {
+    val doc = createDoc(tamSent2, "tam2-test")
+    val mentions = testReach.extractFrom(doc)
+    val am = applySieves(mentions)
+
+    val uRep = am.distinctSimpleEvents("Ubiquitination").head
+    val pRep = am.distinctSimpleEvents("Phosphorylation").head
+
+    am.distinctPredecessorsOf(uRep).size should be(1)
+    val pr = am.getPrecedenceRelations(uRep).head
+    pr.before == pRep.equivalenceHash should be (true)
+    pr.after == uRep.equivalenceHash should be (true)
+  }
+
+  val tamSent3 = "AFT was ubiquitinated when BEF had been phosphorylated"
+
+  tamSent3 should "be annotated with the phosphorylation preceding the ubiquitination" in {
+    val doc = createDoc(tamSent3, "tam3-test")
+    val mentions = testReach.extractFrom(doc)
+    val am = applySieves(mentions)
+
+    val uRep = am.distinctSimpleEvents("Ubiquitination").head
+    val pRep = am.distinctSimpleEvents("Phosphorylation").head
+
+    am.distinctPredecessorsOf(uRep).size should be(1)
+    val pr = am.getPrecedenceRelations(uRep).head
+    pr.before == pRep.equivalenceHash should be (true)
+    pr.after == uRep.equivalenceHash should be (true)
+  }
+
+  val interSent1 = "BEF was phosphorylated. Then, AFT was ubiquitinated."
+
+  interSent1 should "be annotated with the phosphorylation preceding the ubiquitination" in {
+    val doc = createDoc(interSent1, "inter1-test")
+    val mentions = testReach.extractFrom(doc)
+    val am = applySieves(mentions)
+
+    val uRep = am.distinctSimpleEvents("Ubiquitination").head
+    val pRep = am.distinctSimpleEvents("Phosphorylation").head
+
+    am.distinctPredecessorsOf(uRep).size should be(1)
+    val pr = am.getPrecedenceRelations(uRep).head
+    pr.before == pRep.equivalenceHash should be (true)
+    pr.after == uRep.equivalenceHash should be (true)
+  }
+
+  val interSent2 = "BEF was phosphorylated. Subsequently AFT was ubiquitinated."
+
+  interSent2 should "be annotated with the phosphorylation preceding the ubiquitination" in {
+    val doc = createDoc(interSent2, "inter2-test")
+    val mentions = testReach.extractFrom(doc)
+    val am = applySieves(mentions)
+
+    val uRep = am.distinctSimpleEvents("Ubiquitination").head
+    val pRep = am.distinctSimpleEvents("Phosphorylation").head
+
+    am.distinctPredecessorsOf(uRep).size should be(1)
+    val pr = am.getPrecedenceRelations(uRep).head
+    pr.before == pRep.equivalenceHash should be (true)
+    pr.after == uRep.equivalenceHash should be (true)
+  }
+
+  val interSent3 = "AFT was ubiquitinated. Prior to this, BEF was phosphorylated."
+
+  interSent3 should "be annotated with the phosphorylation preceding the ubiquitination" in {
+    val doc = createDoc(interSent3, "inter3-test")
+    val mentions = testReach.extractFrom(doc)
+    val am = applySieves(mentions)
+
+    val uRep = am.distinctSimpleEvents("Ubiquitination").head
+    val pRep = am.distinctSimpleEvents("Phosphorylation").head
+
+    am.distinctPredecessorsOf(uRep).size should be(1)
+    val pr = am.getPrecedenceRelations(uRep).head
+    pr.before == pRep.equivalenceHash should be (true)
+    pr.after == uRep.equivalenceHash should be (true)
+  }
+
+  val interSent4 = "AFT was ubiquitinated. Previously, BEF was phosphorylated."
+
+  interSent4 should "be annotated with the phosphorylation preceding the ubiquitination" in {
+    val doc = createDoc(interSent4, "inter4-test")
+    val mentions = testReach.extractFrom(doc)
+    val am = applySieves(mentions)
+
+    val uRep = am.distinctSimpleEvents("Ubiquitination").head
+    val pRep = am.distinctSimpleEvents("Phosphorylation").head
+
+    am.distinctPredecessorsOf(uRep).size should be(1)
+    val pr = am.getPrecedenceRelations(uRep).head
+    pr.before == pRep.equivalenceHash should be (true)
+    pr.after == uRep.equivalenceHash should be (true)
+  }
+
+
+  // Play it safe by ignoring cues not at the beginning of the sentence.
+  val interSent5 = "AFT was ubiquitinated. There is intervening material and, previously, BEF was phosphorylated."
+
+  interSent5 should "have no precedence relations" in {
+    val doc = createDoc(interSent5, "inter5-test")
+    val mentions = testReach.extractFrom(doc)
+    val am = applySieves(mentions)
+
+    val uRep = am.distinctSimpleEvents("Ubiquitination").head
+    val pRep = am.distinctSimpleEvents("Phosphorylation").head
+
+    am.distinctPredecessorsOf(uRep).size should be(0)
+  }
+
+}

--- a/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
@@ -43,6 +43,14 @@ object TestUtils {
   val chunkId = "1"
   val mentionManager = new MentionManager()
 
+  // For use in Assembly tests.
+  def createDoc(text: String, id: String): Document = {
+    val doc = bioproc.annotate(text)
+    doc.id = Some(id)
+    doc.text = Some(text)
+    doc
+  }
+
   def getBioMentions(text:String, verbose:Boolean = false):Seq[BioMention] = {
     val entry = FriesEntry(docId, chunkId, "example", "example", isTitle = false, text)
     val result = Try(testReach.extractFrom(entry))


### PR DESCRIPTION
This commit closes #186 by handling the construction "EventA is dependent on the EventB" with both dependency and surface rules. I took the liberty of reorganizing our assembly test files as well.