### PR TITLE
Breadcrumb predecessors (resolves #296)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ pomExtra := (
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.13",
+  "org.clulab" % "bioresources" % "1.1.14-SNAPSHOT",
   "org.clulab" %% "processors" % "5.9.3",
   "org.clulab" %% "processors" % "5.9.3" classifier "models",
   "com.typesafe" % "config" % "1.2.1",

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ pomExtra := (
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.14-SNAPSHOT",
+  "org.clulab" % "bioresources" % "1.1.13",
   "org.clulab" %% "processors" % "5.9.3",
   "org.clulab" %% "processors" % "5.9.3" classifier "models",
   "com.typesafe" % "config" % "1.2.1",

--- a/src/main/scala/org/clulab/reach/ReachCLI.scala
+++ b/src/main/scala/org/clulab/reach/ReachCLI.scala
@@ -2,7 +2,6 @@ package org.clulab.reach
 
 import java.io.File
 import java.util.Date
-
 import scala.collection.JavaConverters._
 import scala.collection.parallel.ForkJoinTaskSupport
 import com.typesafe.config.ConfigFactory

--- a/src/test/scala/org/clulab/reach/TestReachCLI.scala
+++ b/src/test/scala/org/clulab/reach/TestReachCLI.scala
@@ -37,8 +37,7 @@ class TestReachCLI extends FlatSpec with Matchers {
 
   "ReachCLI" should "output TEXT correctly on NXML papers" in {
     println(s"Will output TEXT output in directory ${txtDir.getAbsolutePath}")
-    val outputType = "text"
-    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = txtDir, outputFormat = outputType, logFile = txtLogFile, verbose = false)
+    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = txtDir, outputFormat = "text", logFile = txtLogFile, verbose = false)
     val errorCount = cli.processPapers(threadLimit = None, withAssembly = false)
     if(errorCount > 0) dumpLog(txtLogFile)
     errorCount should be (0)
@@ -46,8 +45,7 @@ class TestReachCLI extends FlatSpec with Matchers {
 
   it should "output FRIES correctly on NXML papers without assembly" in {
     println(s"Will output FRIES output in directory ${friesDir.getAbsolutePath}")
-    val outputType = "fries"
-    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = friesDir, outputFormat = outputType, logFile = friesLogFile, verbose = false)
+    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = friesDir, outputFormat = "fries", logFile = friesLogFile, verbose = false)
     val errorCount = cli.processPapers(threadLimit = None, withAssembly = false)
     if(errorCount > 0) dumpLog(friesLogFile)
     errorCount should be (0)
@@ -55,8 +53,7 @@ class TestReachCLI extends FlatSpec with Matchers {
 
   it should "output FRIES correctly on NXML papers with Assembly" in {
     println(s"Will output FRIES output in directory ${friesWithAssemblyDir.getAbsolutePath}")
-    val outputType = "fries"
-    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = friesWithAssemblyDir, outputFormat = outputType, logFile = friesWithAssemblyLogFile, verbose = false)
+    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = friesWithAssemblyDir, outputFormat = "fries", logFile = friesWithAssemblyLogFile, verbose = false)
     val errorCount = cli.processPapers(threadLimit = None, withAssembly = true)
     if(errorCount > 0) dumpLog(friesWithAssemblyLogFile)
     errorCount should be (0)
@@ -64,8 +61,7 @@ class TestReachCLI extends FlatSpec with Matchers {
 
   it should "output IndexCard correctly on NXML papers" in {
     println(s"Will output IndexCard output in directory ${icDir.getAbsolutePath}")
-    val outputType = "indexcard"
-    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = icDir, outputFormat = outputType, logFile = icLogFile, verbose = false)
+    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = icDir, outputFormat = "indexcard", logFile = icLogFile, verbose = false)
     val errorCount = cli.processPapers(threadLimit = None, withAssembly = false)
     if(errorCount > 0) dumpLog(icLogFile)
     errorCount should be (0)

--- a/src/test/scala/org/clulab/reach/TestReachCLI.scala
+++ b/src/test/scala/org/clulab/reach/TestReachCLI.scala
@@ -40,7 +40,7 @@ class TestReachCLI extends FlatSpec with Matchers {
     val outputType = "text"
     val cli = new ReachCLI(papersDir = nxmlDir, outputDir = txtDir, outputFormat = outputType, logFile = txtLogFile, verbose = false)
     val errorCount = cli.processPapers(threadLimit = None, withAssembly = false)
-    if(errorCount > 0) dumpLog(friesLogFile)
+    if(errorCount > 0) dumpLog(txtLogFile)
     errorCount should be (0)
   }
 
@@ -54,11 +54,11 @@ class TestReachCLI extends FlatSpec with Matchers {
   }
 
   it should "output FRIES correctly on NXML papers with Assembly" in {
-    println(s"Will output FRIES output in directory ${friesDir.getAbsolutePath}")
+    println(s"Will output FRIES output in directory ${friesWithAssemblyDir.getAbsolutePath}")
     val outputType = "fries"
     val cli = new ReachCLI(papersDir = nxmlDir, outputDir = friesWithAssemblyDir, outputFormat = outputType, logFile = friesWithAssemblyLogFile, verbose = false)
     val errorCount = cli.processPapers(threadLimit = None, withAssembly = true)
-    if(errorCount > 0) dumpLog(friesLogFile)
+    if(errorCount > 0) dumpLog(friesWithAssemblyLogFile)
     errorCount should be (0)
   }
 
@@ -67,7 +67,7 @@ class TestReachCLI extends FlatSpec with Matchers {
     val outputType = "indexcard"
     val cli = new ReachCLI(papersDir = nxmlDir, outputDir = icDir, outputFormat = outputType, logFile = icLogFile, verbose = false)
     val errorCount = cli.processPapers(threadLimit = None, withAssembly = false)
-    if(errorCount > 0) dumpLog(friesLogFile)
+    if(errorCount > 0) dumpLog(icLogFile)
     errorCount should be (0)
   }
 


### PR DESCRIPTION
While we were already disallowing direct contradictions (i.e., **A precedes B** cannot co-occur with **B precedes A**), it seems that somewhere in the dark, winding chain of causal predecessors loops may lurk waiting to prey on unsuspecting algorithms.  

The method for generating participant features now leaves a trail of breadcrumbs to avoid wandering down the same dark corridors again and again...and again.

The `TestReachCLI` suite now passes on `bioresources 1.1.14-SNAPSHOT`.