### PR TITLE
support controlled and controller regulations

### DIFF
--- a/src/main/scala/edu/arizona/sista/reach/extern/export/fries/FriesOutput.scala
+++ b/src/main/scala/edu/arizona/sista/reach/extern/export/fries/FriesOutput.scala
@@ -258,7 +258,9 @@ class FriesOutput extends JsonOutputter {
     for (mention <- eventMentions) {
       if (REGULATION_EVENTS.contains(mention.label)) {
         // "reach down" to process any child regulations first, before processing current regulation
-        val regulations = mention.arguments.getOrElse("controlled", Nil).filter(_.matches("Regulation"))
+        val controlledRegulations = mention.arguments.getOrElse("controlled", Nil).filter(_.matches("Regulation"))
+        val controllerRegulations = mention.arguments.getOrElse("controller", Nil).filter(_.matches("Regulation"))
+        val regulations = controlledRegulations ++ controllerRegulations
         for (reg <- regulations) {
           val passage = getPassageForMention(passageMap, reg)
           frames ++= mkEventMention(paperId, passage, reg.toBioMention, contextIdMap, entityMap, eventMap)


### PR DESCRIPTION
We were only considering nested regulations in the "controlled" slot, but
they can also nest as "controllers".

We encountered this problem on the sentence: "In the present study , we have further shown that ERK induced RhoA phosphorylation enhances the formation of actin stress fibers , which is consistent with the increased RhoA activity induced by ERK mediated RhoA phosphorylation ."