### PR TITLE
Add participant features from precedence

### DIFF
--- a/src/main/scala/org/clulab/assembly/Assembler.scala
+++ b/src/main/scala/org/clulab/assembly/Assembler.scala
@@ -45,9 +45,9 @@ class Assembler(mns: Seq[Mention]) {
   def getInputFeaturesForParticipants(parent: Mention): Seq[RoleWithFeatures] = {
     val rwfs = for {
       (role, mns) <- parent.arguments
-      m <- mns
-      ptms = participantFeatureTracker.getInputFeatures(m, parent)
-    } yield RoleWithFeatures(role, m, ptms)
+      participant <- mns
+      ptms = participantFeatureTracker.getInputFeatures(participant, parent)
+    } yield RoleWithFeatures(role, participant, parent, ptms)
     rwfs.toSeq
   }
 

--- a/src/main/scala/org/clulab/assembly/ParticipantFeatureTracker.scala
+++ b/src/main/scala/org/clulab/assembly/ParticipantFeatureTracker.scala
@@ -7,10 +7,11 @@ import org.clulab.odin.Mention
 /**
   * Storage class for an event's participant (+ the input features for the participant)
   * @param role the participant's role (theme, controlled, etc.)
-  * @param mention the mention associated with the participant
+  * @param participant the [[Mention]] associated with the participant
+  * @param parent the [[Mention]] (an event) serving as the participant's parent
   * @param features Set[[PTM]] defining the state of the participant upon event input (pulled from causal predecessors)
   */
