### PR TITLE
Isolate flattening of controllers to export

### DIFF
--- a/src/main/resources/org/clulab/reach/biogrammar/events_master.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/events_master.yml
@@ -243,6 +243,7 @@ rules:
       actionFlow: "mkBioMention"
       priority: "6"
 
+
   # Positive Regulation
   - import: org/clulab/reach/biogrammar/events/pos-reg_template.yml
     vars:

--- a/src/main/resources/org/clulab/reach/biogrammar/taxonomy.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/taxonomy.yml
@@ -2,15 +2,15 @@
 - ModificationTrigger
 - Site
 - Context:
-  - Species
-  - CellLine
-  - Organ
-  - CellType
-  - Cellular_component
-  - TissueType
-  - ContextDirection
-  - ContextLocation
-  - ContextPossessive
+    - Species
+    - CellLine
+    - Organ
+    - CellType
+    - Cellular_component
+    - TissueType
+    - ContextDirection
+    - ContextLocation
+    - ContextPossessive
 - Modification:
     - PTM
     - Mutant:
@@ -36,7 +36,7 @@
                 - Hydroxylation
                 - Methylation
                 - Phosphorylation:
-                  - AutoPhosphorylation
+                    - AutoPhosphorylation
                 - Ribosylation
                 - Sumoylation
                 - Ubiquitination
@@ -61,38 +61,38 @@
     - Entity:
       # Any BioEntity may appear as the controlled in an Activation
       - BioEntity:
-        - BioProcess   # ex. "apoptosis"
-        - BioChemicalEntity:
-            - Generic_entity
-            - Simple_chemical
-            - Equivalable: #TODO: Better name
-                - Family
-                - MacroMolecule:
-                    - Protein
-                    - Gene_or_gene_product
-                    - Complex
-                    - GENE
+          - BioProcess   # ex. "apoptosis"
+          - BioChemicalEntity:
+              - Generic_entity
+              - Simple_chemical
+              - Equivalable: #TODO: Better name
+                  - Family
+                  - MacroMolecule:
+                      - Protein
+                      - Gene_or_gene_product
+                      - Complex
+                      - GENE
 # a preliminary taxonomy for assembly (precedence relations)
 - Precedence:
-  # for pairs that are directly (immediately) connected
-  # difficult to know from odin rules alone, but not impossible
-  - DirectConnection
-  # for pairs that are indirectly (not immediately) connected
-  - IndirectConnection
-  # Between-sentence precedence
-  - BetweenSentence:
-    - TimexAfter
-    - TimexBefore
-    - SentenceInitialEvent
-    - InterAfter
-    - InterBefore
-  # tense and aspect detection
-  - TAM:
-    - Aux
-    - Tense:
-      - PastTense
-      - PresentTense
-      - FutureTense
-    - Aspect:
-      - Perfective
-      - Progressive
+    # for pairs that are directly (immediately) connected
+    # difficult to know from odin rules alone, but not impossible
+    - DirectConnection
+    # for pairs that are indirectly (not immediately) connected
+    - IndirectConnection
+    # Between-sentence precedence
+    - BetweenSentence:
+        - TimexAfter
+        - TimexBefore
+        - SentenceInitialEvent
+        - InterAfter
+        - InterBefore
+    # tense and aspect detection
+    - TAM:
+        - Aux
+        - Tense:
+            - PastTense
+            - PresentTense
+            - FutureTense
+        - Aspect:
+            - Perfective
+            - Progressive

--- a/src/main/scala/org/clulab/assembly/AssemblyManager.scala
+++ b/src/main/scala/org/clulab/assembly/AssemblyManager.scala
@@ -553,7 +553,7 @@ class AssemblyManager(
         // TODO: is site part of label?
         case mut: mentions.Mutant => Set(MutantEntity(mut.label))
         // TODO: should site be handled differently?
-        case ptm: mentions.PTM => Set(PTM(ptm.toString, None))
+        case ptm: mentions.PTM => Set(PTM(ptm.toString, None, ptm.negated))
         case _ => Nil
       }
     if (m matches "Entity") Set(EntityLabel(m.label)) ++ mods else mods

