### PR TITLE
Turn n-ary complex into n-ary binding event

### DIFF
--- a/src/main/resources/org/clulab/reach/biogrammar/events/bind_events.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/events/bind_events.yml
@@ -328,7 +328,7 @@
 
 - name: binding_token_5
   label: Binding
-  action: mkBinding
+  action: mkNaryBinding
   priority: ${ priority }
   type: token
   pattern: |

--- a/src/main/scala/org/clulab/coref/CorefUtils.scala
+++ b/src/main/scala/org/clulab/coref/CorefUtils.scala
@@ -62,7 +62,7 @@ object CorefUtils {
   def argsComplete(args: Map[String,Seq[CorefMention]], lbls: Seq[String]): Boolean = {
     lbls match {
       case binding if lbls contains "Binding" =>
-        args.contains("theme") && args("theme").length == 2
+        args.contains("theme") && args("theme").length >= 2 // Binding is not required to be binary anymore (see binding_token_5)
       case simple if lbls contains "SimpleEvent" =>
         args.contains("theme") && args("theme").nonEmpty
       case complex if lbls contains "ComplexEvent" =>

--- a/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
@@ -197,6 +197,16 @@ class DarpaActions extends Actions {
     if regs.isEmpty && hasController(activation) && hasDistinctControllerControlled(activation)
   } yield activation
 
+  /** For bindings that should not be split into pairs */
+  def mkNaryBinding(mentions: Seq[Mention], state: State): Seq[Mention] = mentions map {
+    case m: EventMention if m matches "Binding" =>
+      // get the binding event participants
+      // note that they could be called either "theme1" or "theme2"
+      val themes = m.arguments.getOrElse("theme1", Nil) ++ m.arguments.getOrElse("theme2", Nil)
+      val arguments = Map("theme" -> themes)
+      m.copy(arguments = arguments)
+  }
+
   def mkBinding(mentions: Seq[Mention], state: State): Seq[Mention] = mentions flatMap {
     case m: EventMention if m.matches("Binding") =>
       // themes in a subject position

--- a/src/test/scala/org/clulab/reach/TestBindingEvents.scala
+++ b/src/test/scala/org/clulab/reach/TestBindingEvents.scala
@@ -437,10 +437,8 @@ class TestBindingEvents extends FlatSpec with Matchers {
   sent42 should "contain three binary binding events" in {
     val mentions = getBioMentions(sent42)
     val bindings = mentions.filter(_ matches "Binding")
-    bindings should have size (3)
-    hasEventWithArguments("Binding", List("Mek", "Ras"), bindings) should be (true)
-    hasEventWithArguments("Binding", List("Mek", "Akt1"), bindings) should be (true)
-    hasEventWithArguments("Binding", List("Ras", "Akt1"), bindings) should be (true)
+    bindings should have size (1)
+    hasEventWithArguments("Binding", List("Mek", "Ras", "Akt1"), bindings) should be (true)
   }
 
   val sent43 = "We provide evidence and a model illustrating how oncogenic, activated Ras can increase the DNA binding and transcription function of SAF-1 / MAZ transcription factor, a transcriptional regulator of VEGF."


### PR DESCRIPTION
This pull request implements a new action for binding events that doesn't splits them into pairs. This action is used by the `binding_token_5` rule to generate a single binding event with all the members of the complex.

Closes #300 