### PR TITLE
Resolves #199

### DIFF
--- a/src/main/resources/edu/arizona/sista/reach/biogrammar/events_master.yml
+++ b/src/main/resources/edu/arizona/sista/reach/biogrammar/events_master.yml
@@ -238,8 +238,8 @@ rules:
       ruleType: "regulation"
       triggers: "acceler|accept|accumul|action|activat|aid|allow|associ|augment|cataly|caus|cleav|confer|contribut|convert|direct|driv|elev|elicit|enabl|enhanc|escort|export|gener|high|increas|induc|induct|initi|interact|interconvert|involv|lead|led|major|mediat|modul|necess|overexpress|potent|proce|produc|prolong|promot|rais|reactivat|re-express|releas|render|requir|rescu|respons|restor|result|retent|signal|stimul|support|synerg|synthes|target|trigger|underli|up-regul|upregul"
       actionFlow: "mkRegulation"
-      priority: "7"
-      controlledType: "SimpleEvent"
+      priority: "7-8"
+      controlledType: "Event"
       controllerType: "PossibleController"
 
   # Negative Regulation
@@ -249,8 +249,8 @@ rules:
       ruleType: "regulation"
       triggers: "abolish|abrog|absenc|antagon|arrest|attenu|block|blunt|deactiv|decreas|defect|defici|degrad|delay|deplet|deregul|diminish|disengag|disrupt|down|down-reg|downreg|drop|dysregul|elimin|impair|imped|inactiv|inhibit|interf|knockdown|lack|limit|loss|lost|lower|negat|neutral|nullifi|oppos|overc|perturb|prevent|reduc|reliev|remov|repress|resist|restrict|revers|shutdown|slow|starv|suppress|supress|uncoupl"
       actionFlow: "mkRegulation"
-      priority: "7"
-      controlledType: "SimpleEvent"
+      priority: "7-8"
+      controlledType: "Event"
       controllerType: "PossibleController"
 
   # Positive Activation
@@ -260,7 +260,7 @@ rules:
       ruleType: "activation"
       triggers: "acceler|activat|aid|allow|augment|direct|elev|elicit|enabl|enhanc|increas|induc|initi|modul|necess|overexpress|potenti|produc|prolong|promot|rais|reactivat|rescu|respons|restor|re-express|retent|sequest|signal|stimul|support|synerg|synthes|trigger|up-regul|upregul"
       actionFlow: "mkActivation"
-      priority: "8" # must be 1 + priority of regulations!
+      priority: "9" # must be 1 + priority of regulations!
       controlledType: "BioEntity"
       controllerType: "PossibleController"
 
@@ -271,6 +271,6 @@ rules:
       ruleType: "activation"
       triggers: "attenu|block|deactiv|decreas|degrad|diminish|disrupt|impair|imped|inhibit|knockdown|limit|lower|negat|reduc|reliev|repress|restrict|revers|slow|starv|suppress|supress"
       actionFlow: "mkActivation"
-      priority: "8" # must be 1 + priority of regulations!
+      priority: "9" # must be 1 + priority of regulations!
       controlledType: "BioEntity"
       controllerType: "PossibleController"

