### PR TITLE
Precedence fixes and updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ pomExtra := (
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.13",
+  "org.clulab" % "bioresources" % "1.1.14",
   "org.clulab" %% "processors" % "5.9.3",
   "org.clulab" %% "processors" % "5.9.3" classifier "models",
   "com.typesafe" % "config" % "1.2.1",

--- a/src/main/scala/org/clulab/assembly/Assembler.scala
+++ b/src/main/scala/org/clulab/assembly/Assembler.scala
@@ -21,11 +21,10 @@ class Assembler(mns: Seq[Mention]) {
     val links = for {
       m <- mentions
       eer = am.getEER(m)
-      eh = eer.equivalenceHash
-      pr <- am.getPrecedenceRelations(eh)
+      pr <- am.getPrecedenceRelationsFor(eer)
       after = pr.after
       // current mention should be the successor
-      if after == eh
+      if after.equivalenceHash == eer.equivalenceHash
       e <- pr.evidence
       // only consider links with well-formed evidence
       if e.arguments.contains("before") && e.arguments.contains("after")

--- a/src/main/scala/org/clulab/assembly/AssemblyManager.scala
+++ b/src/main/scala/org/clulab/assembly/AssemblyManager.scala
@@ -11,14 +11,14 @@ import org.clulab.reach.mentions
 
 /**
  * Stores precedence information for two distinct [[EntityEventRepresentation]]
- * @param before [[EntityEventRepresentation.equivalenceHash]] identifying the EER that precedes [[PrecedenceRelation.after]]
- * @param after [[EntityEventRepresentation.equivalenceHash]] identifying the EER that follows [[PrecedenceRelation.before]]
+ * @param before the [[EntityEventRepresentation] that precedes [[PrecedenceRelation.after]]
+ * @param after the [[EntityEventRepresentation]] that follows [[PrecedenceRelation.before]]
  * @param evidence the mentions that serve as evidence for this precedence relation
  * @param foundBy the name of the Sieve which found this relation
  */
 case class PrecedenceRelation(
-  before: Int,
-  after: Int,
+  before: EER,
+  after: EER,
   var evidence: Set[Mention],
   foundBy: String
 ) {
@@ -28,6 +28,7 @@ case class PrecedenceRelation(
     * @param other Any comparison object
     * @return a Boolean
     */
+  // TODO: Should this be in terms of an Equiv Hash?
   def strictlyEquivalent(other: Any): Boolean = other match {
     case pr: PrecedenceRelation => this.before == pr.before && this.after == pr.after
     case _ => false
@@ -38,6 +39,7 @@ case class PrecedenceRelation(
     * @param other Any comparison object
     * @return a Boolean
     */
+  // TODO: Should this be in terms of an Equiv Hash?
   def isEquivalentTo(other: Any): Boolean = other match {
     case pr: PrecedenceRelation => this.before == pr.before || this.after == pr.after
     case _ => false
@@ -76,8 +78,8 @@ class AssemblyManager(
   }
 
   private var idToMentionState: immutable.Map[IDPointer, MentionState] = mentionStateToID.map{ case (k, v) => (v, k)}
-  // PrecedenceRelations associated with a distinct EER (key is equivalenceHash)
-  private var idToPrecedenceRelations: immutable.Map[Int, Set[PrecedenceRelation]] =
+  // PrecedenceRelations associated with a distinct EER
+  private var EERtoPrecedenceRelations: immutable.Map[EER, Set[PrecedenceRelation]] =
     Map.empty
       .withDefaultValue(Set.empty[PrecedenceRelation])
   // initialize to size of LUT 2
@@ -88,7 +90,7 @@ class AssemblyManager(
   //
 
   /**
-   * Stores a PrecedenceRelation in [[idToPrecedenceRelations]] connecting "before" and "after".
+   * Stores a PrecedenceRelation in [[EERtoPrecedenceRelations]] connecting "before" and "after".
    * Tracks "before" and "after" Mentions and produces EERs, is not already present.
    * @param before an Odin Mention that causally precedes "after"
    * @param after an Odin Mention that (causally) follows "before"
@@ -98,7 +100,7 @@ class AssemblyManager(
   def storePrecedenceRelation(
     before: Mention,
     after: Mention,
-    evidence: Set[Mention],
+    evidence: Set[Mention] = Set.empty[Mention],
     foundBy: String
   ): Unit = {
 
@@ -106,36 +108,12 @@ class AssemblyManager(
     // and get their corresponding EERs
     val eer1 = getOrCreateEER(before)
     val eer2 = getOrCreateEER(after)
-
-    // create a PR for the two EERs
-    val pr = PrecedenceRelation(
-      before = eer1.equivalenceHash,
-      after = eer2.equivalenceHash,
-      evidence,
-      foundBy
-    )
-
-    updateIDtoPrecedenceRelations(pr)
+    val ev: Set[Mention] = if (evidence.isEmpty) sieves.SieveUtils.createEvidenceForCPR(before, after, foundBy) else evidence
+    storePrecedenceRelation(before = eer1, after = eer2, ev, foundBy)
   }
 
   /**
-   * Stores a PrecedenceRelation in [[idToPrecedenceRelations]] connecting "before" and "after".
-   * Tracks "before" and "after" Mentions and produces EERs, is not already present.
-   * @param before an Odin Mention that causally precedes "after"
-   * @param after an Odin Mention that (causally) follows "before"
-   * @param foundBy the name of the sieve or procedure that discovered this precedence relation
-   */
-  def storePrecedenceRelation(
-    before: Mention,
-    after: Mention,
-    foundBy: String
-  ): Unit = {
-    val evidence = sieves.SieveUtils.createEvidenceForCPR(before, after, foundBy)
-    storePrecedenceRelation(before, after, evidence, foundBy)
-  }
-
-  /**
-   * Stores a PrecedenceRelation in [[idToPrecedenceRelations]] for the EERs corresponding to "before" and "after"
+   * Stores a PrecedenceRelation in [[EERtoPrecedenceRelations]] for the EERs corresponding to "before" and "after"
    * @param before an [[EntityEventRepresentation]] that causally precedes "after"
    * @param after an [[EntityEventRepresentation]] that (causally) follows "before"
    * @param foundBy the name of the sieve or procedure that discovered this precedence relation
@@ -143,63 +121,54 @@ class AssemblyManager(
   def storePrecedenceRelation(
     before: EER,
     after: EER,
+    evidence: Set[Mention],
     foundBy: String
   ): Unit = {
 
     val pr = PrecedenceRelation(
-      before.equivalenceHash,
-      after.equivalenceHash,
-      Set.empty[Mention],
+      before,
+      after,
+      evidence,
       foundBy
     )
 
-    updateIDtoPrecedenceRelations(pr)
+    updateEERtoPrecedenceRelations(pr)
   }
 
+  def storePrecedenceRelation(
+    before: EER,
+    after: EER,
+    foundBy: String
+  ): Unit = storePrecedenceRelation(before, after, Set.empty[Mention], foundBy)
+
   /**
-   * Update entries in [[idToPrecedenceRelations]] for pr.before and pr.after
+   * Update entries in [[EERtoPrecedenceRelations]] for pr.before and pr.after
    * @param pr a [[PrecedenceRelation]]
    */
-  private def updateIDtoPrecedenceRelations(pr: PrecedenceRelation): Unit = {
-
+  private def updateEERtoPrecedenceRelations(pr: PrecedenceRelation): Unit = {
     // update PRs for before
-    updateIDtoPrecedenceRelations(pr.before, pr)
+    val before = pr.before
+    val oldBefore = EERtoPrecedenceRelations.getOrElse(before, Set.empty)
+    EERtoPrecedenceRelations = EERtoPrecedenceRelations + (before -> (oldBefore ++ Set(pr)))
     // update PRs for after
-    updateIDtoPrecedenceRelations(pr.after, pr)
-  }
-
-  /**
-   * Update entry in [[idToPrecedenceRelations]] for the provided equivalenceHash (eh)
-   * @param eh an [[EntityEventRepresentation.equivalenceHash]]
-   * @param pr a [[PrecedenceRelation]]
-   */
-  private def updateIDtoPrecedenceRelations(eh: Int, pr: PrecedenceRelation): Unit = {
-    val old = idToPrecedenceRelations.getOrElse(eh, Set.empty)
-    // add the pr to the set of existing PRs
-    idToPrecedenceRelations = idToPrecedenceRelations + (eh -> (old ++ Set(pr)))
+    val after = pr.after
+    val oldAfter = EERtoPrecedenceRelations.getOrElse(after, Set.empty)
+    EERtoPrecedenceRelations = EERtoPrecedenceRelations + (after -> (oldAfter ++ Set(pr)))
   }
 
   // retrieval of PrecedenceRelations
   /**
    * Retrieves the Set of PrecedenceRelations corresponding to the provided [[EntityEventRepresentation.equivalenceHash]] (eh)
-   * @param eh an [[EntityEventRepresentation.equivalenceHash]]
-   */
-  def getPrecedenceRelations(eh: Int): Set[PrecedenceRelation] = idToPrecedenceRelations(eh)
-
-  /**
-   * Retrieves the Set of PrecedenceRelations corresponding to the provided [[EntityEventRepresentation]] (eer)
    * @param eer an [[EntityEventRepresentation]]
    */
-  def getPrecedenceRelations(eer: EER): Set[PrecedenceRelation] = {
-    idToPrecedenceRelations(eer.equivalenceHash)
-  }
+  def getPrecedenceRelationsFor(eer: EER): Set[PrecedenceRelation] = EERtoPrecedenceRelations(eer)
 
   /**
    * Retrieves the Set of PrecedenceRelations corresponding to the provided Mention
    * @param m an Odin Mention
    */
-  def getPrecedenceRelations(m: Mention): Set[PrecedenceRelation] = {
-    getPrecedenceRelations(getOrCreateEER(m))
+  def getPrecedenceRelationsFor(m: Mention): Set[PrecedenceRelation] = {
+    getPrecedenceRelationsFor(getOrCreateEER(m))
   }
 
   /**
@@ -208,22 +177,18 @@ class AssemblyManager(
   def getPrecedenceRelations: Set[PrecedenceRelation] = {
    for {
      e <- distinctEvents
-     pr <- getPrecedenceRelations(e)
+     pr <- getPrecedenceRelationsFor(e)
    } yield pr
   }
 
   /**
-   * Retrieves the distinct Set of EER predecessors for the provided equivalenceHash (eh).
-   * @param eh an [[EntityEventRepresentation.equivalenceHash]]
-   * @return the Set of distinct EntityEventRepresentations known to causally precede any EER corresponding to eh
+   * Retrieves the distinct Set of EER predecessors for the provided EER.
+   * @param eer an [[EntityEventRepresentation]]
+   * @return the Set of distinct EntityEventRepresentations known to causally precede any EER corresponding to [[EntityEventRepresentation.equivalenceHash]]
    */
-  def distinctPredecessorsOf(eh: Int): Set[EER] = {
-   val predecessors = predecessorsOf(eh)
-    distinctEERsFromSet(predecessors)
-  }
-
   def distinctPredecessorsOf(eer: EER): Set[EER] = {
-    distinctPredecessorsOf(eer.equivalenceHash)
+    val predecessors = predecessorsOf(eer)
+    distinctEERsFromSet(predecessors)
   }
 
   /**
@@ -238,25 +203,14 @@ class AssemblyManager(
   }
 
   /**
-   * Retrieves the non-distinct Set of EER predecessors for the provided equivalenceHash (eh).
-   * @param eh an [[EntityEventRepresentation.equivalenceHash]]
-   * @return the Set of non-distinct EntityEventRepresentations known to causally precede any EER corresponding to eh
-   */
-  def predecessorsOf(eh: Int): Set[EER] = for {
-    pr <- getPrecedenceRelations(eh)
-    before = pr.before
-    if before != eh
-    eer <- getEquivalentEERs(before)
-  } yield eer
-
-  /**
    * Retrieves the non-distinct Set of EER predecessors for the provided EER.
    * @param eer an [[EntityEventRepresentation]]
    * @return the Set of non-distinct EntityEventRepresentations known to causally precede eer
    */
-  def predecessorsOf(eer: EER): Set[EER] = {
-    predecessorsOf(eer.equivalenceHash)
-  }
+  def predecessorsOf(eer: EER): Set[EER] = for {
+    pr <- EERtoPrecedenceRelations(eer)
+    if pr.before.equivalenceHash != eer.equivalenceHash
+  } yield pr.before
 
   /**
    * Retrieves the non-distinct Set of EER predecessors for the provided Mention (m).
@@ -271,22 +225,13 @@ class AssemblyManager(
   }
 
   /**
-   * Retrieves the distinct Set of EER successors for the provided equivalenceHash (eh).
-   * @param eh an [[EntityEventRepresentation.equivalenceHash]]
-   * @return the Set of distinct EntityEventRepresentations known to causally succeed any EER corresponding to eh
-   */
-  def distinctSuccessorsOf(eh: Int): Set[EER] = {
-    val successors = successorsOf(eh)
-    distinctEERsFromSet(successors)
-  }
-
-  /**
    * Retrieves the distinct Set of EER successors for the provided EER.
    * @param eer an [[EntityEventRepresentation]]
    * @return the Set of distinct EntityEventRepresentations known to causally succeed any EER corresponding to eh
    */
   def distinctSuccessorsOf(eer: EER): Set[EER] = {
-    distinctSuccessorsOf(eer.equivalenceHash)
+    val successors = successorsOf(eer)
+    distinctEERsFromSet(successors)
   }
 
   /**
@@ -302,25 +247,14 @@ class AssemblyManager(
   }
 
   /**
-   * Retrieves the non-distinct Set of EER successors for the provided equivalenceHash (eh).
-   * @param eh an [[EntityEventRepresentation.equivalenceHash]]
-   * @return the Set of non-distinct EntityEventRepresentations known to causally succeed any EER corresponding to eh
-   */
-  def successorsOf(eh: Int): Set[EER] = for {
-    pr <- getPrecedenceRelations(eh)
-    after = pr.after
-    if after != eh
-    eer <- getEquivalentEERs(after)
-  } yield eer
-
-  /**
    * Retrieves the non-distinct Set of EER successors for the provided EER.
    * @param eer an [[EntityEventRepresentation]]
    * @return the Set of non-distinct EntityEventRepresentations known to causally succeed eer
    */
-  def successorsOf(eer: EER): Set[EER] = {
-    successorsOf(eer.equivalenceHash)
-  }
+  def successorsOf(eer: EER): Set[EER] = for {
+    pr <- getPrecedenceRelationsFor(eer)
+    if pr.after.equivalenceHash != eer.equivalenceHash
+  } yield eer
 
   /**
    * Retrieves the non-distinct Set of EER successors for the provided Mention (m).
@@ -1371,6 +1305,7 @@ class AssemblyManager(
    * @return
    */
   def getEquivalentEERs(eh: Int): Set[EER] = ehToEERs.getOrElse(eh, Set.empty[EER])
+  def getEquivalentEERs(eer: EER): Set[EER] = ehToEERs.getOrElse(eer.equivalenceHash, Set.empty[EER])
 
   /**
    * Returns groups of equivalent [[EntityEventRepresentation]], ignoring differences due to [[IDPointer]] references.

--- a/src/main/scala/org/clulab/assembly/AssemblyManager.scala
+++ b/src/main/scala/org/clulab/assembly/AssemblyManager.scala
@@ -487,7 +487,9 @@ class AssemblyManager(
         // TODO: is site part of label?
         case mut: mentions.Mutant => Set(MutantEntity(mut.label))
         // TODO: should site be handled differently?
-        case ptm: mentions.PTM => Set(PTM(ptm.toString, None, ptm.negated))
+        case ptm: mentions.PTM =>
+          val site: Option[String] = if (ptm.site.nonEmpty) Some(ptm.site.get.text) else None
+          Set(PTM(ptm.label, site, ptm.negated))
         case _ => Nil
       }
     if (m matches "Entity") Set(EntityLabel(m.label)) ++ mods else mods

--- a/src/main/scala/org/clulab/assembly/ParticipantFeatureTracker.scala
+++ b/src/main/scala/org/clulab/assembly/ParticipantFeatureTracker.scala
@@ -45,7 +45,10 @@ class ParticipantFeatureTracker(am: AssemblyManager) {
     unseenPredecessors.flatten ++ seen
   }
 
-  private def getPredecessors(m: Mention): Set[EER] = getPredecessors(manager.getEER(m))
+  private def getPredecessors(m: Mention): Set[EER] = {
+    val eer = manager.getEER(m)
+    getPredecessors(eer) - eer
+  }
 
   final def getInputFeatures(m: Mention, parent: Mention): Set[representations.PTM] = m match {
     // we only retrieve PTMs from an entity that is not a complex
@@ -53,7 +56,7 @@ class ParticipantFeatureTracker(am: AssemblyManager) {
       // can only retrieve features on an entity that is not a complex
       // TODO: should this be changed to get or create?
       // TODO: Check that an SimpleEntity with a PTM would be equivalent to a SimpleEvent without a cause
-      manager.getEER(m) match {
+      manager.getEER(entity) match {
         case ent: SimpleEntity =>
           // Check for predecessors of parent
           val predecessors = getPredecessors(parent)

--- a/src/main/scala/org/clulab/assembly/RunAssembly.scala
+++ b/src/main/scala/org/clulab/assembly/RunAssembly.scala
@@ -107,9 +107,9 @@ object RunAnnotationEval extends App {
         am.trackMentions(Seq(e1, e2))
         val goldRel = anno.relation match {
           case "E1 precedes E2" =>
-            Seq(PrecedenceRelation(am.getEER(e1).equivalenceHash, am.getEER(e2).equivalenceHash, Set.empty[Mention], "gold"))
+            Seq(PrecedenceRelation(am.getEER(e1), am.getEER(e2), Set.empty[Mention], "gold"))
           case "E2 precedes E1" =>
-            Seq(PrecedenceRelation(am.getEER(e2).equivalenceHash, am.getEER(e1).equivalenceHash, Set.empty[Mention], "gold"))
+            Seq(PrecedenceRelation(am.getEER(e2), am.getEER(e1), Set.empty[Mention], "gold"))
           case _ => Nil
         }
         (goldRel, Seq(e1, e2))

--- a/src/main/scala/org/clulab/assembly/representations/Event.scala
+++ b/src/main/scala/org/clulab/assembly/representations/Event.scala
@@ -11,24 +11,36 @@ trait Event extends EntityEventRepresentation {
 
   /** PrecedenceRelations for this Event */
   def precedenceRelations: Set[PrecedenceRelation] = {
-    manager.getPrecedenceRelations(equivalenceHash)
+    manager.getPrecedenceRelationsFor(this)
   }
 
   /** Causal predecessors of this Event */
   def predecessors: Set[EntityEventRepresentation] =
-    manager.predecessorsOf(equivalenceHash).map(_.asInstanceOf[Event])
+    manager.predecessorsOf(this).map(_.asInstanceOf[Event])
 
   /** Distinct causal predecessors of this Event */
   def distinctPredecessors: Set[EntityEventRepresentation] =
-    manager.distinctPredecessorsOf(equivalenceHash).map(_.asInstanceOf[Event])
+    manager.distinctPredecessorsOf(this).map(_.asInstanceOf[Event])
+
+  /** Equivalent causal predecessors of this Event */
+  def equivalentPredecessors: Set[EntityEventRepresentation] = for {
+    p <- predecessors
+    e <- manager.getEquivalentEERs(p)
+  } yield e
 
   /** Causal successors of this Event */
   def successors: Set[EntityEventRepresentation] =
-    manager.successorsOf(equivalenceHash).map(_.asInstanceOf[Event])
+    manager.successorsOf(this).map(_.asInstanceOf[Event])
 
   /** Distinct causal successors of this Event */
   def distinctSuccessors: Set[EntityEventRepresentation] =
-    manager.distinctSuccessorsOf(equivalenceHash).map(_.asInstanceOf[Event])
+    manager.distinctSuccessorsOf(this).map(_.asInstanceOf[Event])
+
+  /** Equivalent causal successors of this Event */
+  def equivalentSuccessors: Set[EntityEventRepresentation] = for {
+    s <- successors
+    e <- manager.getEquivalentEERs(s)
+  } yield e
 
   /** Get the entities (patients) serving as input to the event */
   def I: Set[Entity]

--- a/src/main/scala/org/clulab/assembly/sieves/Sieves.scala
+++ b/src/main/scala/org/clulab/assembly/sieves/Sieves.scala
@@ -29,6 +29,9 @@ class DeduplicationSieves extends Sieves {
     am.trackMentions(mentions)
     am
   }
+
+  // TODO: add approximate deduplication sieve
+  def approximateDeduplication(mentions: Seq[Mention], manager: AssemblyManager): AssemblyManager = ???
 }
 
 /**
@@ -287,6 +290,22 @@ class PrecedenceSieves extends Sieves {
     }
     manager
   }
+
+  // TODO: (selectively?) establish causal predecessors between controller and controlled of regulations
+  // ex. A is required for B
+  def regulationsToCausalPredecessors(mentions: Seq[Mention], manager: AssemblyManager): AssemblyManager = ???
+
+  // TODO: Propagate input features from causal predecessors
+  // Extend ParticipantFeatureTracker.getInputFeatures to handle events
+  //   - right now it assumes things are flattened
+  def propagateInputFeatures(mentions: Seq[Mention], manager: AssemblyManager): AssemblyManager = ???
+
+  // TODO: Keep only the "most complete" input features (ex Phos vs. Phos @ B)
+  def keepMostCompleteInputFeatures(mentions: Seq[Mention], manager: AssemblyManager): AssemblyManager = ???
+
+  // TODO: Write sieve to extend causal predecessors to equivalent EERs
+  // Could be selective via voting, textual proximity, etc.
+  def extendPredecessorsToEquivalentEERs(mentions: Seq[Mention], manager: AssemblyManager): AssemblyManager = ???
 }
 
 

--- a/src/main/scala/org/clulab/assembly/sieves/Sieves.scala
+++ b/src/main/scala/org/clulab/assembly/sieves/Sieves.scala
@@ -5,6 +5,7 @@ import org.clulab.assembly.AssemblyManager
 import org.clulab.assembly.relations.classifier.AssemblyRelationClassifier
 import org.clulab.odin._
 import org.clulab.reach.RuleReader
+
 import scala.annotation.tailrec
 
 
@@ -185,7 +186,7 @@ class PrecedenceSieves extends Sieves {
             true,
             name
           )
-          manager.storePrecedenceRelation(e1, e2, Set(evidence), name)
+          manager.storePrecedenceRelation(before = e1, after = e2, Set[Mention](evidence), name)
         case "after" =>
           // create evidence mention
           val evidence = new RelationMention(
@@ -203,7 +204,7 @@ class PrecedenceSieves extends Sieves {
             true,
             name
           )
-          manager.storePrecedenceRelation(e2, e1, Set(evidence), name)
+          manager.storePrecedenceRelation(before = e2, after = e1, Set[Mention](evidence), name)
         case _ => ()
       }
     }

--- a/src/test/scala/org/clulab/assembly/TestAssemblyManager.scala
+++ b/src/test/scala/org/clulab/assembly/TestAssemblyManager.scala
@@ -90,7 +90,7 @@ class TestAssemblyManager extends FlatSpec with Matchers {
 
     phos.output should have size(1)
 
-    val outputEntity =  phos.output.head.asInstanceOf[SimpleEntity]
+    val outputEntity = phos.output.head.asInstanceOf[SimpleEntity]
 
     val ptms = outputEntity.getPTMs
 
@@ -127,7 +127,7 @@ class TestAssemblyManager extends FlatSpec with Matchers {
     // the input and output of the translocations should differ in terms of modifications
     t2.I != t2.O should be(true)
     // however, the grounding ids of both entities should be the same
-    t2.I.size should be(1)
+    t2.I should have size (1)
     t2.I.head.asInstanceOf[SimpleEntity].grounding == t2.O.head.asInstanceOf[SimpleEntity].grounding should be(true)
     t2.I.head.asInstanceOf[SimpleEntity].withSameGrounding contains t2.O.head.asInstanceOf[SimpleEntity] should be(true)
   }
@@ -189,25 +189,25 @@ class TestAssemblyManager extends FlatSpec with Matchers {
     val rem = am.getSimpleEvent(m)
 
     val themes = rem.input("theme")
-    themes.size should be(1)
+    themes should have size (1)
 
     val theme = themes.head.asInstanceOf[SimpleEntity]
 
     val inputPTMs = theme.getPTMs
-    inputPTMs.size should be(1)
+    inputPTMs should have size (1)
 
     val phosInputPTMs = theme.getPTMs("Phosphorylation")
-    phosInputPTMs.size should be(1)
+    phosInputPTMs should have size (1)
 
     val output = rem.output
-    output.size should be(1)
+    output should have size (1)
 
     val outputTheme = output.head.asInstanceOf[SimpleEntity]
     val outputPTMs = outputTheme.getPTMs
-    outputPTMs.size should be(0)
+    outputPTMs should have size (0)
 
     val phosOutputPTMs = outputTheme.getPTMs("Phosphorylation")
-    phosOutputPTMs.size should be(0)
+    phosOutputPTMs should have size (0)
   }
 
   //
@@ -221,8 +221,8 @@ class TestAssemblyManager extends FlatSpec with Matchers {
 
     val am = AssemblyManager(mentions)
 
-    am.getRegulations.size should be(1)
-    am.distinctRegulations.size should be(1)
+    am.getRegulations should have size (1)
+    am.distinctRegulations should have size (1)
   }
 
   val regText2 = "Akt inhibits the phosphorylation of AFT by BEF."
@@ -234,8 +234,8 @@ class TestAssemblyManager extends FlatSpec with Matchers {
 
     val regs: Set[Regulation] = am.distinctRegulations
 
-    am.getRegulations.size should be(2)
-    regs.size should be(2)
+    am.getRegulations should have size (2)
+    regs should have size (2)
 
     regs.count(r => r.controlled.head.isInstanceOf[Regulation]) should be(1)
   }
@@ -302,18 +302,18 @@ class TestAssemblyManager extends FlatSpec with Matchers {
     val p = mentions.filter(_ matches "Phosphorylation").head
 
     // test AssemblyManager's methods
-    am.predecessorsOf(p).size should be(0)
-    am.distinctPredecessorsOf(p).size should be(0)
-    am.successorsOf(p).size should be(0)
-    am.distinctSuccessorsOf(p).size should be(0)
+    am.predecessorsOf(p) should have size (0)
+    am.distinctPredecessorsOf(p) should have size (0)
+    am.successorsOf(p) should have size (0)
+    am.distinctSuccessorsOf(p) should have size (0)
 
     val se = am.getSimpleEvent(p)
 
     // test Event methods
-    se.predecessors.size should be(0)
-    se.distinctPredecessors.size should be(0)
-    se.successors.size should be(0)
-    se.distinctSuccessors.size should be(0)
+    se.predecessors should have size (0)
+    se.distinctPredecessors should have size (0)
+    se.successors should have size (0)
+    se.distinctSuccessors should have size (0)
   }
 
   val precedenceText = "Ras is phosphorylated by Mek after Mek is bound to p53."
@@ -330,55 +330,55 @@ class TestAssemblyManager extends FlatSpec with Matchers {
     val b = mentions.filter(_ matches "Binding").head
 
     // test mention-based methods
-    am.storePrecedenceRelation(p, b, "mention-based-test")
+    am.storePrecedenceRelation(p, b, foundBy = "mention-based-test")
 
-    am.getPrecedenceRelations(p).size should be(1)
-    am.predecessorsOf(p).size should be(0)
-    am.distinctPredecessorsOf(p).size should be(0)
-    am.successorsOf(p).size should be(1)
-    am.distinctSuccessorsOf(p).size should be(1)
+    am.getPrecedenceRelationsFor(p) should have size (1)
+    am.predecessorsOf(p) should have size (0)
+    am.distinctPredecessorsOf(p) should have size (0)
+    am.successorsOf(p) should have size (1)
+    am.distinctSuccessorsOf(p) should have size (1)
 
-    am.getPrecedenceRelations(b).size should be(1)
-    am.predecessorsOf(b).size should be(1)
-    am.distinctPredecessorsOf(b).size should be(1)
-    am.successorsOf(b).size should be(0)
-    am.distinctSuccessorsOf(b).size should be(0)
+    am.getPrecedenceRelationsFor(b) should have size (1)
+    am.predecessorsOf(b) should have size (1)
+    am.distinctPredecessorsOf(b) should have size (1)
+    am.successorsOf(b) should have size (0)
+    am.distinctSuccessorsOf(b) should have size (0)
 
     // test eer-based methods
     val pSE = am.getSimpleEvent(p)
     val bSE = am.getSimpleEvent(b)
 
     // test mention-based methods
-    am.storePrecedenceRelation(p, b, "mention-based-test")
+    am.storePrecedenceRelation(p, b, foundBy = "mention-based-test")
 
-    pSE.precedenceRelations.size should be(1)
-    pSE.predecessors.size should be(0)
-    pSE.distinctPredecessors.size should be(0)
-    pSE.successors.size should be(1)
-    pSE.distinctSuccessors.size should be(1)
+    pSE.precedenceRelations should have size (1)
+    pSE.predecessors should have size (0)
+    pSE.distinctPredecessors should have size (0)
+    pSE.successors should have size (1)
+    pSE.distinctSuccessors should have size (1)
 
-    bSE.precedenceRelations.size should be(1)
-    bSE.predecessors.size should be(1)
-    bSE.distinctPredecessors.size should be(1)
-    bSE.successors.size should be(0)
-    bSE.distinctSuccessors.size should be(0)
+    bSE.precedenceRelations should have size (1)
+    bSE.predecessors should have size (1)
+    bSE.distinctPredecessors should have size (1)
+    bSE.successors should have size (0)
+    bSE.distinctSuccessors should have size (0)
 
     // test distinct v. non-distinct
-    am.storePrecedenceRelation(p, b, "mention-based-test2")
+    am.storePrecedenceRelation(p, b, foundBy = "mention-based-test2")
     // this is a set, but the difference in
     // foundBy means "mention-based-test2" won't get collapsed
-    pSE.precedenceRelations.size should be(2)
-    pSE.predecessors.size should be(0)
-    pSE.distinctPredecessors.size should be(0)
-    pSE.successors.size should be(1)
-    pSE.distinctSuccessors.size should be(1)
+    pSE.precedenceRelations should have size (2)
+    pSE.predecessors should have size (0)
+    pSE.distinctPredecessors should have size (0)
+    pSE.successors should have size (1)
+    pSE.distinctSuccessors should have size (1)
     // this is a set, but the difference in
     // foundBy means "mention-based-test2" won't get collapsed
-    bSE.precedenceRelations.size should be(2)
-    bSE.predecessors.size should be(1)
-    bSE.distinctPredecessors.size should be(1)
-    bSE.successors.size should be(0)
-    bSE.distinctSuccessors.size should be(0)
+    bSE.precedenceRelations should have size (2)
+    bSE.predecessors should have size (1)
+    bSE.distinctPredecessors should have size (1)
+    bSE.successors should have size (0)
+    bSE.distinctSuccessors should have size (0)
   }
 
   "AssemblyManager" should s"not contain any EERs for '$negPhos' if all EERs referencing Mek are removed" in {
@@ -393,7 +393,7 @@ class TestAssemblyManager extends FlatSpec with Matchers {
 
     am.removeEntriesContainingIDofMention(m)
 
-    am.EERs.size should be(0)
+    am.EERs should have size (0)
   }
 
   it should "safely handle mentions in any order" in {

--- a/src/test/scala/org/clulab/assembly/TestAssemblySieves.scala
+++ b/src/test/scala/org/clulab/assembly/TestAssemblySieves.scala
@@ -20,9 +20,9 @@ class TestAssemblySieves extends FlatSpec with Matchers {
     val pRep = am.distinctRegulations(AssemblyManager.positive).head
 
     am.distinctPredecessorsOf(pRep).size should be(1)
-    val pr = am.getPrecedenceRelations(pRep).head
-    pr.before == bRep.equivalenceHash should be (true)
-    pr.after == pRep.equivalenceHash should be (true)
+    val pr = am.getPrecedenceRelationsFor(pRep).head
+    pr.before.equivalenceHash == bRep.equivalenceHash should be (true)
+    pr.after.equivalenceHash == pRep.equivalenceHash should be (true)
 
   }
 
@@ -38,9 +38,9 @@ class TestAssemblySieves extends FlatSpec with Matchers {
     val pRep = am.distinctSimpleEvents("Phosphorylation").head
 
     am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
+    val pr = am.getPrecedenceRelationsFor(uRep).head
+    pr.before.equivalenceHash == pRep.equivalenceHash should be (true)
+    pr.after.equivalenceHash == uRep.equivalenceHash should be (true)
   }
 
   val tamSent2 = "AFT will be ubiquitinated only if BEF is first phosphorylated"
@@ -53,9 +53,9 @@ class TestAssemblySieves extends FlatSpec with Matchers {
     val pRep = am.distinctSimpleEvents("Phosphorylation").head
 
     am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
+    val pr = am.getPrecedenceRelationsFor(uRep).head
+    pr.before isEquivalentTo pRep should be (true)
+    pr.after isEquivalentTo uRep should be (true)
   }
 
   val tamSent3 = "AFT was ubiquitinated when BEF had been phosphorylated"
@@ -68,9 +68,9 @@ class TestAssemblySieves extends FlatSpec with Matchers {
     val pRep = am.distinctSimpleEvents("Phosphorylation").head
 
     am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
+    val pr = am.getPrecedenceRelationsFor(uRep).head
+    pr.before isEquivalentTo pRep should be (true)
+    pr.after isEquivalentTo uRep should be (true)
   }
 
   val interSent1 = "BEF was phosphorylated. Then, AFT was ubiquitinated."
@@ -83,9 +83,9 @@ class TestAssemblySieves extends FlatSpec with Matchers {
     val pRep = am.distinctSimpleEvents("Phosphorylation").head
 
     am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
+    val pr = am.getPrecedenceRelationsFor(uRep).head
+    pr.before isEquivalentTo pRep should be (true)
+    pr.after isEquivalentTo  uRep should be (true)
   }
 
   val interSent2 = "BEF was phosphorylated. Subsequently AFT was ubiquitinated."
@@ -98,9 +98,9 @@ class TestAssemblySieves extends FlatSpec with Matchers {
     val pRep = am.distinctSimpleEvents("Phosphorylation").head
 
     am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
+    val pr = am.getPrecedenceRelationsFor(uRep).head
+    pr.before isEquivalentTo pRep should be (true)
+    pr.after isEquivalentTo uRep should be (true)
   }
 
   val interSent3 = "AFT was ubiquitinated. Prior to this, BEF was phosphorylated."
@@ -113,9 +113,9 @@ class TestAssemblySieves extends FlatSpec with Matchers {
     val pRep = am.distinctSimpleEvents("Phosphorylation").head
 
     am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
+    val pr = am.getPrecedenceRelationsFor(uRep).head
+    pr.before isEquivalentTo pRep should be (true)
+    pr.after isEquivalentTo uRep should be (true)
   }
 
   val interSent4 = "AFT was ubiquitinated. Previously, BEF was phosphorylated."
@@ -128,9 +128,9 @@ class TestAssemblySieves extends FlatSpec with Matchers {
     val pRep = am.distinctSimpleEvents("Phosphorylation").head
 
     am.distinctPredecessorsOf(uRep).size should be(1)
-    val pr = am.getPrecedenceRelations(uRep).head
-    pr.before == pRep.equivalenceHash should be (true)
-    pr.after == uRep.equivalenceHash should be (true)
+    val pr = am.getPrecedenceRelationsFor(uRep).head
+    pr.before isEquivalentTo pRep should be (true)
+    pr.after isEquivalentTo uRep should be (true)
   }
 
 
@@ -144,7 +144,7 @@ class TestAssemblySieves extends FlatSpec with Matchers {
     val uRep = am.distinctSimpleEvents("Ubiquitination").head
     val pRep = am.distinctSimpleEvents("Phosphorylation").head
 
-    am.distinctPredecessorsOf(uRep).size should be(0)
+    am.distinctPredecessorsOf(uRep) should have size (0)
   }
 
 }

--- a/src/test/scala/org/clulab/reach/TestAdHocIMKBs.scala
+++ b/src/test/scala/org/clulab/reach/TestAdHocIMKBs.scala
@@ -7,7 +7,7 @@ import org.clulab.reach.grounding._
 /**
   * Unit tests to ensure a mixed-namespace in-memory KB is working for grounding.
   *   Written by: Tom Hicks. 1/20/2016.
-  *   Last Modified: Update for standardized 2-5 column KB format.
+  *   Last Modified: Update for NER corrections in BioResources 1.1.4.
   */
 class TestAdHocIMKBs extends FlatSpec with Matchers {
 
@@ -20,7 +20,6 @@ class TestAdHocIMKBs extends FlatSpec with Matchers {
     (ahkb3.lookupAll("TROP2").isDefined) should be (false)  // uppercase
     (ahkb3.lookupAll("Trop2").isDefined) should be (false)  // mixed case
     (ahkb3.lookupAll("trop2").isDefined) should be (true)
-    (ahkb3.lookupAll("apoptosis").isDefined) should be (true)
     (ahkb3.lookupAll("nadph").isDefined) should be (true)
     (ahkb3.lookupAll("ros").isDefined) should be (true)
   }
@@ -32,7 +31,6 @@ class TestAdHocIMKBs extends FlatSpec with Matchers {
     (ahkb3.lookupByASpecies("Trop2", "human").isDefined) should be (false) // mixed case
     (ahkb3.lookupByASpecies("trop2", "mouse").isDefined) should be (false)
     (ahkb3.lookupByASpecies("trop2", "human").isDefined) should be (true)
-    (ahkb3.lookupByASpecies("apoptosis", "human").isDefined) should be (true)
     (ahkb3.lookupByASpecies("nadph", "human").isDefined) should be (true)
     (ahkb3.lookupByASpecies("ros", "human").isDefined) should be (true)
   }
@@ -44,7 +42,6 @@ class TestAdHocIMKBs extends FlatSpec with Matchers {
     (ahkb3.lookupBySpecies("TROP2", Set("human","mouse","gorilla")).isDefined) should be (false)
     (ahkb3.lookupBySpecies("trop2", Set("human")).isDefined) should be (true)
     (ahkb3.lookupBySpecies("trop2", Set("human", "mouse")).isDefined) should be (true)
-    (ahkb3.lookupBySpecies("apoptosis", Set("human", "mouse")).isDefined) should be (true)
     (ahkb3.lookupBySpecies("nadph", Set("human", "mouse")).isDefined) should be (true)
     (ahkb3.lookupBySpecies("ros", Set("human", "mouse")).isDefined) should be (true)
   }
@@ -54,7 +51,6 @@ class TestAdHocIMKBs extends FlatSpec with Matchers {
     (ahkb3.lookupHuman("not-in-kb").isDefined) should be (false) // not in KB
     (ahkb3.lookupHuman("TROP2").isDefined) should be (false)  // uppercase
     (ahkb3.lookupHuman("trop2").isDefined) should be (true)
-    (ahkb3.lookupHuman("apoptosis").isDefined) should be (true)
     (ahkb3.lookupHuman("nadph").isDefined) should be (true)
     (ahkb3.lookupHuman("ros").isDefined) should be (true)
   }
@@ -64,7 +60,6 @@ class TestAdHocIMKBs extends FlatSpec with Matchers {
     (ahkb3.lookupNoSpecies("not-in-kb").isDefined) should be (false) // not in KB
     (ahkb3.lookupNoSpecies("TROP2").isDefined) should be (false)  // uppercase
     (ahkb3.lookupNoSpecies("trop2").isDefined) should be (false)  // assumed human
-    (ahkb3.lookupNoSpecies("apoptosis").isDefined) should be (false) // assumed human
     (ahkb3.lookupNoSpecies("nadph").isDefined) should be (false)     // assumed human
     (ahkb3.lookupNoSpecies("ros").isDefined) should be (false)       // assumed human
   }

--- a/src/test/scala/org/clulab/reach/TestReachCLI.scala
+++ b/src/test/scala/org/clulab/reach/TestReachCLI.scala
@@ -9,7 +9,7 @@ import org.scalatest.{Matchers, FlatSpec}
   * Tests the functionality of ReachCLI on the NXML papers in src/test/resources/inputs/nxml
   * User: mihais
   * Date: 12/4/15
-  * Last Modified: Change test input directory.
+  * Last Modified: GHP rewrite for consolidated ReachCLI, cleanups, and changed config file.
   */
 class TestReachCLI extends FlatSpec with Matchers {
   val nxmlDir = new File("src/test/resources/inputs/test-nxml")
@@ -52,7 +52,7 @@ class TestReachCLI extends FlatSpec with Matchers {
   }
 
   it should "output FRIES correctly on NXML papers with Assembly" in {
-    println(s"Will output FRIES output in directory ${friesWithAssemblyDir.getAbsolutePath}")
+    println(s"Will output FRIES with Assembly output in directory ${friesWithAssemblyDir.getAbsolutePath}")
     val cli = new ReachCLI(papersDir = nxmlDir, outputDir = friesWithAssemblyDir, outputFormat = "fries", logFile = friesWithAssemblyLogFile, verbose = false)
     val errorCount = cli.processPapers(threadLimit = None, withAssembly = true)
     if(errorCount > 0) dumpLog(friesWithAssemblyLogFile)


### PR DESCRIPTION
Fixes to Assembly modifications and precedence feature tracking as a result of issue #291: updating the FRIES outputter for participant features.
Make precedence identification more conservative.
Cleanup assembly tests.
Update build to use released bioresources 1.1.14. Updated test for 1.1.14.