-case class RoleWithFeatures(role: String, mention: Mention, features: Set[representations.PTM])
+case class RoleWithFeatures(role: String, participant: Mention, parent: Mention, features: Set[representations.PTM])
 
 class ParticipantFeatureTracker(am: AssemblyManager) {
 

--- a/src/main/scala/org/clulab/assembly/ParticipantFeatureTracker.scala
+++ b/src/main/scala/org/clulab/assembly/ParticipantFeatureTracker.scala
@@ -28,7 +28,7 @@ class ParticipantFeatureTracker(am: AssemblyManager) {
     case entity: SimpleEntity if entity.grounding == gid => entity.getPTMs
     case diffEntity: SimpleEntity if diffEntity.grounding != gid => Set.empty[PTM]
     case complex: Complex => complex.members.flatMap(e => getOutputFeatures(gid, e))
-    case event: SimpleEvent => event.O.flatMap(entity => getOutputFeatures(gid, entity))
+    case event: Event => event.O.flatMap(entity => getOutputFeatures(gid, entity))
   }
 
   /**

--- a/src/main/scala/org/clulab/assembly/ParticipantFeatureTracker.scala
+++ b/src/main/scala/org/clulab/assembly/ParticipantFeatureTracker.scala
@@ -1,0 +1,71 @@
+package org.clulab.assembly
+
+import org.clulab.assembly.representations._
+import org.clulab.odin.Mention
+
+
+/**
+  * Storage class for an event's participant (+ the input features for the participant)
+  * @param role the participant's role (theme, controlled, etc.)
+  * @param mention the mention associated with the participant
+  * @param features Set[[PTM]] defining the state of the participant upon event input (pulled from causal predecessors)
+  */
+case class RoleWithFeatures(role: String, mention: Mention, features: Set[representations.PTM])
+
+class ParticipantFeatureTracker(am: AssemblyManager) {
+
+  private val manager = am
+
+  /**
+    * Get output features (Set of PTMs) for some EER and its causal predecessors. <br>
+    * The output entities of causal predecessors must match the gid in order for their PTMs to be retrieved.
+    * @param gid A [[GroundingID]] that the eer must match
+    * @param eer an [[EntityEventRepresentation]]
+    * @return Set[[PTM]] defining the state of the participant upon event output
+    */
+  def getOutputFeatures(gid: GroundingID, eer: EER): Set[representations.PTM] = eer match {
+    case entity: SimpleEntity if entity.grounding == gid => entity.getPTMs
+    case diffEntity: SimpleEntity if diffEntity.grounding != gid => Set.empty[PTM]
+    case complex: Complex => complex.members.flatMap(e => getOutputFeatures(gid, e))
+    case event: SimpleEvent => event.O.flatMap(entity => getOutputFeatures(gid, entity))
+  }
+
+  /**
+    * Recursively collect the causal predecessors of an [[EER]]
+    * @param eer an [[EER]]
+    * @return the set of causal predecessors (and their causal predecessors, etc.)
+    */
+  private def getPredecessors(eer: EER): Set[EER] = eer match {
+    case noPredecessors: EER if manager.distinctPredecessorsOf(noPredecessors).isEmpty => Set.empty[EER]
+    case hasPredecessors: EER =>
+      val predecessors: Set[EER] = manager.distinctPredecessorsOf(hasPredecessors)
+      predecessors ++ predecessors.flatMap(getPredecessors)
+  }
+
+  private def getPredecessors(m: Mention): Set[EER] = getPredecessors(manager.getEER(m))
+
+  final def getInputFeatures(m: Mention, parent: Mention): Set[representations.PTM] = m match {
+    // we only retrieve PTMs from an entity that is not a complex
+    case entity if entity matches "Entity" =>
+      // can only retrieve features on an entity that is not a complex
+      // TODO: should this be changed to get or create?
+      // TODO: Check that an SimpleEntity with a PTM would be equivalent to a SimpleEvent without a cause
+      manager.getEER(m) match {
+        case ent: SimpleEntity =>
+          // Check for predecessors of parent
+          val predecessors = getPredecessors(parent)
+          // the Entity's PTMs + those of its relevant predecessors
+          ent.getPTMs ++ predecessors.flatMap(p => getOutputFeatures(ent.grounding, p))
+        // if this is a complex, we don't know which member to look at...
+        case _ => Set.empty[representations.PTM]
+      }
+    case _ => Set.empty[representations.PTM]
+//    // get the output entity of this event
+//    case event if event matches "Event" =>
+//      val outputEntity: Mention = DarpaActions.convertEventToEntity(m, asOutput = true, negated = DarpaActions.hasNegativePolarity(m))
+//      getInputFeatures(outputEntity, parent)
+//    // TODO: should this be changed to lump together all the features of each complex member?
+//    case complex if complex matches "Complex" =>
+//      Set.empty[representations.PTM]
+  }
+}

--- a/src/main/scala/org/clulab/assembly/sieves/Sieves.scala
+++ b/src/main/scala/org/clulab/assembly/sieves/Sieves.scala
@@ -365,7 +365,7 @@ object SieveUtils {
   def findTrigger(m: Mention): TextBoundMention = m match {
     // if mention is TB, just use the mention
     case tb: TextBoundMention =>
-      println(s"no trigger for mention '${tb.text}' with label '${m.label}'")
+      // println(s"no trigger for mention '${tb.text}' with label '${m.label}'")
       tb
     case event: EventMention =>
       event.trigger

--- a/src/main/scala/org/clulab/assembly/sieves/Sieves.scala
+++ b/src/main/scala/org/clulab/assembly/sieves/Sieves.scala
@@ -228,6 +228,7 @@ class PrecedenceSieves extends Sieves {
     def correctScope(m: Mention): Mention = {
       m match {
         // arguments will have at most one "event" argument
+        // FIXME: the nesting is no longer limited
         case nested if nested.arguments contains "event" => nested.arguments("event").head
         case flat => flat
       }
@@ -277,10 +278,10 @@ class PrecedenceSieves extends Sieves {
       label match {
         case E1PrecedesE2 =>
           val evidence = createEvidenceForCPR(e1, e2, sieveName)
-          manager.storePrecedenceRelation(e1, e2, evidence, sieveName)
+          manager.storePrecedenceRelation(before = e1, after = e2, evidence, sieveName)
         case E2PrecedesE1 =>
           val evidence = createEvidenceForCPR(e2, e1, sieveName)
-          manager.storePrecedenceRelation(e2, e1, evidence, sieveName)
+          manager.storePrecedenceRelation(before = e2, after = e1, evidence, sieveName)
       }
     }
     manager

--- a/src/main/scala/org/clulab/reach/AssemblyCLI.scala
+++ b/src/main/scala/org/clulab/reach/AssemblyCLI.scala
@@ -9,7 +9,6 @@ import org.clulab.assembly._
 import org.clulab.odin._
 import org.clulab.reach.extern.export.fries._
 import org.clulab.reach.nxml._
-import ai.lum.nxmlreader.NxmlReader
 import ai.lum.nxmlreader.NxmlDocument
 
 
@@ -50,18 +49,20 @@ class AssemblyCLI(
         println(s"  ${nsToS(startNS, System.nanoTime)}s: $paperId: starting reading")
 
       val mentions = PaperReader.getMentionsFromPaper(file)
-
+      // NOTE: We're already doing this in the exporter, but the mentions given to the Assembler probably
+      // need to match since flattening results in a loss of information
+      val mentionsForOutput = OutputDegrader.prepareForOutput(mentions)
       if (verbose)
         println(s"  ${nsToS(startNS, System.nanoTime)}s: $paperId: finished reading")
 
-      val assemblyAPI = new Assembler(mentions) // do assembly
+      val assemblyAPI = new Assembler(mentionsForOutput) // do assembly
 
       if (verbose)
         println(s"  ${nsToS(startNS, System.nanoTime)}s: $paperId: finished initializing Assembler")
 
       val procTime = AssemblyCLI.now
       val nxmldoc = PaperReader.nxmlReader.read(file)
-      outputMentions(mentions, nxmldoc, paperId, startTime, procTime, outputDir, assemblyAPI)
+      outputMentions(mentionsForOutput, nxmldoc, paperId, startTime, procTime, outputDir, assemblyAPI)
 
       val endTime = AssemblyCLI.now
       val endNS = System.nanoTime


### PR DESCRIPTION
These changes allow us to determine the state of event participants at event input by retrieving the relevant PTMs from the event's causal predecessors (addressing issue #178).  

Note that this version doesn't address whether or not a entity was previously bound, activated, or regulated (though this information could also be recovered from the `AssemblyManager`).