--- a/src/main/scala/edu/arizona/sista/assembly/AssemblyManager.scala
+++ b/src/main/scala/edu/arizona/sista/assembly/AssemblyManager.scala
@@ -1056,7 +1056,7 @@ class AssemblyManager(
     // mention's polarity should be either positive or negative
     require(polarity == AssemblyManager.positive || polarity == AssemblyManager.negative, "Polarity of Regulation must be positive or negative")
     // all controlled args must be simple events
-    require(reg.arguments("controlled").forall(_ matches "SimpleEvent"), "The 'controlled' of any Regulation must be a SimpleEvent")
+    require(reg.arguments("controlled").forall(_ matches "Event"), "The 'controlled' of any Regulation must be an Event")
 
     val controllers: Set[IDPointer] = {
       reg.arguments("controller")

--- a/src/main/scala/edu/arizona/sista/coref/CorefUtils.scala
+++ b/src/main/scala/edu/arizona/sista/coref/CorefUtils.scala
@@ -42,7 +42,7 @@ object CorefUtils {
 
   /**
    * Is the mention generic, e.g. "it", or does it have an argument containing a generic mention,
-   * e.g. "It is phophorylated"?
+   * e.g. "It is phosphorylated"?
    */
   def genericInside (m: CorefMention): Boolean = {
     @tailrec def genericInsideRec(ms: Seq[CorefMention]): Boolean = {
@@ -57,7 +57,7 @@ object CorefUtils {
   }
 
   /**
-   * Are the arguments for this mention complete? Phophorylations require a theme, etc.
+   * Are the arguments for this mention complete? Phosphorylations require a theme, etc.
    */
   def argsComplete(args: Map[String,Seq[CorefMention]], lbls: Seq[String]): Boolean = {
     lbls match {

--- a/src/main/scala/edu/arizona/sista/reach/DarpaActions.scala
+++ b/src/main/scala/edu/arizona/sista/reach/DarpaActions.scala
@@ -498,7 +498,7 @@ class DarpaActions extends Actions {
 
 
   /** Test whether the given mention has a controller argument. */
-  def hasController(mention: Mention): Boolean = mention.arguments.get("controlled").isDefined
+  def hasController(mention: Mention): Boolean = mention.arguments.get("controller").isDefined
 
   /** Gets a mention and checks that the controller and controlled are different.
     * Returns true if either the controller or the controlled is missing,

--- a/src/main/scala/edu/arizona/sista/reach/DarpaActions.scala
+++ b/src/main/scala/edu/arizona/sista/reach/DarpaActions.scala
@@ -371,8 +371,9 @@ class DarpaActions extends Actions {
 
   /** global action for EventEngine */
   def cleanupEvents(mentions: Seq[Mention], state: State): Seq[Mention] = {
-    val r0 = filterEventsWithExtraRecursion(mentions, state)
-    val r1 = siteSniffer(r0, state)
+    // Regulations of regulations now allowed.
+    // val r0 = filterEventsWithExtraRecursion(mentions, state)
+    val r1 = siteSniffer(mentions, state)
     val r2 = keepIfValidArgs(r1, state)
     val r3 = NegationHandler.detectNegations(r2, state)
     val r4 = HypothesisHandler.detectHypotheses(r3, state)
@@ -585,11 +586,16 @@ class DarpaActions extends Actions {
   /** sorts a sequence of Mentions so that mentions with event controllers appear first */
   def sortMentionsByController(mentions: Seq[Mention]): Seq[Mention] = mentions sortWith { (m1, m2) =>
     // get the controller of the first mention
-    val ctrl1 = m1.arguments.get("controller")
-    val ctrl2 = m2.arguments.get("controller")
-    (ctrl1, ctrl2) match {
-      case (Some(Seq(c1)), Some(Seq(c2))) if c1.matches("Event") && !c2.matches("Event") => true
-      case (Some(Seq(c1)), None) => true
+    val ctrlr1 = m1.arguments.get("controller")
+    val ctrlr2 = m2.arguments.get("controller")
+    val ctrld1 = m1.arguments.get("controlled").get.head
+    val ctrld2 = m2.arguments.get("controlled").get.head
+    (ctrlr1, ctrlr2, ctrld1, ctrld2) match {
+      case (Some(Seq(cr1)), Some(Seq(cr2)), cd1, cd2)
+        if cr1.matches("Event") && !cr2.matches("Event") => true
+      case (Some(Seq(cr1)), Some(Seq(cr2)), cd1, cd2)
+        if !(!cr1.matches("Event") && cr2.matches("Event")) && cd1.matches("Regulation") && !cd2.matches("Regulation") => true
+      case (Some(Seq(cr1)), None, cd1, cd2) => true
       case _ => false
     }
   }

--- a/src/main/scala/edu/arizona/sista/reach/MentionFilter.scala
+++ b/src/main/scala/edu/arizona/sista/reach/MentionFilter.scala
@@ -44,82 +44,87 @@ object MentionFilter {
     var toRemove = mutable.Set[Mention]()
     // Check each Regulation to see if there are any "more complete" Mentions
     // for the controlled available in the state
-    val correctedRegulations =
-      for {reg <- regulations
-           // it should only ever have ONE controlled
-           controlled = reg
-             .arguments("controlled")
-             .head
-             // treat it as a CorefEventMention to simplify filtering
-             .toCorefMention.asInstanceOf[CorefEventMention]
-           // how many args does the controlled Mention have?
-           argCount = controlled.antecedentOrElse(controlled).arguments.size
-      } yield {
-        // Are there any "more complete" SimpleEvents in the State
-        // that are candidates to replace the current "controlled" arg?
-        val replacementCandidates: Seq[BioEventMention] =
-          state.mentionsFor(reg.sentence, controlled.tokenInterval, controlled.label)
+    val correctedRegulations = for {
+      reg <- regulations
+      // it should only ever have ONE controlled
+      controlled = reg
+        .arguments("controlled")
+        .head
+        // treat it as a CorefEventMention to simplify filtering
+        //.toCorefMention.asInstanceOf[CorefEventMention]
+        .toCorefMention
+      // how many args does the controlled Mention have?
+      argCount = controlled.antecedentOrElse(controlled).arguments.size
+    } yield {
+      // Are there any "more complete" SimpleEvents in the State
+      // that are candidates to replace the current "controlled" arg?
+      val replacementCandidates: Seq[CorefMention] = controlled match {
+        case rel if rel.isInstanceOf[CorefRelationMention] => Nil
+        case ev => state.mentionsFor(reg.sentence, controlled.tokenInterval, controlled.label)
             // If the label is the same, these MUST be CorefEventMentions (i.e SimpleEvents)
-            .map(_.toCorefMention.asInstanceOf[CorefEventMention])
+            //.map(_.toCorefMention.asInstanceOf[CorefEventMention])
+            .map(_.toCorefMention)
             .filter(m =>
-            m.antecedentOrElse(m).arguments.size > argCount &&
-              (m.trigger == controlled.trigger))
-        // Do we have any "more complete" Mentions to substitute for the controlled?
-        replacementCandidates match {
-          // Use the current reg, since there aren't any "more complete"
-          // candidate Mentions for the controlled
-          case Nil => Seq(reg)
-          // There are some more complete candidates for the controlled arg...
-          case candidates =>
-            // For each "more complete" SimpleEvent, create a new Regulation...
-            for (r <- candidates) yield {
-              reg.toCorefMention match {
-                // Is the reg we're replacing a BioRelationMention?
-                case relReg: CorefRelationMention =>
-                  val updatedArgs = relReg.arguments updated("controlled", Seq(r))
-                  val junk = relReg.arguments("controlled").head.toCorefMention
-                  // Keep track of what we need to get rid of...
-                  toRemove += junk
-                  // Create the "more complete" BioRelationMentions
-                  val moreCompleteReg =
-                    new CorefRelationMention(
-                      relReg.labels,
-                      updatedArgs,
-                      relReg.sentence,
-                      relReg.document,
-                      relReg.keep,
-                      relReg.foundBy)
-                  // Move Negation modifications from controlled to Reg.
-                  //promoteNegationModifications(moreCompleteReg, r)
-                  // return the new Regulation
-                  moreCompleteReg
-                // Is the Regulation we're replacing a BioEventMention?
-                case eventReg: CorefEventMention =>
-                  val updatedArgs = eventReg.arguments updated("controlled", Seq(r))
-                  val junk = eventReg.arguments("controlled").head.toCorefMention
-                  // Keep track of what we need to get rid of...
-                  toRemove += junk
-                  // Create the "more complete" BioEventMentions
-                  val moreCompleteReg =
-                    new CorefEventMention(
-                      eventReg.labels,
-                      eventReg.trigger,
-                      updatedArgs,
-                      eventReg.sentence,
-                      eventReg.document,
-                      eventReg.keep,
-                      eventReg.foundBy,
-                      eventReg.isDirect)
-                  // Move Negation modifications from controlled to Reg.
-                  //promoteNegationModifications(eventReg, r)
-                  // return the new Regulation
-                  moreCompleteReg
-              }
-            }
-        }
+              m.isInstanceOf[CorefEventMention] &&
+              m.antecedentOrElse(m).arguments.size > argCount &&
+                (m.asInstanceOf[CorefEventMention].trigger == ev.asInstanceOf[CorefEventMention].trigger))
       }
+      // Do we have any "more complete" Mentions to substitute for the controlled?
+      replacementCandidates match {
+        // Use the current reg, since there aren't any "more complete"
+        // candidate Mentions for the controlled
+        case Nil => Seq(reg)
+        // There are some more complete candidates for the controlled arg...
+        case candidates =>
+          // For each "more complete" SimpleEvent, create a new Regulation...
+          for (r <- candidates) yield {
+            reg.toCorefMention match {
+              // Is the reg we're replacing a BioRelationMention?
+              case relReg: CorefRelationMention =>
+                val updatedArgs = relReg.arguments updated("controlled", Seq(r))
+                val junk = relReg.arguments("controlled").head.toCorefMention
+                // Keep track of what we need to get rid of...
+                toRemove += junk
+                // Create the "more complete" BioRelationMentions
+                val moreCompleteReg =
+                  new CorefRelationMention(
+                    relReg.labels,
+                    updatedArgs,
+                    relReg.sentence,
+                    relReg.document,
+                    relReg.keep,
+                    relReg.foundBy)
+                // Move Negation modifications from controlled to Reg.
+                //promoteNegationModifications(moreCompleteReg, r)
+                // return the new Regulation
+                moreCompleteReg
+              // Is the Regulation we're replacing a BioEventMention?
+              case eventReg: CorefEventMention =>
+                val updatedArgs = eventReg.arguments updated("controlled", Seq(r))
+                val junk = eventReg.arguments("controlled").head.toCorefMention
+                // Keep track of what we need to get rid of...
+                toRemove += junk
+                // Create the "more complete" BioEventMentions
+                val moreCompleteReg =
+                  new CorefEventMention(
+                    eventReg.labels,
+                    eventReg.trigger,
+                    updatedArgs,
+                    eventReg.sentence,
+                    eventReg.document,
+                    eventReg.keep,
+                    eventReg.foundBy,
+                    eventReg.isDirect)
+                // Move Negation modifications from controlled to Reg.
+                //promoteNegationModifications(eventReg, r)
+                // return the new Regulation
+                moreCompleteReg
+            }
+          }
+      }
+    }
 
-    def filterByController(regulations: Seq[BioMention]): Seq[CorefMention] = {
+    def filterByController(regulations: Seq[CorefMention]): Seq[CorefMention] = {
       // collect all regulation events with a Complex controller
       val regulationsWithComplexController = regulations.filter { m =>
         m.arguments.contains("controller") && m.arguments("controller").head.matches("Complex")
@@ -140,10 +145,30 @@ object MentionFilter {
           }
         }
       }
-      (regulationsWithComplexController ++ remainingRegulations).map(_.toCorefMention)
+      regulationsWithComplexController ++ remainingRegulations
     }
-    val correctedRegs = correctedRegulations
-      .flatten
+
+    def filterByControlled(regulations: Seq[BioMention]): Seq[CorefMention] = {
+      val highestOrder = for {
+        r <- regulations.map(_.toCorefMention)
+      } yield {
+        val isRedundant = regulations.exists{ m =>
+          val mctrld = m.arguments("controlled").head
+          ((m.isInstanceOf[CorefRelationMention] && r.isInstanceOf[CorefRelationMention]) || (
+            m.isInstanceOf[CorefEventMention] && r.isInstanceOf[CorefEventMention] &&
+            m.asInstanceOf[CorefEventMention].trigger == r.asInstanceOf[CorefEventMention].trigger)) &&
+            m.arguments("controller") == r.arguments("controller") &&
+            mctrld.matches("Regulation") &&
+            mctrld.arguments("controlled") == r.arguments("controlled")
+        }
+        if (isRedundant) None else Some(r)
+      }
+      highestOrder.flatten
+    }
+
+
+    val correctedRegs = filterByControlled(correctedRegulations
+      .flatten)
       .groupBy(_.arguments("controlled"))
       .values
       .map(filterByController)

--- a/src/main/scala/edu/arizona/sista/reach/PaperReader.scala
+++ b/src/main/scala/edu/arizona/sista/reach/PaperReader.scala
@@ -89,6 +89,11 @@ object PaperReader {
   }
 
   /**
+   * Get mentions from text
+   */
+  def getMentionsFromText(text: String): Seq[Mention] = rs.extractFrom(text, "", "")
+
+  /**
    * Produces FriesEntries from .csv papers using [[CSVParser]] and [[ReachSystem]]
    * @param file a File with the .csv extension
    * @return Seq[FriesEntry]

--- a/src/main/scala/edu/arizona/sista/reach/extern/export/fries/FriesOutput.scala
+++ b/src/main/scala/edu/arizona/sista/reach/extern/export/fries/FriesOutput.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable.ListBuffer
 /**
   * Defines classes and methods used to build and output the FRIES format.
   *   Written by Mihai Surdeanu. 5/22/2015.
-  *   Last Modified: Change argument-label tag to type per Hans schema.
+  *   Last Modified: Update to allow regulations of regulations, 2-deep.
   */
 class FriesOutput extends JsonOutputter {
   // local type definitions:
@@ -257,6 +257,13 @@ class FriesOutput extends JsonOutputter {
     // now, print all regulation events, which control the above events
     for (mention <- eventMentions) {
       if (REGULATION_EVENTS.contains(mention.label)) {
+        // "reach down" to process any child regulations first, before processing current regulation
+        val regulations = mention.arguments.getOrElse("controlled", Nil).filter(_.matches("Regulation"))
+        for (reg <- regulations) {
+          val passage = getPassageForMention(passageMap, reg)
+          frames ++= mkEventMention(paperId, passage, reg.toBioMention, contextIdMap, entityMap, eventMap)
+        }
+        // process current regulation
         val passage = getPassageForMention(passageMap, mention)
         frames ++= mkEventMention(paperId, passage, mention.toBioMention, contextIdMap, entityMap, eventMap)
       }

--- a/src/test/scala/edu/arizona/sista/assembly/TestAssemblyManager.scala
+++ b/src/test/scala/edu/arizona/sista/assembly/TestAssemblyManager.scala
@@ -17,23 +17,14 @@ class TestAssemblyManager extends FlatSpec with Matchers {
   val text7 = "ASPP2 is transported from the membrane to the nucleus and cytosol"
 
   // the assembly manager is not intimidated by multiple documents
-  val doc1 = createDoc(text1, "assembly-test1")
-  val doc2 = createDoc(text2, "assembly-test2")
-  val doc3 = createDoc(text3, "assembly-test3")
-  val doc4 = createDoc(text4, "assembly-test4")
-  val doc5 = createDoc(text5, "assembly-test5")
-  val doc6 = createDoc(text6, "assembly-test6")
+  val mentions1 = getMentionsFromText(text1)
+  val mentions2 = getMentionsFromText(text2)
+  val mentions3 = getMentionsFromText(text3)
+  val mentions4 = getMentionsFromText(text4)
+  val mentions5 = getMentionsFromText(text5)
+  val mentions6 = getMentionsFromText(text6)
   // translocations
-  val doc7 = createDoc(text7, "assembly-test7")
-
-  val mentions1 = testReach.extractFrom(doc1)
-  val mentions2 = testReach.extractFrom(doc2)
-  val mentions3 = testReach.extractFrom(doc3)
-  val mentions4 = testReach.extractFrom(doc4)
-  val mentions5 = testReach.extractFrom(doc5)
-  val mentions6 = testReach.extractFrom(doc6)
-  // translocations
-  val mentions7 = testReach.extractFrom(doc7)
+  val mentions7 = getMentionsFromText(text7)
 
   //
   // SimpleEntity tests
@@ -189,9 +180,7 @@ class TestAssemblyManager extends FlatSpec with Matchers {
   val dePhos = "Mek was dephosphorylated."
   dePhos should "produce a Dephosphorylation event with a Phosphorylation on the input" in {
 
-    val doc = createDoc(dePhos, "assembly-test")
-
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(dePhos)
 
     val am = AssemblyManager(mentions)
 
@@ -251,8 +240,6 @@ class TestAssemblyManager extends FlatSpec with Matchers {
     regs.count(r => r.controlled.head.isInstanceOf[Regulation]) should be(1)
   }
 
-
-
   //
   // Negation tests
   //
@@ -260,9 +247,7 @@ class TestAssemblyManager extends FlatSpec with Matchers {
   val negPhos = "Mek was not phosphorylated."
   negPhos should "have a negated SimpleEvent representation for the Phosphorylation mention" in {
 
-    val doc = createDoc(negPhos, "assembly-test")
-
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(negPhos)
 
     val am = AssemblyManager(mentions)
 
@@ -276,9 +261,7 @@ class TestAssemblyManager extends FlatSpec with Matchers {
   val negReg = "Mek was not phosphorylated by Ras."
   negReg should "have a negated Regulation representation" in {
 
-    val doc = createDoc(negReg, "assembly-test")
-
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(negReg)
 
     val am = AssemblyManager()
 
@@ -292,9 +275,8 @@ class TestAssemblyManager extends FlatSpec with Matchers {
   }
 
   it should "not have a negated SimpleEvent representation for the Phosphorylation" in {
-    val doc = createDoc(negReg, "assembly-test")
 
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(negReg)
 
     val am = AssemblyManager()
 
@@ -310,9 +292,8 @@ class TestAssemblyManager extends FlatSpec with Matchers {
   // test PrecedenceRelations
 
   it should "not have any precedence relations for the phosphorylation" in {
-    val doc = createDoc(negPhos, "assembly-test")
 
-    val mentions = testReach.extractFrom(doc)
+    val mentions =  getMentionsFromText(negReg)
 
     val am = AssemblyManager()
 
@@ -339,9 +320,7 @@ class TestAssemblyManager extends FlatSpec with Matchers {
 
   precedenceText should "have a PrecedenceRelation showing the Phosphorylation following the Binding" in {
 
-    val doc = createDoc(precedenceText, "assembly-test")
-
-    val mentions = testReach.extractFrom(doc)
+    val mentions =  getMentionsFromText(precedenceText)
 
     val am = AssemblyManager()
 
@@ -403,9 +382,8 @@ class TestAssemblyManager extends FlatSpec with Matchers {
   }
 
   "AssemblyManager" should s"not contain any EERs for '$negPhos' if all EERs referencing Mek are removed" in {
-    val doc = createDoc(negPhos, "assembly-test")
 
-    val mentions = testReach.extractFrom(doc)
+    val mentions =  getMentionsFromText(negPhos)
 
     val am = AssemblyManager()
 
@@ -420,8 +398,7 @@ class TestAssemblyManager extends FlatSpec with Matchers {
 
   it should "safely handle mentions in any order" in {
     val text = "EHT1864 inhibited AKT phosphorylation induced by LPA and S1P, but not EGF or PDGF"
-    val doc = createDoc(text, "mention-order-test")
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(text)
 
     val am1 = AssemblyManager(mentions)
     val am2 = AssemblyManager(mentions.sortBy(_.label))

--- a/src/test/scala/edu/arizona/sista/assembly/TestAssemblyManager.scala
+++ b/src/test/scala/edu/arizona/sista/assembly/TestAssemblyManager.scala
@@ -1,7 +1,7 @@
 package edu.arizona.sista.assembly
 
 import edu.arizona.sista.assembly.AssemblyRunner._
-import edu.arizona.sista.assembly.representations.SimpleEntity
+import edu.arizona.sista.assembly.representations.{Regulation, SimpleEntity}
 import edu.arizona.sista.processors.Document
 import edu.arizona.sista.reach.TestUtils._
 import org.scalatest.{Matchers, FlatSpec}
@@ -121,7 +121,10 @@ class TestAssemblyManager extends FlatSpec with Matchers {
     ptm.site.isDefined should be(true)
   }
 
-  // test Translocations
+  //
+  // Translocation tests
+  //
+
   s"$text7" should "contain 2 Translocation events" in {
     val am = AssemblyManager(mentions7)
 
@@ -226,6 +229,38 @@ class TestAssemblyManager extends FlatSpec with Matchers {
     val phosOutputPTMs = outputTheme.getPTMs("Phosphorylation")
     phosOutputPTMs.size should be(0)
   }
+
+  //
+  // Regulation tests
+  //
+
+  val regText1 = "AFT is phosphorylated by BEF."
+  regText1 should "produce one Regulation representation" in {
+
+    val mentions = getMentionsFromText(regText1)
+
+    val am = AssemblyManager(mentions)
+
+    am.getRegulations.size should be(1)
+    am.distinctRegulations.size should be(1)
+  }
+
+  val regText2 = "Akt inhibits the phosphorylation of AFT by BEF."
+  regText2 should "produce two Regulation representations (one with nesting)" in {
+
+    val mentions = getMentionsFromText(regText2)
+
+    val am = AssemblyManager(mentions)
+
+    val regs: Set[Regulation] = am.distinctRegulations
+
+    am.getRegulations.size should be(2)
+    regs.size should be(2)
+
+    regs.count(r => r.controlled.head.isInstanceOf[Regulation]) should be(1)
+  }
+
+
 
   //
   // Negation tests

--- a/src/test/scala/edu/arizona/sista/assembly/TestAssemblySieves.scala
+++ b/src/test/scala/edu/arizona/sista/assembly/TestAssemblySieves.scala
@@ -13,8 +13,7 @@ class TestAssemblySieves extends FlatSpec with Matchers {
     "interaction between SRC-3 and ERα and can occur outside of the nucleus."
 
   intraSent1 should "be annotated with the binding preceding the phosphorylation" in {
-    val doc = createDoc(intraSent1, "intra1-test")
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(intraSent1)
     val am = applySieves(mentions)
 
     val bRep = am.distinctSimpleEvents("Binding").head
@@ -32,8 +31,7 @@ class TestAssemblySieves extends FlatSpec with Matchers {
   val tamSent1 = "Once BEF had been phosphorylated, AFT was ubiquitinated"
 
   tamSent1 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(tamSent1, "tam1-test")
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(tamSent1)
     val am = applySieves(mentions)
 
     val uRep = am.distinctSimpleEvents("Ubiquitination").head
@@ -48,8 +46,7 @@ class TestAssemblySieves extends FlatSpec with Matchers {
   val tamSent2 = "AFT will be ubiquitinated only if BEF is first phosphorylated"
 
   tamSent2 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(tamSent2, "tam2-test")
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(tamSent2)
     val am = applySieves(mentions)
 
     val uRep = am.distinctSimpleEvents("Ubiquitination").head
@@ -64,8 +61,7 @@ class TestAssemblySieves extends FlatSpec with Matchers {
   val tamSent3 = "AFT was ubiquitinated when BEF had been phosphorylated"
 
   tamSent3 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(tamSent3, "tam3-test")
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(tamSent3)
     val am = applySieves(mentions)
 
     val uRep = am.distinctSimpleEvents("Ubiquitination").head
@@ -80,8 +76,7 @@ class TestAssemblySieves extends FlatSpec with Matchers {
   val interSent1 = "BEF was phosphorylated. Then, AFT was ubiquitinated."
 
   interSent1 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(interSent1, "inter1-test")
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(interSent1)
     val am = applySieves(mentions)
 
     val uRep = am.distinctSimpleEvents("Ubiquitination").head
@@ -96,8 +91,7 @@ class TestAssemblySieves extends FlatSpec with Matchers {
   val interSent2 = "BEF was phosphorylated. Subsequently AFT was ubiquitinated."
 
   interSent2 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(interSent2, "inter2-test")
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(interSent2)
     val am = applySieves(mentions)
 
     val uRep = am.distinctSimpleEvents("Ubiquitination").head
@@ -112,8 +106,7 @@ class TestAssemblySieves extends FlatSpec with Matchers {
   val interSent3 = "AFT was ubiquitinated. Prior to this, BEF was phosphorylated."
 
   interSent3 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(interSent3, "inter3-test")
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(interSent3)
     val am = applySieves(mentions)
 
     val uRep = am.distinctSimpleEvents("Ubiquitination").head
@@ -128,8 +121,7 @@ class TestAssemblySieves extends FlatSpec with Matchers {
   val interSent4 = "AFT was ubiquitinated. Previously, BEF was phosphorylated."
 
   interSent4 should "be annotated with the phosphorylation preceding the ubiquitination" in {
-    val doc = createDoc(interSent4, "inter4-test")
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(interSent4)
     val am = applySieves(mentions)
 
     val uRep = am.distinctSimpleEvents("Ubiquitination").head
@@ -146,8 +138,7 @@ class TestAssemblySieves extends FlatSpec with Matchers {
   val interSent5 = "AFT was ubiquitinated. There is intervening material and, previously, BEF was phosphorylated."
 
   interSent5 should "have no precedence relations" in {
-    val doc = createDoc(interSent5, "inter5-test")
-    val mentions = testReach.extractFrom(doc)
+    val mentions = getMentionsFromText(interSent5)
     val am = applySieves(mentions)
 
     val uRep = am.distinctSimpleEvents("Ubiquitination").head

--- a/src/test/scala/edu/arizona/sista/reach/TestRegulationEvents.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestRegulationEvents.scala
@@ -419,4 +419,26 @@ class TestRegulationEvents extends FlatSpec with Matchers {
     hasPositiveRegulationByEntity("E2", "Phosphorylation", List("SRC-3"), mentions) should be (true)
     hasEventWithArguments("Binding", List("SRC-3", "ERalpha"), mentions) should be (true)
   }
+
+  val sent46 = "Akt inhibits the phosphorylation of AFT by BEF."
+  sent46 should "contain a regulation of a regulation" in {
+    val mentions = getBioMentions(sent46)
+    val inner = mentions.filter(_ matches "Positive_regulation")
+    val outer = mentions.filter(_ matches "Negative_regulation")
+    inner should have size (1)
+    outer should have size (1)
+    hasPositiveRegulationByEntity("BEF", "Phosphorylation", List("AFT"), mentions) should be (true)
+    outer.head.arguments("controlled").head == inner.head should be (true)
+  }
+
+  val sent47 = "The phosphorylation of AFT by BEF is inhibited by the ubiquitination of Akt."
+  sent47 should "contain a regulation of a regulation" in {
+    val mentions = getBioMentions(sent47)
+    val inner = mentions.filter(_ matches "Positive_regulation")
+    val outer = mentions.filter(_ matches "Negative_regulation")
+    inner should have size (1)
+    outer should have size (1)
+    hasPositiveRegulationByEntity("BEF", "Phosphorylation", List("AFT"), mentions) should be (true)
+    outer.head.arguments("controlled").head == inner.head should be (true)
+  }
 }

--- a/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
@@ -36,12 +36,14 @@ object TestUtils {
     val paperAnnotations = Map(1 -> annotatePaper(nxml1)/*, 2 -> annotatePaper(nxml2), 3 -> annotatePaper(nxml3)*/)
   }
 
-  val testReach = new ReachSystem(contextEngineType = Engine.withName("Policy4"), contextParams = Map("bound" -> "5")) // All tests should use this system!
-  val testReader = new NxmlReader
-  val bioproc = testReach.processor // quick access to a process, if needed.
+  val testReach = PaperReader.rs // All tests should use this system!
+  val testReader = PaperReader.nxmlReader
+  val bioproc = testReach.processor // quick access to a processor, if needed.
   val docId = "testdoc"
   val chunkId = "1"
   val mentionManager = new MentionManager()
+
+  def getMentionsFromText(text: String): Seq[Mention] = PaperReader.getMentionsFromText(text)
 
   def getBioMentions(text:String, verbose:Boolean = false):Seq[BioMention] = {
     val entry = FriesEntry(docId, chunkId, "example", "example", isTitle = false, text)

--- a/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestUtils.scala
@@ -37,7 +37,7 @@ object TestUtils {
   }
 
   val testReach = PaperReader.rs // All tests should use this system!
-  val testReader = PaperReader.nxmlReader
+  val testReader = new NxmlReader
   val bioproc = testReach.processor // quick access to a processor, if needed.
   val docId = "testdoc"
   val chunkId = "1"


### PR DESCRIPTION
These changes allow Regulations of Regulations, resolving issue #199.  The added tests cover behavior associated with Regulation Mentions, corresponding assembly representations, and `FriesOutput` (export).