### PR TITLE
build ReachConstants from taxonomy.yml

### DIFF
--- a/src/main/scala/org/clulab/reach/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/DarpaActions.scala
@@ -703,8 +703,10 @@ class DarpaActions extends Actions {
 
 object DarpaActions {
 
+  import ReachConstants.taxonomy
+
   // These labels are given to the Regulation created when splitting a SimpleEvent with a cause
-  val REG_LABELS = Seq("Positive_regulation", "Regulation", "ComplexEvent", "Event", "PossibleController")
+  val REG_LABELS = taxonomy.hypernymsFor("Positive_regulation")
 
   // These are used to detect semantic inversions of regulations/activations. See DarpaActions.countSemanticNegatives
   val SEMANTIC_NEGATIVE_PATTERN = "attenu|block|deactiv|decreas|degrad|diminish|disrupt|impair|imped|inhibit|knockdown|limit|lower|negat|reduc|reliev|repress|restrict|revers|slow|starv|suppress|supress".r

--- a/src/main/scala/org/clulab/reach/ReachConstants.scala
+++ b/src/main/scala/org/clulab/reach/ReachConstants.scala
@@ -1,57 +1,37 @@
 package org.clulab.reach
 
 /**
-  * Object defining constants used across Reach.
-  * This is not a package object because its constants are not needed by all Reach classes.
-  *   Written by Tom Hicks. 4/14/2016.
-  *   Last Modified: Initial creation with event taxonomy sets.
+  * This object wraps the taxonomy
   */
+import java.util.Collection
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.Constructor
+import org.clulab.odin.impl.Taxonomy
+
+
 object ReachConstants {
 
-  val ACTIVATION_EVENTS = Set(
-    "Negative_activation",
-    "Positive_activation"
-  )
+  // Could be used by other components
+  val taxonomy = readTaxonomy("org/clulab/reach/biogrammar/taxonomy.yml")
 
-  val REGULATION_EVENTS = Set(
-    "Negative_regulation",
-    "Positive_regulation"
-  )
+  private def readTaxonomy(path: String): Taxonomy = {
+    val url = getClass.getClassLoader.getResource(path)
+    val source = if (url == null) io.Source.fromFile(path) else io.Source.fromURL(url)
+    val input = source.mkString
+    source.close()
+    val yaml = new Yaml(new Constructor(classOf[Collection[Any]]))
+    val data = yaml.load(input).asInstanceOf[Collection[Any]]
+    Taxonomy(data)
+  }
 
-  val COMPLEX_EVENTS =  ACTIVATION_EVENTS ++ REGULATION_EVENTS
+  val ACTIVATION_EVENTS = taxonomy.hyponymsFor("ActivationEvent").toSet
+  val REGULATION_EVENTS = taxonomy.hyponymsFor("Regulation").toSet
+  val COMPLEX_EVENTS = taxonomy.hyponymsFor("ComplexEvent").toSet
 
-  val ADDITION_EVENTS = Set(
-    "Acetylation",
-    "Farnesylation",
-    "Glycosylation",
-    "Hydrolysis",
-    "Hydroxylation",
-    "Methylation",
-    "Phosphorylation",
-    "Ribosylation",
-    "Sumoylation",
-    "Ubiquitination"
-  )
-
-  val REMOVAL_EVENTS = Set(
-    "Deacetylation",
-    "Defarnesylation",
-    "Deglycosylation",
-    "Dehydrolysis",
-    "Dehydroxylation",
-    "Demethylation",
-    "Dephosphorylation",
-    "Deribosylation",
-    "Desumoylation",
-    "Deubiquitination"
-  )
-
+  val ADDITION_EVENTS = taxonomy.hyponymsFor("AdditionEvent").toSet
+  val REMOVAL_EVENTS = taxonomy.hyponymsFor("RemovalEvent").toSet
   val MODIFICATION_EVENTS = ADDITION_EVENTS ++ REMOVAL_EVENTS
-
-  val SIMPLE_EVENTS = MODIFICATION_EVENTS ++ Set(
-    "Binding",
-    "Generic_event",
-    "Translocation"
-  )
+  val SIMPLE_EVENTS = taxonomy.hyponymsFor("SimpleEvent").toSet
 
 }
+


### PR DESCRIPTION
`ReachConstants` is now built directly from the taxonomy.  I've also exposed the an instance of `Taxonomy` that can be used elsewhere (see minor change to `DarpaActions` companion object).