### PR TITLE
hack to support nested regulations in FriesOutput

### DIFF
--- a/src/main/scala/edu/arizona/sista/reach/extern/export/fries/FriesOutput.scala
+++ b/src/main/scala/edu/arizona/sista/reach/extern/export/fries/FriesOutput.scala
@@ -209,16 +209,7 @@ class FriesOutput extends JsonOutputter {
     // dereference all coreference mentions:
     val derefedMentions = allMentions.map(m => m.antecedentOrElse(m))
 
-    // FIXME this is a hack to process the arguments of nested regulations
-    val childMentions = for {
-      m <- derefedMentions
-      if MentionManager.isEventMention(m)
-      if m matches "Regulation"
-      args <- m.arguments.values
-      a <- args
-    } yield a
-
-    for(mention <- derefedMentions ++ childMentions) {
+    for(mention <- derefedMentions) {
       mention match {
         case em:BioTextBoundMention =>
           val passage = getPassageForMention(passageMap, em)

--- a/src/test/scala/edu/arizona/sista/reach/TestFriesOutput.scala
+++ b/src/test/scala/edu/arizona/sista/reach/TestFriesOutput.scala
@@ -106,9 +106,9 @@ class TestFriesOutput extends FlatSpec with Matchers {
 
   it should "have 2 protein entities" in {
     val ents = (json \ "entities" \ "frames") \\ "type" \\ classOf[JString]
-    ents.isEmpty should be (false)
-    (ents.size == 2) should be (true)
-    ents.forall(_ == "protein") should be (true)
+    ents should not be empty
+    ents should have size 2
+    all (ents) should be ("protein")
   }
 
   it should "have the given protein names" in {
@@ -120,15 +120,15 @@ class TestFriesOutput extends FlatSpec with Matchers {
 
   it should "have the expected xref properties" in {
     val xrefs = json \ "entities" \ "frames" \ "xrefs" \\ classOf[JObject]
-    (xrefs.size == 2) should be (true)
+    xrefs should have size 2
     val xrefs0 = xrefs(0)
-    (xrefs0.getOrElse("namespace", "") == "uniprot") should be (true)
-    (xrefs0.getOrElse("object-type", "") == "db-reference") should be (true)
-    (xrefs0.getOrElse("id", "") == "P31749") should be (true)
+    xrefs0 should contain ("namespace" -> "uniprot")
+    xrefs0 should contain ("object-type" -> "db-reference")
+    xrefs0 should contain ("id" -> "P31749")
     val xrefs1 = xrefs(1)
-    (xrefs1.getOrElse("namespace", "") == "uniprot") should be (true)
-    (xrefs1.getOrElse("object-type", "") == "db-reference") should be (true)
-    (xrefs1.getOrElse("id", "") == "P49190") should be (true)
+    xrefs1 should contain ("namespace" -> "uniprot")
+    xrefs1 should contain ("object-type" -> "db-reference")
+    xrefs1 should contain ("id" -> "P49190")
   }
 
 


### PR DESCRIPTION
We encountered a 2 level nested regulation in one of the dryrun papers.
Once again the serializer failed.

This is a hack to be able to continue with the evaluation.
A real solution would be to rewrite the serializer from scratch.