--- a/src/main/scala/org/clulab/coref/Coref.scala
+++ b/src/main/scala/org/clulab/coref/Coref.scala
@@ -234,7 +234,7 @@ class Coref {
         })
         argsAsEntities = argMs.map(ms => ms.map(m =>
           if (lbl == "controller" && m.isInstanceOf[EventMention] && m.isGeneric) {
-            val ant = da.convertEventToEntity(m.antecedent.get.asInstanceOf[BioEventMention]).get.toCorefMention
+            val ant = da.convertEventToEntity(m.antecedent.get.asInstanceOf[BioEventMention]).toCorefMention
             createdComplexes = createdComplexes :+ ant
             val copy = new CorefEventMention(
               m.labels,

--- a/src/main/scala/org/clulab/coref/Coref.scala
+++ b/src/main/scala/org/clulab/coref/Coref.scala
@@ -1,21 +1,20 @@
 package org.clulab.coref
 
 import org.clulab.odin.{Mention, _}
-import org.clulab.processors.Document
 import org.clulab.reach.grounding.{ReachKBConstants, KBEntry}
-import org.clulab.reach.{mentions, DarpaActions, DarpaLinks}
+import org.clulab.reach.DarpaLinks
+import org.clulab.reach.DarpaActions.convertEventToEntity
 import org.clulab.reach.utils.DependencyUtils._
 import org.clulab.reach.display._
 import org.clulab.reach.mentions._
 import org.clulab.coref.CorefUtils._
-
 import scala.annotation.tailrec
+
 
 class Coref {
 
   val debug: Boolean = false
   val verbose: Boolean = debug
-  val da: DarpaActions = new DarpaActions()
 
   /**
     * Make a map from TextBoundMentions to copies of themselves with a maximum of 1 antecedent
@@ -234,7 +233,7 @@ class Coref {
         })
         argsAsEntities = argMs.map(ms => ms.map(m =>
           if (lbl == "controller" && m.isInstanceOf[EventMention] && m.isGeneric) {
-            val ant = da.convertEventToEntity(m.antecedent.get.asInstanceOf[BioEventMention]).toCorefMention
+            val ant = convertEventToEntity(m.antecedent.get.asInstanceOf[BioEventMention]).toCorefMention
             createdComplexes = createdComplexes :+ ant
             val copy = new CorefEventMention(
               m.labels,

--- a/src/main/scala/org/clulab/reach/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/DarpaActions.scala
@@ -514,68 +514,6 @@ class DarpaActions extends Actions {
     }
   }
 
-  /** Recursively converts an Event to an Entity with the appropriate modifications representing its state.
-    * SimpleEvent -> theme + PTM <br>
-    * Binding -> Complex (treated as an Entity) <br>
-    * ComplexEvent -> recursive call on controlled (the event's "output") <br>
-    */
-  @tailrec
-  final def convertEventToEntity(m: Mention, negated: Boolean = false): BioMention = m.toBioMention match {
-
-    // no conversion needed
-    // FIXME: consider case of "activated RAS".
-    // We may want to add a Negation mod to this entity conditionally
-    // or add a PTM with the label "UNKNOWN" and negate it (depending on value of negated)
-    case tb: BioTextBoundMention => tb
-
-    // These are event triggers used by coref (a SimpleEvent without a theme)
-    // FIXME: should these be handled differently?
-    case generic if generic matches "Generic_event" => generic
-
-    // convert a binding into a Complex so that it is treated as an entity
-    case binding if binding matches "Binding" =>
-      new BioRelationMention(
-        taxonomy.hypernymsFor("Complex"),
-        binding.arguments,
-        binding.sentence,
-        binding.document,
-        binding.keep,
-        binding.foundBy
-      )
-
-    // convert event to PTM on its theme.
-    // negate PTM according to current value of "negated"
-    // (this SimpleEvent may have been the controlled to some negative ComplexEvent)
-    case se: BioEventMention if se matches "SimpleEvent" =>
-      // get the theme of the event (assume only one theme)
-      val entity = se.arguments("theme").head.toBioMention
-      // get an optional site (assume only one site)
-      val siteOption = se.arguments.get("site").map(_.head)
-      // create new mention for the entity
-      val modifiedEntity = new BioTextBoundMention(entity)
-      // attach a modification based on the event trigger
-      val label = getModificationLabel(se.label)
-      BioMention.copyAttachments(entity, modifiedEntity)
-      modifiedEntity.modifications += PTM(label, evidence = Some(se.trigger), site = siteOption, negated)
-      modifiedEntity
-
-    // dig into the controlled (event's "output" or the part that is altered in some way)
-    case posEvent if (posEvent matches "ComplexEvent") && (!hasNegativePolarity(posEvent)) =>
-      // get the controlled of the event (assume only one controlled)
-      val controlled = posEvent.arguments("controlled").head.toBioMention
-      convertEventToEntity(controlled, negated)
-
-    // dig into the controlled (event's "output" or the part that is altered in some way)
-    // ComplexEvents with negative polarity "negate" the ptm of the contained entity
-    // (see https://github.com/clulab/reach/issues/184)
-    case negEvent if (negEvent matches "ComplexEvent") && hasNegativePolarity(negEvent) =>
-      // get the controlled of the event (assume only one controlled)
-      val controlled = negEvent.arguments("controlled").head.toBioMention
-      // negate the underlying PTM
-      // if received event has negative polarity (see issue #184)
-      convertEventToEntity(controlled, negated=true)
-  }
-
   /** Returns true if both mentions are grounded to the same entity */
   def sameEntityID(m1: BioMention, m2: BioMention): Boolean = {
     require(m1.isGrounded, "mention must be grounded")
@@ -648,29 +586,65 @@ class DarpaActions extends Actions {
     false
   }
 
-}
+  /** Recursively converts an Event to an Entity with the appropriate modifications representing its state.
+    * SimpleEvent -> theme + PTM <br>
+    * Binding -> Complex (treated as an Entity) <br>
+    * ComplexEvent -> recursive call on controlled (the event's "output") <br>
+    */
+  @tailrec
+  final def convertEventToEntity(m: Mention, negated: Boolean = false): BioMention = m.toBioMention match {
 
-object DarpaActions {
+    // no conversion needed
+    // FIXME: consider case of "activated RAS".
+    // We may want to add a Negation mod to this entity conditionally
+    // or add a PTM with the label "UNKNOWN" and negate it (depending on value of negated)
+    case entity if entity matches "Entity" => entity
 
-  def hasNegativePolarity(m: Mention): Boolean = if (m.label.toLowerCase startsWith "negative") true else false
-  // These labels are given to the Regulation created when splitting a SimpleEvent with a cause
-  val REG_LABELS = taxonomy.hypernymsFor("Positive_regulation")
+    // These are event triggers used by coref (a SimpleEvent without a theme)
+    // FIXME: should these be handled differently?
+    case generic if generic matches "Generic_event" => generic
 
-  // These are used to detect semantic inversions of regulations/activations. See DarpaActions.countSemanticNegatives
-  val SEMANTIC_NEGATIVE_PATTERN = "attenu|block|deactiv|decreas|degrad|diminish|disrupt|impair|imped|inhibit|knockdown|limit|lower|negat|reduc|reliev|repress|restrict|revers|slow|starv|suppress|supress".r
+    // convert a binding into a Complex so that it is treated as an entity
+    case binding if binding matches "Binding" =>
+      new BioRelationMention(
+        taxonomy.hypernymsFor("Complex"),
+        binding.arguments,
+        binding.sentence,
+        binding.document,
+        binding.keep,
+        binding.foundBy
+      )
 
-  val MODIFIER_LABELS = "amod".r
+    // convert event to PTM on its theme.
+    // negate PTM according to current value of "negated"
+    // (this SimpleEvent may have been the controlled to some negative ComplexEvent)
+    case se: BioEventMention if se matches "SimpleEvent" =>
+      // get the theme of the event (assume only one theme)
+      val entity = se.arguments("theme").head.toBioMention
+      // get an optional site (assume only one site)
+      val siteOption = se.arguments.get("site").map(_.head)
+      // create new mention for the entity
+      val modifiedEntity = new BioTextBoundMention(entity)
+      // attach a modification based on the event trigger
+      val label = DarpaActions.getModificationLabel(se.label)
+      BioMention.copyAttachments(entity, modifiedEntity)
+      modifiedEntity.modifications += PTM(label, evidence = Some(se.trigger), site = siteOption, negated)
+      modifiedEntity
 
-  // patterns for "reverse" modifications
-  val deAcetylatPat     = "(?i)de-?acetylat".r
-  val deFarnesylatPat   = "(?i)de-?farnesylat".r
-  val deGlycosylatPat   = "(?i)de-?glycosylat".r
-  val deHydrolyPat      = "(?i)de-?hydroly".r
-  val deHydroxylatPat   = "(?i)de-?hydroxylat".r
-  val deMethylatPat     = "(?i)de-?methylat".r
-  val dePhosphorylatPat = "(?i)de-?phosphorylat".r
-  val deRibosylatPat    = "(?i)de-?ribosylat".r
-  val deSumoylatPat     = "(?i)de-?sumoylat".r
-  val deUbiquitinatPat  = "(?i)de-?ubiquitinat".r
+    // dig into the controlled (event's "output" or the part that is altered in some way)
+    case posEvent if (posEvent matches "ComplexEvent") && (!DarpaActions.hasNegativePolarity(posEvent)) =>
+      // get the controlled of the event (assume only one controlled)
+      val controlled = posEvent.arguments("controlled").head.toBioMention
+      convertEventToEntity(controlled, negated)
 
+    // dig into the controlled (event's "output" or the part that is altered in some way)
+    // ComplexEvents with negative polarity "negate" the ptm of the contained entity
+    // (see https://github.com/clulab/reach/issues/184)
+    case negEvent if (negEvent matches "ComplexEvent") && DarpaActions.hasNegativePolarity(negEvent) =>
+      // get the controlled of the event (assume only one controlled)
+      val controlled = negEvent.arguments("controlled").head.toBioMention
+      // negate the underlying PTM
+      // if received event has negative polarity (see issue #184)
+      convertEventToEntity(controlled, negated=true)
+  }
 }

--- a/src/main/scala/org/clulab/reach/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/DarpaActions.scala
@@ -285,7 +285,7 @@ class DarpaActions extends Actions {
         // FIXME There could be more than one cause...
         val cause: Seq[Mention] = m.arguments("cause")
         val evArgs = m.arguments - "cause"
-        val ev = new BioEventMention(m.copy(arguments = evArgs))
+        val ev = new BioEventMention(m.copy(arguments = evArgs), direct = true)
         // make sure the regulation is valid
         val controlledArgs: Set[Mention] = evArgs.values.flatten.toSet
         // controller of an event should not be an arg in the controlled

--- a/src/main/scala/org/clulab/reach/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/DarpaActions.scala
@@ -528,6 +528,10 @@ class DarpaActions extends Actions {
     // or add a PTM with the label "UNKNOWN" and negate it (depending on value of negated)
     case tb: BioTextBoundMention => tb
 
+    // These are event triggers used by coref (a SimpleEvent without a theme)
+    // FIXME: should these be handled differently?
+    case generic if generic matches "Generic_event" => generic
+
     // convert a binding into a Complex so that it is treated as an entity
     case binding if binding matches "Binding" =>
       new BioRelationMention(

--- a/src/main/scala/org/clulab/reach/MentionFilter.scala
+++ b/src/main/scala/org/clulab/reach/MentionFilter.scala
@@ -274,7 +274,7 @@ object MentionFilter {
           // don't consider the rec as an alternate
           (c != rec) &&
             // only consider matches if the controlleds are equivalent
-            (c.arguments("controlled") == controlled) &&
+            (c.arguments("controlled").head == controlled) &&
             // candidates for replacement should have a
             hasEventAsController(c)
         )

--- a/src/main/scala/org/clulab/reach/MentionFilter.scala
+++ b/src/main/scala/org/clulab/reach/MentionFilter.scala
@@ -193,8 +193,8 @@ object MentionFilter {
       val da = new DarpaActions
       (a,b) match {
         case (exactA, exactB) if exactA == exactB => true
-        case (ent: CorefTextBoundMention, ev: CorefEventMention) => da.convertEventToEntity(ev).getOrElse(ev) == ent
-        case (ev: CorefEventMention, ent: CorefTextBoundMention) => da.convertEventToEntity(ev).getOrElse(ev) == ent
+        case (ent: CorefTextBoundMention, ev: CorefEventMention) => da.convertEventToEntity(ev) == ent
+        case (ev: CorefEventMention, ent: CorefTextBoundMention) => da.convertEventToEntity(ev) == ent
         case different => false
       }
     }

--- a/src/main/scala/org/clulab/reach/MentionFilter.scala
+++ b/src/main/scala/org/clulab/reach/MentionFilter.scala
@@ -190,11 +190,10 @@ object MentionFilter {
     }
 
     def ptmEquivalent(a: CorefMention, b: CorefMention): Boolean = {
-      val da = new DarpaActions
       (a,b) match {
         case (exactA, exactB) if exactA == exactB => true
-        case (ent: CorefTextBoundMention, ev: CorefEventMention) => da.convertEventToEntity(ev) == ent
-        case (ev: CorefEventMention, ent: CorefTextBoundMention) => da.convertEventToEntity(ev) == ent
+        case (ent: CorefTextBoundMention, ev: CorefEventMention) => convertEventToEntity(ev) == ent
+        case (ev: CorefEventMention, ent: CorefTextBoundMention) => convertEventToEntity(ev) == ent
         case different => false
       }
     }

--- a/src/main/scala/org/clulab/reach/OutputDegrader.scala
+++ b/src/main/scala/org/clulab/reach/OutputDegrader.scala
@@ -44,6 +44,9 @@ object OutputDegrader {
       }
       flattenedRepresentation.toBioMention
       }
+
+    // Site, Cellular_component, CellLine, TissueType, Species, etc.
+    case other => other
   }
 
   /** Recursively converts an Event to an Entity with the appropriate modifications representing its state.

--- a/src/main/scala/org/clulab/reach/OutputDegrader.scala
+++ b/src/main/scala/org/clulab/reach/OutputDegrader.scala
@@ -1,0 +1,108 @@
+package org.clulab.reach
+
+import org.clulab.odin._
+import org.clulab.reach.mentions._
+import scala.annotation.tailrec
+
+
+/**
+  * Degrade internal representations for output
+  */
+object OutputDegrader {
+
+  /** Flattens nested controllers
+    * TODO: Should this also flatten controlleds?
+    */
+  def flattenMentions(mentions: Seq[Mention]): Seq[BioMention] = for {
+    mention <- mentions
+  } yield flattenMention(mention)
+
+  def flattenMention(m: Mention): BioMention = m.toBioMention match {
+
+    // No flattening necessary
+    case entity if entity matches "Entity" => entity
+
+    // A Generic_event is essentially a trigger for a SimpleEvent (no theme is present)
+    case generic if generic matches "Generic_event" => generic
+
+    // SimpleEvents need not be modified
+    case se if se matches "SimpleEvent" => se
+
+    // Flatten controller of a ComplexEvent
+    case ce if ce matches "ComplexEvent" =>
+      ce.arguments.get("controller") match {
+      // no controller
+      // TODO: should controlled be flattened?
+      case None => ce
+        // a single controller
+      case Some(Seq(controller)) => val flattenedController = flattenController(controller)
+      val updatedArguments = ce.arguments.updated("controller", Seq(flattenedController))
+        // TODO: should we flatten the controlled as well?
+      val flattenedRepresentation = ce match {
+          case rel: RelationMention => rel.copy(arguments = updatedArguments)
+          case em: EventMention => em.copy(arguments = updatedArguments)
+      }
+      flattenedRepresentation.toBioMention
+      }
+  }
+
+  /** Recursively converts an Event to an Entity with the appropriate modifications representing its state.
+    * SimpleEvent -> theme + PTM <br>
+    * Binding -> Complex (treated as an Entity) <br>
+    * ComplexEvent -> recursive call on controller <br>
+    */
+  @tailrec
+  final def flattenController(m: Mention, negated: Boolean = false): BioMention = m.toBioMention match {
+
+    // no conversion needed
+    // FIXME: consider case of "activated RAS".
+    // We may want to add a Negation mod to this entity conditionally
+    // or add a PTM with the label "UNKNOWN" and negate it (depending on value of negated)
+    case entity if entity matches "Entity" => entity
+
+    // These are event triggers used by coref (a SimpleEvent without a theme)
+    // FIXME: should these be handled differently?
+    case generic if generic matches "Generic_event" => generic
+
+    // convert a binding into a Complex so that it is treated as an entity
+    case binding if binding matches "Binding" =>
+      new BioRelationMention(
+        taxonomy.hypernymsFor("Complex"),
+        binding.arguments,
+        binding.sentence,
+        binding.document,
+        binding.keep,
+        binding.foundBy
+      )
+
+    // convert event to PTM on its theme.
+    // negate PTM according to current value of "negated"
+    // (this SimpleEvent may have been the controlled to some negative ComplexEvent)
+    case se: BioEventMention if se matches "SimpleEvent" =>
+      // get the theme of the event (assume only one theme)
+      val entity = se.arguments("theme").head.toBioMention
+      // get an optional site (assume only one site)
+      val siteOption = se.arguments.get("site").map(_.head)
+      // create new mention for the entity
+      val modifiedEntity = new BioTextBoundMention(entity)
+      // attach a modification based on the event trigger
+      val label = DarpaActions.getModificationLabel(se.label)
+      BioMention.copyAttachments(entity, modifiedEntity)
+      modifiedEntity.modifications += PTM(label, evidence = Some(se.trigger), site = siteOption, negated)
+      modifiedEntity
+
+    // dig into the controller
+    case posEvent if (posEvent matches "ComplexEvent") && (!DarpaActions.hasNegativePolarity(posEvent)) =>
+      // get the controller of the event (assume only one controller)
+      val controller = posEvent.arguments("controller").head.toBioMention
+      flattenController(controller, negated)
+
+    // dig into the controller
+    case negEvent if (negEvent matches "ComplexEvent") && DarpaActions.hasNegativePolarity(negEvent) =>
+      // get the controller of the event (assume only one controller)
+      val controller = negEvent.arguments("controller").head.toBioMention
+      // negate the underlying PTM
+      // if received event has negative polarity (see issue #184)
+      flattenController(controller, negated=true)
+  }
+}

--- a/src/main/scala/org/clulab/reach/ReachConstants.scala
+++ b/src/main/scala/org/clulab/reach/ReachConstants.scala
@@ -1,28 +1,9 @@
 package org.clulab.reach
 
 /**
-  * This object wraps the taxonomy
+  * Convenience sets built from taxonomy
   */
-import java.util.Collection
-import org.yaml.snakeyaml.Yaml
-import org.yaml.snakeyaml.constructor.Constructor
-import org.clulab.odin.impl.Taxonomy
-
-
 object ReachConstants {
-
-  // Could be used by other components
-  val taxonomy = readTaxonomy("org/clulab/reach/biogrammar/taxonomy.yml")
-
-  private def readTaxonomy(path: String): Taxonomy = {
-    val url = getClass.getClassLoader.getResource(path)
-    val source = if (url == null) io.Source.fromFile(path) else io.Source.fromURL(url)
-    val input = source.mkString
-    source.close()
-    val yaml = new Yaml(new Constructor(classOf[Collection[Any]]))
-    val data = yaml.load(input).asInstanceOf[Collection[Any]]
-    Taxonomy(data)
-  }
 
   val ACTIVATION_EVENTS = taxonomy.hyponymsFor("ActivationEvent").toSet
   val REGULATION_EVENTS = taxonomy.hyponymsFor("Regulation").toSet

--- a/src/main/scala/org/clulab/reach/ReachSystem.scala
+++ b/src/main/scala/org/clulab/reach/ReachSystem.scala
@@ -66,6 +66,7 @@ class ReachSystem(
     val entitiesPerEntry = for (doc <- documents) yield extractEntitiesFrom(doc)
     contextEngine.infer(entries, documents, entitiesPerEntry)
     val entitiesWithContextPerEntry = for (es <- entitiesPerEntry) yield contextEngine.assign(es)
+    // get events
     val eventsPerEntry = for ((doc, es) <- documents zip entitiesWithContextPerEntry) yield {
         val events = extractEventsFrom(doc, es)
         MentionFilter.keepMostCompleteMentions(events, State(events))
@@ -77,7 +78,6 @@ class ReachSystem(
     val resolved = resolveCoref(groupMentionsByDocument(grounded, documents))
     // Coref introduced incomplete Mentions that now need to be pruned
     val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
-    // val complete = MentionFilter.keepMostCompleteMentions(eventsWithContext, State(eventsWithContext)).map(_.toBioMention)
 
     resolveDisplay(complete)
   }

--- a/src/main/scala/org/clulab/reach/display/package.scala
+++ b/src/main/scala/org/clulab/reach/display/package.scala
@@ -105,10 +105,10 @@ package object display {
         println(s"""$indent\t\t${evidence.label} by \"${evidence.text}\"\n"""
           + s"""$indent\t\t\tMutation rule: ${evidence.foundBy}\n"""
           + s"""$indent\t\t\tMutation attachment rule: $foundBy""")
-      case PTM(mod, evidence, site) =>
+      case PTM(mod, evidence, site, negated) =>
         val siteText = if (site.nonEmpty) {s" @ ${site.get.text}"} else ""
         val evidenceText = if (evidence.nonEmpty) {s""" based on \"${evidence.get.text}\""""} else ""
-        println(s"""$indent\t\t$PTM = \"$mod\"$siteText$evidenceText""")
+        println(s"""$indent\t\t$PTM (negated=$negated)= \"$mod\"$siteText$evidenceText""")
       case EventSite(site) =>
         println(s"""$indent\t\twith Site \"${site.text}\"""")
       case _ => ()

--- a/src/main/scala/org/clulab/reach/display/package.scala
+++ b/src/main/scala/org/clulab/reach/display/package.scala
@@ -108,7 +108,7 @@ package object display {
       case PTM(mod, evidence, site, negated) =>
         val siteText = if (site.nonEmpty) {s" @ ${site.get.text}"} else ""
         val evidenceText = if (evidence.nonEmpty) {s""" based on \"${evidence.get.text}\""""} else ""
-        println(s"""$indent\t\t$PTM (negated=$negated)= \"$mod\"$siteText$evidenceText""")
+        println(s"""$indent\t\t$PTM (negated=$negated) = \"$mod\"$siteText$evidenceText""")
       case EventSite(site) =>
         println(s"""$indent\t\twith Site \"${site.text}\"""")
       case _ => ()

--- a/src/main/scala/org/clulab/reach/extern/export/MentionManager.scala
+++ b/src/main/scala/org/clulab/reach/extern/export/MentionManager.scala
@@ -221,8 +221,9 @@ class MentionManager {
           mStrings += s"${indent}mutant: ${evidence.text}"
         case Negation(evidence) =>
           mStrings += s"${indent}negation: ${evidence.text}"
-        case PTM(modLabel, evidence, site) =>
+        case PTM(modLabel, evidence, site, negated) =>
           val evText = if (evidence.isDefined) evidence.get.text else ""
+          // FIXME: how should value of "negated" be displayed?
           mStrings += s"${indent}PTM: ${evText}"
           if (site.isDefined)
             mStrings ++= mentionToStrings(site.get, level+1)

--- a/src/main/scala/org/clulab/reach/extern/export/fries/FriesOutput.scala
+++ b/src/main/scala/org/clulab/reach/extern/export/fries/FriesOutput.scala
@@ -221,7 +221,7 @@ class FriesOutput extends JsonOutputter {
       mention match {
         case em:BioTextBoundMention =>
           val passage = getPassageForMention(passageMap, em)
-          frames ++= mkEntityMention(paperId, passage, em.toBioMention.asInstanceOf[BioTextBoundMention], contextIdMap, entityMap)
+          frames ++= mkEntityMention(paperId, passage, em, contextIdMap, entityMap)
         case _ => // these are events; we will export them later
       }
     }

--- a/src/main/scala/org/clulab/reach/extern/export/fries/FriesOutput.scala
+++ b/src/main/scala/org/clulab/reach/extern/export/fries/FriesOutput.scala
@@ -374,7 +374,8 @@ class FriesOutput extends JsonOutputter {
         val participants = new PropMap
         val complexParticipants = arg.asInstanceOf[RelationMention].arguments
         for(key <- complexParticipants.keySet) {
-          val ms: Seq[Mention] = complexParticipants.get(key).get
+          // FIXME: resolve each participant.  Should this be done elsewhere?
+          val ms: Seq[Mention] = complexParticipants.get(key).get.map(m => m.antecedentOrElse(m))
           for ((p, i) <- ms.zipWithIndex) {
             assert(p.isInstanceOf[TextBoundMention], {
               println(s"ASSERT-ERROR: complex participant is not an instance of TextBoundMention: ${p}")

--- a/src/main/scala/org/clulab/reach/extern/export/indexcards/IndexCardOutput.scala
+++ b/src/main/scala/org/clulab/reach/extern/export/indexcards/IndexCardOutput.scala
@@ -3,17 +3,15 @@ package org.clulab.reach.extern.export.indexcards
 import java.io.File
 import java.util.Date
 import java.util.regex.Pattern
-
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-
 import org.clulab.odin.Mention
 import org.clulab.reach.ReachConstants._
 import org.clulab.reach.extern.export._
 import org.clulab.reach.grounding.KBResolution
 import org.clulab.reach.mentions._
 import org.clulab.reach.nxml.FriesEntry
-
+import org.clulab.reach.OutputDegrader
 import JsonOutputter._
 import IndexCardOutput._
 
@@ -101,12 +99,13 @@ class IndexCardOutput extends JsonOutputter {
 
     // keeps just events:
     val eventMentions = derefedMentions.filter(MentionManager.isEventMention)
-
+    // flatten mentions
+    val flattenedMentions = OutputDegrader.flattenMentions(eventMentions).map(_.toCorefMention)
     // keeps track of simple events that participate in regulations
     val simpleEventsInRegs = new mutable.HashSet[Mention]()
 
     // first, print all regulation events
-    for(mention <- eventMentions) {
+    for (mention <- flattenedMentions) {
       if (REGULATION_EVENTS.contains(mention.label)) {
         val card = mkRegulationIndexCard(mention, simpleEventsInRegs)
         card.foreach(c => {
@@ -117,7 +116,7 @@ class IndexCardOutput extends JsonOutputter {
     }
 
     // now, print everything else that wasn't printed already
-    for(mention <- eventMentions) {
+    for (mention <- flattenedMentions) {
       if (! REGULATION_EVENTS.contains(mention.label) &&
           ! simpleEventsInRegs.contains(mention))
       {

--- a/src/main/scala/org/clulab/reach/mentions/BioMention.scala
+++ b/src/main/scala/org/clulab/reach/mentions/BioMention.scala
@@ -42,6 +42,9 @@ class BioEventMention(
 
   def this(m: EventMention) =
     this(m.labels, m.trigger, m.arguments, m.sentence, m.document, m.keep, m.foundBy)
+
+  def this(m: EventMention, direct: Boolean) =
+    this(m.labels, m.trigger, m.arguments, m.sentence, m.document, m.keep, m.foundBy, direct)
 }
 
 class BioRelationMention(

--- a/src/main/scala/org/clulab/reach/mentions/BioMention.scala
+++ b/src/main/scala/org/clulab/reach/mentions/BioMention.scala
@@ -20,6 +20,7 @@ class BioTextBoundMention(
     super.hashCode() * 42 + mutations.hashCode()
   }
 
+  def this(m: Mention) = this(m.labels, m.tokenInterval, m.sentence, m.document, m.keep, m.foundBy)
 }
 
 class BioEventMention(
@@ -34,12 +35,13 @@ class BioEventMention(
 ) extends EventMention(labels, trigger, arguments, sentence, document, keep, foundBy)
     with Modifications with Grounding with Display with Context{
 
-
   override def hashCode: Int = {
     val mutations = modifications.filter(_.isInstanceOf[Mutant])
     super.hashCode() * 42 + mutations.hashCode()
   }
 
+  def this(m: EventMention) =
+    this(m.labels, m.trigger, m.arguments, m.sentence, m.document, m.keep, m.foundBy)
 }
 
 class BioRelationMention(
@@ -57,6 +59,8 @@ class BioRelationMention(
     super.hashCode() * 42 + mutations.hashCode()
   }
 
+  def this(m: RelationMention) =
+    this(m.labels, m.arguments, m.sentence, m.document, m.keep, m.foundBy)
 }
 
 object BioMention{

--- a/src/main/scala/org/clulab/reach/mentions/CorefMention.scala
+++ b/src/main/scala/org/clulab/reach/mentions/CorefMention.scala
@@ -193,13 +193,13 @@ class CorefEventMention(
 
 
 class CorefRelationMention(
-                          labels: Seq[String],
-                          arguments: Map[String, Seq[Mention]],
-                          sentence: Int,
-                          document: Document,
-                          keep: Boolean,
-                          foundBy: String
-                          ) extends BioRelationMention(labels, arguments, sentence, document, keep, foundBy) with Anaphoric {
+  labels: Seq[String],
+  arguments: Map[String, Seq[Mention]],
+  sentence: Int,
+  document: Document,
+  keep: Boolean,
+  foundBy: String
+) extends BioRelationMention(labels, arguments, sentence, document, keep, foundBy) with Anaphoric {
 
   def isGeneric: Boolean = false
 

--- a/src/main/scala/org/clulab/reach/mentions/Modifications.scala
+++ b/src/main/scala/org/clulab/reach/mentions/Modifications.scala
@@ -23,7 +23,8 @@ sealed trait Modification {
 case class PTM(
   label: String,
   evidence: Option[Mention] = None,
-  site: Option[Mention] = None
+  site: Option[Mention] = None,
+  negated: Boolean = false
 ) extends Modification {
   override def toString: String = {
     val b = new StringBuilder()

--- a/src/main/scala/org/clulab/reach/package.scala
+++ b/src/main/scala/org/clulab/reach/package.scala
@@ -1,0 +1,23 @@
+package org.clulab
+
+import java.util.Collection
+import org.clulab.odin.impl.Taxonomy
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.Constructor
+
+
+package object reach {
+
+  // Taxonomy object
+  val taxonomy = readTaxonomy("org/clulab/reach/biogrammar/taxonomy.yml")
+
+  private def readTaxonomy(path: String): Taxonomy = {
+    val url = getClass.getClassLoader.getResource(path)
+    val source = if (url == null) io.Source.fromFile(path) else io.Source.fromURL(url)
+    val input = source.mkString
+    source.close()
+    val yaml = new Yaml(new Constructor(classOf[Collection[Any]]))
+    val data = yaml.load(input).asInstanceOf[Collection[Any]]
+    Taxonomy(data)
+  }
+}

--- a/src/test/scala/org/clulab/reach/DemoTests.scala
+++ b/src/test/scala/org/clulab/reach/DemoTests.scala
@@ -49,9 +49,10 @@ class DemoTests2 extends FunSuite with BeforeAndAfter {
     assert(hasEventWithArguments("Hydroxylation", List("Pkh1"), mentions), summarizeError(text, "Hydroxylation", assignedParty))
   }
 
-  test("there should be an up-regulation of the hydroxylation of Pkh1 by S6K1") {
-    assert(hasPositiveRegulationByEntity("S6K1", "Hydroxylation", List("Pkh1"), mentions), summarizeError(text, "Positive_regulation", assignedParty))
-  }
+  // Because we now prefer events over entities as controllers, the controller is now a phosphorylation.
+//  test("there should be an up-regulation of the hydroxylation of Pkh1 by S6K1") {
+//    assert(hasPositiveRegulationByEntity("S6K1", "Hydroxylation", List("Pkh1"), mentions), summarizeError(text, "Positive_regulation", assignedParty))
+//  }
 
   //test("In the future")(pending)
 }

--- a/src/test/scala/org/clulab/reach/TestActivationEvents.scala
+++ b/src/test/scala/org/clulab/reach/TestActivationEvents.scala
@@ -172,8 +172,7 @@ class TestActivationEvents extends FlatSpec with Matchers {
     val mentions = getBioMentions(sent21)
     val activations = mentions.filter(_ matches "Positive_activation")
     activations should have size (1)
-    val mods = activations.head.arguments("controller").head.toBioMention.modifications.map(_.label)
-    mods should contain ("Phosphorylation")
+    activations.head.arguments("controller").head.label should equal ("Phosphorylation")
   }
 
   val sent22 = "The phosphorylation of MEK deactivates K-Ras."
@@ -181,10 +180,9 @@ class TestActivationEvents extends FlatSpec with Matchers {
     val mentions = getBioMentions(sent22)
     val negActs = mentions.filter(_ matches "Negative_activation")
     negActs.length should be (1)
-    val mods = negActs.head.arguments("controller").head.toBioMention.modifications.map(_.label)
-    mods should contain ("Phosphorylation")
+    negActs.head.arguments("controller").head.label should equal ("Phosphorylation")
     // We shouldn't pick up any Positive Activations
-    mentions.count(_ matches "Positve_activation") should be(0)
+    mentions.count(_ matches "Positive_activation") should be (0)
   }
 
   // Relies on COREF

--- a/src/test/scala/org/clulab/reach/TestCoreference.scala
+++ b/src/test/scala/org/clulab/reach/TestCoreference.scala
@@ -256,12 +256,12 @@ class TestCoreference extends FlatSpec with Matchers {
     "have been several reports suggesting that Shp2 may specifically de-phosphorylate the tyrosine phosphorylation " +
     "sites on Gab1 that bind to p85, thus terminating recruitment of PI-3 kinase and EGF-induced activation of the " +
     "PI-3 kinase pathway"
-  sent24 should "have a complex controller if it produces an ActivationEvent" in {
+  sent24 should "have a Binding as a controller if it produces an ActivationEvent" in {
     val mentions = getBioMentions(sent24)
     val act = mentions.find(_ matches "ActivationEvent")
     if (act.nonEmpty) {
       val controller = act.get.arguments("controller").head
-      (controller.antecedentOrElse(controller) matches "Complex") should be (true)
+      (controller.antecedentOrElse(controller) matches "Binding") should be (true)
     }
   }
 

--- a/src/test/scala/org/clulab/reach/TestOutputDegrader.scala
+++ b/src/test/scala/org/clulab/reach/TestOutputDegrader.scala
@@ -1,0 +1,94 @@
+package org.clulab.reach
+
+import org.scalatest.{FlatSpec, Matchers}
+import org.clulab.reach.mentions._
+import TestUtils._
+
+
+class TestOutputDegrader extends FlatSpec with Matchers {
+
+  // Check that controller is converted to an entity + PTM(Phos) (adapt from this test)
+  val sent1 = "The phosphorylation of ASPP1 inhibits the ubiquitination of ASPP2"
+  sent1 should "contain a controller with a PTM" in {
+    val mentions = getFlattenedBioMentionsFromText(sent1)
+    val reg = mentions.find(_ matches "Negative_regulation")
+    reg should be ('defined)
+    reg.get.arguments should contain key ("controller")
+    reg.get.arguments should contain key ("controlled")
+    reg.get.arguments("controller") should have size (1)
+    reg.get.arguments("controlled") should have size (1)
+    val controller = reg.get.arguments("controller").head.toBioMention
+    val controlled = reg.get.arguments("controlled").head.toBioMention
+    // Before flattening, the text of the controller is the phospho event
+    controller.text should be ("ASPP1")
+    controller.modifications should have size (1)
+    controller.modifications.head.label should be ("Phosphorylation")
+    controlled.labels should contain ("Ubiquitination")
+    controlled.asInstanceOf[BioEventMention].isDirect should be (false)
+    controlled.arguments should contain key ("theme")
+    controlled.arguments should not contain key ("cause")
+    controlled.arguments("theme").head.text should be ("ASPP2")
+  }
+
+  // Check that controller is converted to a Complex (adapt from this test)
+  val sent2 = "The binding of ASPP1 and ASPP2 promotes the phosphorylation of MEK"
+  sent2 should "contain a controller with a complex" in {
+    val mentions = getFlattenedBioMentionsFromText(sent2)
+    val reg = mentions.find(_ matches "Positive_regulation")
+    reg should be ('defined)
+    reg.get.arguments should contain key ("controller")
+    reg.get.arguments should contain key ("controlled")
+    reg.get.arguments("controller") should have size (1)
+    reg.get.arguments("controlled") should have size (1)
+    val controller = reg.get.arguments("controller").head.toBioMention
+    val controlled = reg.get.arguments("controlled").head.toBioMention
+    controller.text should be ("ASPP1 and ASPP2")
+    controller.labels should contain ("Complex")
+    controlled.labels should contain ("Phosphorylation")
+    controlled.arguments should contain key ("theme")
+    controlled.arguments should not contain key ("cause")
+    controlled.arguments("theme").head.text should be ("MEK")
+    controlled.asInstanceOf[BioEventMention].isDirect should be (false)
+  }
+
+  // Check that controller is converted to a Complex (adapt from this test)
+  val sent3 = "The binding of BS1 and BS2 promotes the phosphorylation of MEK"
+  sent3 should "contain one positive regulation" in {
+    val mentions = getFlattenedBioMentionsFromText(sent3)
+    val posReg = mentions.filter(_ matches "Positive_regulation")
+    posReg should have size (1)
+    posReg.head.arguments should contain key ("controller")
+    posReg.head.arguments should contain key ("controlled")
+    posReg.head.arguments("controller") should have size (1)
+    posReg.head.arguments("controlled") should have size (1)
+    val controller = posReg.head.arguments("controller").head.toBioMention
+    val controlled = posReg.head.arguments("controlled").head.toBioMention
+    controller.matches("Complex") should be (true)
+    controlled.matches("Phosphorylation") should be (true)
+    controlled.asInstanceOf[BioEventMention].isDirect should be (false)
+  }
+
+  // Check that controller is converted to an entity + PTM(Phos) (adapt from this test)
+  val sent4 = "The phosphorylation of MEK activates K-Ras."
+  sent4 should "contain 1 activation with a phosphorylation event as its controller" in {
+    val mentions = getFlattenedBioMentionsFromText(sent4)
+    val activations = mentions.filter(_ matches "Positive_activation")
+    activations should have size (1)
+    val mods = activations.head.arguments("controller").head.toBioMention.modifications.map(_.label)
+    mods should contain ("Phosphorylation")
+  }
+
+  // Check that controller is converted to an entity + PTM(Phos) (adapt from this test)
+  val sent5 = "The phosphorylation of MEK deactivates K-Ras."
+  sent5 should "contain 1 Negative Activation with a phosphorylation event as its controller" in {
+    val mentions = getFlattenedBioMentionsFromText(sent5)
+    val negActs = mentions.filter(_ matches "Negative_activation")
+    negActs.length should be (1)
+    val mods = negActs.head.arguments("controller").head.toBioMention.modifications.map(_.label)
+    mods should contain ("Phosphorylation")
+    // We shouldn't pick up any Positive Activations
+    mentions.count(_ matches "Positve_activation") should be (0)
+  }
+
+  // TODO: Add more tests to check the flattening of nested events
+}

--- a/src/test/scala/org/clulab/reach/TestReachCLI.scala
+++ b/src/test/scala/org/clulab/reach/TestReachCLI.scala
@@ -63,8 +63,6 @@ class TestReachCLI extends FlatSpec with Matchers {
 
   def dumpLog(logFile:File): Unit = {
     println("LOG FILE:")
-    for(line <- io.Source.fromFile(logFile)) {
-      println(line)
-    }
+    println(io.Source.fromFile(logFile).mkString)
   }
 }

--- a/src/test/scala/org/clulab/reach/TestRegulationEvents.scala
+++ b/src/test/scala/org/clulab/reach/TestRegulationEvents.scala
@@ -162,9 +162,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
     reg.get.arguments("controlled") should have size (1)
     val controller = reg.get.arguments("controller").head.toBioMention
     val controlled = reg.get.arguments("controlled").head.toBioMention
-    controller.text should be ("ASPP1")
-    controller.modifications should have size (1)
-    controller.modifications.head.label should be ("Phosphorylation")
+    controller.label should equal ("Phosphorylation")
     controlled.labels should contain ("Ubiquitination")
     controlled.asInstanceOf[BioEventMention].isDirect should be (false)
     controlled.arguments should contain key ("theme")
@@ -183,8 +181,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
     reg.get.arguments("controlled") should have size (1)
     val controller = reg.get.arguments("controller").head.toBioMention
     val controlled = reg.get.arguments("controlled").head.toBioMention
-    controller.text should be ("ASPP1 and ASPP2")
-    controller.labels should contain ("Complex")
+    controller.label should equal ("Binding")
     controlled.labels should contain ("Phosphorylation")
     controlled.arguments should contain key ("theme")
     controlled.arguments should not contain key ("cause")
@@ -251,7 +248,7 @@ class TestRegulationEvents extends FlatSpec with Matchers {
     posReg.head.arguments("controlled") should have size (1)
     val controller = posReg.head.arguments("controller").head.toBioMention
     val controlled = posReg.head.arguments("controlled").head.toBioMention
-    controller.matches("Complex") should be (true)
+    controller.matches("Binding") should be (true)
     controlled.matches("Phosphorylation") should be (true)
     controlled.asInstanceOf[BioEventMention].isDirect should be (false)
   }

--- a/src/test/scala/org/clulab/reach/TestUtils.scala
+++ b/src/test/scala/org/clulab/reach/TestUtils.scala
@@ -44,7 +44,15 @@ object TestUtils {
   val mentionManager = new MentionManager()
 
   def getMentionsFromText(text: String): Seq[Mention] = PaperReader.getMentionsFromText(text)
-  
+
+  def getBioMentionsFromText(text: String): Seq[BioMention] = for {
+    m <- getMentionsFromText(text)
+  } yield m.toBioMention
+
+  def getFlattenedBioMentionsFromText(text: String): Seq[BioMention] = for {
+    m <- getMentionsFromText(text)
+  } yield OutputDegrader.flattenMention(m).toBioMention
+
   def getBioMentions(text:String, verbose:Boolean = false):Seq[BioMention] = {
     val entry = FriesEntry(docId, chunkId, "example", "example", isTitle = false, text)
     val result = Try(testReach.extractFrom(entry))


### PR DESCRIPTION
These changes resolve #184, which is a major change to the system.

## Summary
* `reach` now produces nested events where `Event -> Entity` conversion (ex. `Binding -> Complex` when serving as the `controller` of a `ComplexEvent`) is postponed until export (see `OutputDegrader`).   I think this is a step in the right direction for `reach`.

* Actions associated with `ComplexEvents` have been simplified. 
* Changes to existing tests to reflect these changes, as well as new tests for the "flattening".