### PR TITLE
Issue259

### DIFF
--- a/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
@@ -18,7 +18,7 @@
   label: ${ label }
   action: ${ actionFlow }
   pattern: |
-    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/]
+    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/ & !mention=ModificationTrigger]
     cause:BioChemicalEntity? = <xcomp? (nsubj | agent | <vmod) /appos|nn|conj_(and|or|nor)|cc/{,2}
     theme:BioChemicalEntity = (dobj | xcomp) /conj_(and|or|nor)|dep|cc|nn|prep_of/{,2} (>> [word=by]){,2}
     site:Site? = dobj? /prep_(at|on)|nn|conj_(and|or|nor)|cc/{,2}
@@ -30,7 +30,7 @@
   label: ${ label }
   action: ${ actionFlow }
   pattern: |
-    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/]
+    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/ & !mention=ModificationTrigger]
     cause:BioChemicalEntity? = <xcomp? (nsubj | agent | <vmod) /appos|nn|conj_(and|or|nor)|cc/{,2}
     site:Site = (dobj | xcomp) /conj_(and|or|nor)|dep|cc|nn|prep_of/{,2} (>> [word=by]){,2}
     theme:BioChemicalEntity = dobj? /prep_(at|on)|nn|conj_(and|or|nor)|cc/{,2}

--- a/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
@@ -30,7 +30,7 @@
   label: ${ label }
   action: ${ actionFlow }
   pattern: |
-    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/ & !mention=ModificationTrigger]
+    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/]
     cause:BioChemicalEntity? = <xcomp? (nsubj | agent | <vmod) /appos|nn|conj_(and|or|nor)|cc/{,2}
     site:Site = (dobj | xcomp) /conj_(and|or|nor)|dep|cc|nn|prep_of/{,2} (>> [word=by]){,2}
     theme:BioChemicalEntity = dobj? /prep_(at|on)|nn|conj_(and|or|nor)|cc/{,2}

--- a/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
@@ -18,7 +18,7 @@
   label: ${ label }
   action: ${ actionFlow }
   pattern: |
-    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/ & !mention=ModificationTrigger]
+    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/]
     cause:BioChemicalEntity? = <xcomp? (nsubj | agent | <vmod) /appos|nn|conj_(and|or|nor)|cc/{,2}
     theme:BioChemicalEntity = (dobj | xcomp) /conj_(and|or|nor)|dep|cc|nn|prep_of/{,2} (>> [word=by]){,2}
     site:Site? = dobj? /prep_(at|on)|nn|conj_(and|or|nor)|cc/{,2}
@@ -36,7 +36,7 @@
     theme:BioChemicalEntity = dobj? /prep_(at|on)|nn|conj_(and|or|nor)|cc/{,2}
 
 
-- name: ${ eventName }_syntax_2_verb
+- name: ${ eventName }_syntax_2a_verb
   priority: ${ priority }
   example: "Human deoxycytidine kinase is ${ verbalTriggerLemma }d by ASPP2 on serine 128. The BRCT1 domain of XRCC1 is ${ verbalTriggerLemma }d in vitro by DNA-PK. ... reveals that XRCC1 is ${ verbalTriggerLemma }d by the co-immunoprecipitated DNA-PK"
   label: ${ label }
@@ -44,7 +44,19 @@
   pattern: |
     trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/ & !mention=ModificationTrigger]
     cause:BioChemicalEntity? = (agent|prep_by) (vmod dobj)? /conj_(and|or|nor)|nn|cc|prep_of/{,2}
-    theme:BioChemicalEntity = (>nsubjpass prep_of?|<vmod) /conj_(and|or|nor)|nn|cc/{,2}
+    theme:BioChemicalEntity = >nsubjpass prep_of? /conj_(and|or|nor)|nn|cc/{,2}
+    site:Site? = (agent|prep_by /conj_(and|or|nor)|nn|cc|prep_of/{,2})? /prep_(at|on)|conj_/{1,2}
+
+
+- name: ${ eventName }_syntax_2b_verb
+  priority: ${ priority }
+  example: "Human deoxycytidine kinase is ${ verbalTriggerLemma }d by ASPP2 on serine 128. The BRCT1 domain of XRCC1 is ${ verbalTriggerLemma }d in vitro by DNA-PK. ... reveals that XRCC1 is ${ verbalTriggerLemma }d by the co-immunoprecipitated DNA-PK"
+  label: ${ label }
+  action: ${ actionFlow }
+  pattern: |
+    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/ & !mention=ModificationTrigger]
+    cause:BioChemicalEntity = (agent|prep_by) (vmod dobj)? /conj_(and|or|nor)|nn|cc|prep_of/{,2}
+    theme:BioChemicalEntity = <vmod /conj_(and|or|nor)|nn|cc/{,2}
     site:Site? = (agent|prep_by /conj_(and|or|nor)|nn|cc|prep_of/{,2})? /prep_(at|on)|conj_/{1,2}
 
 
