### PR TITLE
Detect autophosphorylations (resolves #252)

### DIFF
--- a/src/main/resources/org/clulab/reach/biogrammar/events/simple-event-auto_template.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/events/simple-event-auto_template.yml
@@ -1,0 +1,53 @@
+
+- name: ${ eventName }_syntax_1_noun
+  priority: ${ priority }
+  example: "EGFR autophosphorylation."
+  label: ${ label }
+  action: ${ actionFlow }
+  pattern: |
+    trigger = [lemma=/${ nominalTriggerLemma }/ & ${triggerPrefix} & tag=/^N/ & !mention=ModificationTrigger]
+    # these two should be the same
+    cause:BioChemicalEntity = nn
+    theme:BioChemicalEntity = nn
+    site:Site? = /prep_(at|on)|nn|conj_(and|or|nor)|cc/{,2}
+
+
+- name: ${ eventName }_syntax_2_noun
+  priority: ${ priority }
+  example: "The autophosphorylation of EGFR."
+  label: ${ label }
+  action: ${ actionFlow }
+  pattern: |
+    trigger = [lemma=/${ nominalTriggerLemma }/ & ${triggerPrefix} & tag=/^N/ & !mention=ModificationTrigger]
+    # these two should be the same
+    cause:BioChemicalEntity = prep_of
+    theme:BioChemicalEntity = prep_of
+    site:Site? = prep_of? /prep_(at|on)|nn|conj_(and|or|nor)|cc/{,2}
+
+
+- name: ${ eventName }_syntax_1_verb
+  priority: ${ priority }
+  example: "EGFR is autophosphorylated."
+  label: ${ label }
+  action: ${ actionFlow }
+  pattern: |
+    trigger = [lemma=/${ verbalTriggerLemma }/ & !mention=ModificationTrigger]
+    # these two should be the same
+    cause:BioChemicalEntity = /^nsubj/
+    theme:BioChemicalEntity = /^nsubj/
+    site:Site? = prep_on
+
+
+- name: ${ eventName }_syntax_2_verb
+  priority: ${ priority }
+  example: "EGFR phosphorylates itself."
+  label: ${ label }
+  action: ${ actionFlow }
+  pattern: |
+    trigger = [lemma=/${ baseVerbalTriggerLemma }/ & !word=/(?i)^(de|auto)/ & !mention=ModificationTrigger]
+    # these two should be the same
+    # assertion on syntactic context of trigger
+    # direct object of predicate must be the word "itself"
+    cause:BioChemicalEntity = (?= (dobj|agent|prep_by) [word=itself]) /^nsubj/
+    theme:BioChemicalEntity = (?= (dobj|agent|prep_by) [word=itself]) /^nsubj/
+    site:Site? = /prep_(at|on)|nn|conj_(and|or|nor)|cc/{,2}

--- a/src/main/resources/org/clulab/reach/biogrammar/events_master.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/events_master.yml
@@ -30,6 +30,18 @@ rules:
       label: "Phosphorylation"
       verbalTriggerLemma: "phosphorylate"
       nominalTriggerLemma: "phosphorylation"
+      triggerPrefix: "!word=/(?i)^(de|auto)/"
+      priority: "5"
+
+  # AutoPhosphorylations
+  - import: org/clulab/reach/biogrammar/events/simple-event-auto_template.yml
+    vars:
+      eventName: "AutoPhosphorylation"
+      actionFlow: "handleAutoEvent"
+      label: "AutoPhosphorylation"
+      verbalTriggerLemma: "auto-?phosphorylate"
+      baseVerbalTriggerLemma: "phosphorylate"
+      nominalTriggerLemma: "auto-?phosphorylation"
       triggerPrefix: "!word=/(?i)^de/"
       priority: "5"
 

--- a/src/main/resources/org/clulab/reach/biogrammar/taxonomy.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/taxonomy.yml
@@ -35,7 +35,8 @@
                 - Hydrolysis
                 - Hydroxylation
                 - Methylation
-                - Phosphorylation
+                - Phosphorylation:
+                  - AutoPhosphorylation
                 - Ribosylation
                 - Sumoylation
                 - Ubiquitination

--- a/src/test/scala/org/clulab/reach/TestTemplaticAutoEvents.scala
+++ b/src/test/scala/org/clulab/reach/TestTemplaticAutoEvents.scala
@@ -1,0 +1,142 @@
+package org.clulab.reach
+
+import org.scalatest.{FlatSpec, Matchers}
+import TestUtils.getMentionsFromText
+
+
+class TestTemplaticAutoEvents extends FlatSpec with Matchers {
+
+  val example1 = "EGFR autophosphorylates on a tyrosine residue."
+  example1 should "contain an AutoPhosphorylation with a Site" in {
+
+    val mentions = getMentionsFromText(example1)
+    val autophos = mentions filter(_ matches "AutoPhosphorylation")
+    val regs = mentions filter(_ matches "Positive_regulation")
+
+    autophos should have size (1)
+    autophos.head.arguments.keySet should contain ("site")
+    autophos.head.arguments.keySet should contain ("theme")
+    autophos.head.arguments("theme") should have size (1)
+    autophos.head.arguments("theme").head.text should equal ("EGFR")
+
+    regs shouldNot be (empty)
+    regs.head.arguments.keySet should contain ("controller")
+    regs.head.arguments("controller") should have size (1)
+    regs.head.arguments("controller").head.text should equal ("EGFR")
+  }
+
+  val example2 = "EGFR phosphorylates itself."
+  example2 should "contain an AutoPhosphorylation without a Site" in {
+
+    val mentions = getMentionsFromText(example2)
+    val autophos = mentions filter(_ matches "AutoPhosphorylation")
+    val regs = mentions filter(_ matches "Positive_regulation")
+
+    autophos should have size (1)
+    autophos.head.arguments.keySet shouldNot contain ("site")
+    autophos.head.arguments.keySet should contain ("theme")
+    autophos.head.arguments("theme") should have size (1)
+    autophos.head.arguments("theme").head.text should equal ("EGFR")
+
+    regs shouldNot be (empty)
+    regs.head.arguments.keySet should contain ("controller")
+    regs.head.arguments("controller") should have size (1)
+    regs.head.arguments("controller").head.text should equal ("EGFR")
+  }
+
+  val example3 = "However, stimulation with EGF for varying time intervals revealed no significant differences in the levels of autophosphorylation of EGFR in cells expressing wild type Gab1 versus the Gab1 F446/472/589 mutant."
+  example3 should "contain an AutoPhosphorylation without a Site" in {
+
+    val mentions = getMentionsFromText(example3)
+    val autophos = mentions filter(_ matches "AutoPhosphorylation")
+    val regs = mentions filter(_ matches "Positive_regulation")
+
+    autophos should have size (1)
+    autophos.head.arguments.keySet shouldNot contain ("site")
+    autophos.head.arguments.keySet should contain ("theme")
+    autophos.head.arguments("theme") should have size (1)
+    autophos.head.arguments("theme").head.text should equal ("EGFR")
+
+    regs shouldNot be (empty)
+    regs.head.arguments.keySet should contain ("controller")
+    regs.head.arguments("controller") should have size (1)
+    regs.head.arguments("controller").head.text should equal ("EGFR")
+  }
+
+  val example4 = "As has been previously reported, recruitment of Shp2 by Gab1 does not alter the magnitude or kinetics of tyrosine autophosphorylation of EGFR."
+  example4 should "contain an AutoPhosphorylation with a Site" in {
+
+    val mentions = getMentionsFromText(example4)
+    val autophos = mentions filter (_ matches "AutoPhosphorylation")
+    val regs = mentions filter (_ matches "Positive_regulation")
+
+    autophos should have size (1)
+    autophos.head.arguments.keySet should contain ("site")
+    autophos.head.arguments.keySet should contain ("theme")
+    autophos.head.arguments("theme") should have size (1)
+    autophos.head.arguments("theme").head.text should equal("EGFR")
+
+    regs shouldNot be (empty)
+    regs.head.arguments.keySet should contain ("controller")
+    regs.head.arguments("controller") should have size (1)
+    regs.head.arguments("controller").head.text should equal("EGFR")
+  }
+
+  val example5 = "Levels of EGFR autophosphorylation are represented linearly following quantitation by densitometry and normalization for protein expression levels."
+  example5 should "contain an AutoPhosphorylation without a Site" in {
+
+    val mentions = getMentionsFromText(example5)
+    val autophos = mentions filter (_ matches "AutoPhosphorylation")
+    val regs = mentions filter (_ matches "Positive_regulation")
+
+    autophos should have size (1)
+    autophos.head.arguments.keySet shouldNot contain ("site")
+    autophos.head.arguments.keySet should contain ("theme")
+    autophos.head.arguments("theme") should have size (1)
+    autophos.head.arguments("theme").head.text should equal("EGFR")
+
+    regs shouldNot be (empty)
+    regs.head.arguments.keySet should contain ("controller")
+    regs.head.arguments("controller") should have size (1)
+    regs.head.arguments("controller").head.text should equal("EGFR")
+  }
+
+  val example6 = "Because the substrates of Shp2 are for the most part unknown, we were additionally interested in examining the state of EGFR tyrosine phosphorylation following treatment with EGF in order to determine if the failure of Gab1 to bind p85, and potentially recruit Shp2, would influence levels of EGFR autophosphorylation."
+  example6 should "contain an AutoPhosphorylation without a Site" in {
+
+    val mentions = getMentionsFromText(example6)
+    val autophos = mentions filter (_ matches "AutoPhosphorylation")
+    val regs = mentions filter (_ matches "Positive_regulation")
+
+    autophos should have size (1)
+    autophos.head.arguments.keySet shouldNot contain ("site")
+    autophos.head.arguments.keySet should contain ("theme")
+    autophos.head.arguments("theme") should have size (1)
+    autophos.head.arguments("theme").head.text should equal("EGFR")
+
+    regs shouldNot be (empty)
+    regs.head.arguments.keySet should contain ("controller")
+    regs.head.arguments("controller") should have size (1)
+    regs.head.arguments("controller").head.text should equal("EGFR")
+  }
+
+  val example7 = "The experiment presented in Fig shows that all cell lines exhibit EGFR autophosphorylation in response to EGF treatment, while only cells expressing the ectopically introduced ErbB3 protein show ErbB3 tyrosine phosphorylation in response to EGF stimulation."
+  example7 should "contain an AutoPhosphorylation without a Site" in {
+
+    val mentions = getMentionsFromText(example5)
+    val autophos = mentions filter (_ matches "AutoPhosphorylation")
+    val regs = mentions filter (_ matches "Positive_regulation")
+
+    autophos should have size (1)
+    autophos.head.arguments.keySet shouldNot contain ("site")
+    autophos.head.arguments.keySet should contain ("theme")
+    autophos.head.arguments("theme") should have size (1)
+    autophos.head.arguments("theme").head.text should equal("EGFR")
+
+    regs shouldNot be (empty)
+    regs.head.arguments.keySet should contain ("controller")
+    regs.head.arguments("controller") should have size (1)
+    regs.head.arguments("controller").head.text should equal("EGFR")
+  }
+}
+


### PR DESCRIPTION
Per @bgyori's request, I've added support for the detection of autophosphorylation events.  

# Changes
1. Tests for the examples in #252.
2. `AutoPhosphorylation` added to the taxonomy under `Phosphorylation`.  An `AutoPhosphorylation` event requires a "theme" and `cause`, which is transformed into a `Positive_regulation` where the `controller` matches the "theme" of the `controlled` (an `AutoPhosphorylation`).  This transformation basically mirrors how we currently handle `SimpleEvents` with a `cause`.
3. A new rule template for "auto" events (we may want to eventually add autoubiquitination, autoacetylation, etc.).  Currently, the template contains only four syntactic patterns, though I believe those four rules cover the majority of encountered structures.
4. A new action to properly handle these events. `splitSimpleEvents` could not be reused, as it disallows overlapping controllers and controlleds.