### PR TITLE
solves the "key not found: controller" encountered in the 1K

### DIFF
--- a/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
+++ b/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
@@ -147,6 +147,8 @@ object MentionFilter {
     }
 
     def preferRegulations(regulations: Seq[BioMention]): Seq[CorefMention] = {
+      // the purpose of this method *seems* to be to filter out duplicates. Is that the case?
+      // we can do that pretty easily in assembly...maybe this could be retired/rewritten?
       val highestOrderControlled = for {
         r <- regulations.map(_.toCorefMention)
       } yield {
@@ -155,6 +157,8 @@ object MentionFilter {
           ((m.isInstanceOf[CorefRelationMention] && r.isInstanceOf[CorefRelationMention]) ||
             (m.isInstanceOf[CorefEventMention] && r.isInstanceOf[CorefEventMention] &&
             m.asInstanceOf[CorefEventMention].trigger == r.asInstanceOf[CorefEventMention].trigger)) &&
+            // ensure both mentions have a controller
+            m.arguments.get("controller").isDefined && r.arguments.get("controller").isDefined &&
             m.arguments("controller") == r.arguments("controller") &&
             mctrld.matches("Regulation") &&
             mctrld.arguments("controlled") == r.arguments("controlled")

--- a/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
+++ b/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
@@ -167,6 +167,8 @@ object MentionFilter {
       }
       val highestOrder = for {
         r <- highestOrderControlled.flatten
+        // ensure there is a controller
+        if r.arguments.keySet contains "controller"
       } yield {
         val isRedundant = regulations.filter(_.arguments.get("controller").isDefined).exists{ m =>
           val mctrlr = m.arguments("controller").head


### PR DESCRIPTION
I ran this on the four papers that failed with "key not found: controller" in the 1K run.  They all pass.