### PR TITLE
Prevent BioProcesses from being controllers (except of other BioProcesses)

### DIFF
--- a/src/test/scala/org/clulab/reach/TestActivationEvents.scala
+++ b/src/test/scala/org/clulab/reach/TestActivationEvents.scala
@@ -277,4 +277,14 @@ class TestActivationEvents extends FlatSpec with Matchers {
     val mentions = getBioMentions(sent35)
     hasPositiveActivation("Ras", "MKP3", mentions) should be(true)
   }
+  val sent36 = "Apoptosis activated p53."
+  sent36 should "contain no activations" in {
+    val mentions = getBioMentions(sent36)
+    hasPositiveActivation("Apoptosis", "p53", mentions) should be (false)
+  }
+  val sent37 = "Cell aging increases apoptosis"
+  sent37 should "contain 1 activation" in {
+    val mentions = getBioMentions(sent37)
+    hasPositiveActivation("Cell aging", "apoptosis", mentions) should be (true)
+  }
 }

--- a/src/test/scala/org/clulab/reach/TestRegulationEvents.scala
+++ b/src/test/scala/org/clulab/reach/TestRegulationEvents.scala
@@ -512,4 +512,10 @@ class TestRegulationEvents extends FlatSpec with Matchers {
     hasPositiveRegulationByEntity("RAS", "Binding", List("p53", "ASPP2"), mentions) should be (true)    // fails
   }
 
+  val sent55 = "Apoptosis promotes the phosphorylation of p53."
+  sent55 should "contain no regulations" in {
+    val mentions = getBioMentions(sent55)
+    hasPositiveRegulationByEntity("Apoptosis", "Phosphorylation", List("p53"), mentions) should be (false)
+  }
+
 }


### PR DESCRIPTION
This closes #150 by disallowing BioProcesses from acting as controllers in Regulations of any kind, and as controllers of Activations except when the controlled is also a BioProcess (e.g. "Cell aging increases apoptosis."). Tests for each relevant case are provided.