### PR TITLE
upgrade nxmlreader

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ libraryDependencies ++= Seq(
   "org.apache.lucene" % "lucene-core" % "5.3.1",
   "org.apache.lucene" % "lucene-analyzers-common" % "5.3.1",
   "org.apache.lucene" % "lucene-queryparser" % "5.3.1",
-  "ai.lum" %% "nxmlreader" % "0.0.3"
+  "ai.lum" %% "nxmlreader" % "0.0.4"
 )
 
 // settings for building project website


### PR DESCRIPTION
Use new release of nxmlreader. Fixes bugs mentioned in #309.
This pull request won't compile until the new version of nxmlreader becomes available in maven central.