@@ -413,7 +425,7 @@
   label: ${ label }
   action: ${ actionFlow }
   pattern: |
-    @theme:BioChemicalEntity (?<trigger> [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag="VBN" & !mention=ModificationTrigger]) (by @cause:BioChemicalEntity)? (/^(on|at)$/ @site:Site)?
+    @theme:BioChemicalEntity (?<trigger> [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag="VBN" & !mention=ModificationTrigger]) (by @cause:BioChemicalEntity)? (/^(on|at)$/ @site:Site)? (?! [tag="DT" | mention="BioEntity"])
 
 
 - name: ${ eventName }_token_5_verb

--- a/src/main/resources/org/clulab/reach/biogrammar/modifications/modifications.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/modifications/modifications.yml
@@ -16,7 +16,7 @@ rules:
   action: mkBioMention
   pattern: |
     # note the use of nested lookaheads, muahaha!
-    [!lemma=/^(un|non)/ & lemma=/${modTriggerWords}/ & !outgoing=/prep_by|agent/ & tag=/^(JJ|VBN)/] (?= @BioChemicalEntity (?! [lemma=/^(fragment|protein)/]? [lemma="by"] @BioChemicalEntity))
+    [!lemma=/^(un|non)/ & lemma=/${modTriggerWords}/ & !outgoing=/prep_by|agent|vmod|nsubj/ & tag=/^(JJ|VBN)/] (?= @BioChemicalEntity (?! [lemma=/^(fragment|protein)/]? [lemma="by"] @BioChemicalEntity))
 
 - name: modification_trigger_2
   label: ModificationTrigger

--- a/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
@@ -489,11 +489,12 @@ object DarpaActions {
   /** Test whether the given mention has a controller argument. */
   def hasController(mention: Mention): Boolean = mention.arguments.get("controller").isDefined
 
+  /** Test whether the mention has a bioprocess controller and, if so, if its use is legitimate */
   def bioprocessValid(m: Mention): Boolean = {
     (m.arguments.getOrElse("controller", Nil).map(_.label), m.arguments.getOrElse("controlled", Nil).map(_.label)) match {
-      case (irrelevant, _) if !irrelevant.exists("BioProcess" ==) => true
+      case (irrelevant, _) if !irrelevant.contains("BioProcess") => true
       case (procController, procControlled)
-        if procController.exists("BioProcess" ==) & procControlled.exists("BioProcess" ==) => true
+        if procController.contains("BioProcess") & procControlled.contains("BioProcess") => true
       case other => false // e.g. BioProcess controller but BioChemical controlled
     }
   }

--- a/src/test/scala/org/clulab/reach/TestTemplaticSimpleEvents.scala
+++ b/src/test/scala/org/clulab/reach/TestTemplaticSimpleEvents.scala
@@ -576,4 +576,21 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
     phosphos.foreach(phos => phos.arguments("site") should have size (1))
     phosphos.foreach(phos => phos.arguments("site").head.text should equal ("tyrosine"))
   }
+
+  val sent39 = "However, while MEK5D phosphorylated a kinase dead mutant of ERK5 (ERK5-KD) at its TEY site"
+  sent39 should "not contain a phosphorylation of MEK5D" in {
+    val mentions = getBioMentions(sent39)
+    hasEventWithArguments("Phosphorylation", Seq("MEK5D"), mentions) should be (false)
+  }
+  val sent40 = "MEK5D phosphorylated ERK5."
+  sent40 should "contain a phosphorylation of ERK5 by MEK5D" in {
+    val mentions = getBioMentions(sent40)
+    hasEventWithArguments("Phosphorylation", Seq("ERK5"), mentions) should be (true)
+    hasPositiveRegulationByEntity("MEK5D", "Phosphorylation", Seq("ERK5"), mentions) should be (true)
+  }
+  val sent41 = "However, while MEK5D phosphorylated a kinase dead ERK5."
+  sent41 should "not contain a phosphorylation of MEK5D" in {
+    val mentions = getBioMentions(sent41)
+    hasEventWithArguments("Phosphorylation", Seq("MEK5D"), mentions) should be (false)
+  }
 }


### PR DESCRIPTION
These are slight adjustments to the templatic simple event rules to cover issue 259's problems. Although @myedibleenso prescribed a token-based rule to cover cases like "A phosphorylated B." in which (currently) the parser wrongly gives `phosphorylated` a tag of `VBN` (it should be `VBD`), I instead opted to remove the restriction on tags in the closest syntax rule. The reasons for this decision are that (1) the rule still requires correct dependency relations if not the correct tag, which *is* assigned here, so this is not a risky change, and (2) a token rule for this case hasn't been missed until now, leading me to think there is good coverage here and that introducing such a rule would introduce new false positives but few true positives.

Closes #259 