### PR TITLE
Added functioning logger

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,10 @@ libraryDependencies ++= Seq(
   "org.apache.lucene" % "lucene-core" % "5.3.1",
   "org.apache.lucene" % "lucene-analyzers-common" % "5.3.1",
   "org.apache.lucene" % "lucene-queryparser" % "5.3.1",
-  "ai.lum" %% "nxmlreader" % "0.0.5"
+  "ai.lum" %% "nxmlreader" % "0.0.5",
+  // logging
+  "ch.qos.logback"                      %  "logback-classic"                       % "1.1.7",
+  "com.typesafe.scala-logging"         %%  "scala-logging"                         % "3.4.0"
 )
 
 // settings for building project website

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -41,6 +41,12 @@ contextEngine {
     }
 }
 
+logging {
+  # defines project-wide logging level
+  loglevel = INFO
+  logfile = ${HOME}/.reach.log
+}
+
 # this log file gets overwritten every time ReachCLI is executed
 # so you should copy it if you want to keep it around
 logFile = ${HOME}/Documents/reach/log.txt

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+    <define name="loglevel" class="org.clulab.TypesafeConfigPropertyDefiner">
+        <!-- defined in application.conf -->
+        <propertyName>logging.loglevel</propertyName>
+    </define>
+    <define name="logfile" class="org.clulab.TypesafeConfigPropertyDefiner">
+        <!-- defined in application.conf -->
+        <propertyName>logging.logfile</propertyName>
+    </define>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="file" class="ch.qos.logback.core.FileAppender">
+        <param name="Append" value="false" />
+        <file>${logfile}</file>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="${loglevel}">
+        <appender-ref ref="console"/>
+        <appender-ref ref="file"/>
+    </root>
+
+</configuration>

--- a/src/main/scala/org/clulab/TypesafeConfigPropertyDefiner.scala
+++ b/src/main/scala/org/clulab/TypesafeConfigPropertyDefiner.scala
@@ -1,0 +1,16 @@
+package org.clulab
+
+import ch.qos.logback.core.PropertyDefinerBase
+import com.typesafe.config.ConfigFactory
+
+// http://stackoverflow.com/questions/15097967/how-can-i-configure-system-properties-or-logback-configuration-variables-from-ty
+class TypesafeConfigPropertyDefiner extends PropertyDefinerBase {
+
+  private var propertyName: String = ""
+
+  def getPropertyValue = ConfigFactory.load.getString(propertyName)
+
+  def setPropertyName(propertyName: String): Unit = {
+    this.propertyName = propertyName
+  }
+}

--- a/src/main/scala/org/clulab/assembly/Assembler.scala
+++ b/src/main/scala/org/clulab/assembly/Assembler.scala
@@ -1,6 +1,7 @@
 package org.clulab.assembly
 
-import org.clulab.assembly.export.{Equivalence, CausalPrecedence}
+import com.typesafe.scalalogging.LazyLogging
+import org.clulab.assembly.export.{CausalPrecedence, Equivalence}
 import org.clulab.odin.Mention
 
 
@@ -10,14 +11,18 @@ import org.clulab.odin.Mention
   *   Written by: Gus Hahn-Powell. 5/9/2016.
   *   Last Modified: Add method to get input features by participants.
   */
-class Assembler(mns: Seq[Mention]) {
+class Assembler(mns: Seq[Mention]) extends LazyLogging {
   // keep only the valid mentions
+  logger.debug(s"Finding valid mentions...")
   val mentions = mns.filter(AssemblyManager.isValidMention)
-  val am = AssemblyRunner.applySieves(mentions)
 
+  logger.debug(s"Applying sieves...")
+  val am = AssemblyRunner.applySieves(mentions)
   private val participantFeatureTracker = new ParticipantFeatureTracker(am)
 
   val causalPredecessors: Map[Mention, Set[CausalPrecedence]] = {
+
+    logger.debug(s"Building Map of Causal Predecessors...")
     val links = for {
       m <- mentions
       eer = am.getEER(m)
@@ -68,6 +73,8 @@ class Assembler(mns: Seq[Mention]) {
     causalPredecessors.getOrElse(m, Set.empty[CausalPrecedence])
 
   val equivalenceLinks: Map[Mention, Set[Equivalence]] = {
+
+    logger.debug(s"Building Map of Equivalence links...")
     val links = for {
       m <- mentions
       if AssemblyManager.isValidMention(m)

--- a/src/main/scala/org/clulab/assembly/sieves/Sieves.scala
+++ b/src/main/scala/org/clulab/assembly/sieves/Sieves.scala
@@ -1,15 +1,15 @@
 package org.clulab.assembly.sieves
 
+import com.typesafe.scalalogging.LazyLogging
 import com.typesafe.config.ConfigFactory
 import org.clulab.assembly.AssemblyManager
 import org.clulab.assembly.relations.classifier.AssemblyRelationClassifier
 import org.clulab.odin._
 import org.clulab.reach.RuleReader
-
 import scala.annotation.tailrec
 
 
-class Sieves {
+class Sieves extends LazyLogging {
 
 }
 
@@ -25,6 +25,7 @@ class DeduplicationSieves extends Sieves {
    * @return an AssemblyManager
    */
   def trackMentions(mentions: Seq[Mention], manager: AssemblyManager): AssemblyManager = {
+    logger.debug(s"\tapplying trackMentions sieve...")
     val am = AssemblyManager()
     am.trackMentions(mentions)
     am
@@ -51,9 +52,12 @@ class PrecedenceSieves extends Sieves {
     */
   def withinRbPrecedence(mentions: Seq[Mention], manager: AssemblyManager): AssemblyManager = {
 
+    val name = "withinRbPrecedence"
+
+    logger.debug(s"\tapplying $name sieve...")
+
     val p = "/org/clulab/assembly/grammars/precedence.yml"
 
-    val name = "withinRbPrecedence"
     // find rule-based PrecedenceRelations
     for {
       rel <- assemblyViaRules(p, mentions)
@@ -81,6 +85,12 @@ class PrecedenceSieves extends Sieves {
     * @return an AssemblyManager
     */
   def reichenbachPrecedence(mentions: Seq[Mention], manager: AssemblyManager): AssemblyManager = {
+
+    val name = "reichenbachPrecedence"
+
+    logger.debug(s"\tapplying $name sieve...")
+
+    val tam_rules = "/org/clulab/assembly/grammars/tense_aspect.yml"
 
     def getTam(ev: Mention, tams: Seq[Mention], label: String): Option[Mention] = {
       val relevant: Set[Mention] = tams.filter{ tam =>
@@ -134,9 +144,6 @@ class PrecedenceSieves extends Sieves {
         case _ => "none"
       }
     }
-
-    val name = "reichenbachPrecedence"
-    val tam_rules = "/org/clulab/assembly/grammars/tense_aspect.yml"
 
     // TODO: only look at events with verbal triggers
     val evs = mentions.filter(isEvent)
@@ -228,6 +235,12 @@ class PrecedenceSieves extends Sieves {
     */
   def betweenRbPrecedence(mentions: Seq[Mention], manager: AssemblyManager): AssemblyManager = {
 
+    val name = "betweenRbPrecedence"
+
+    logger.debug(s"\tapplying $name sieve...")
+
+    val p = "/org/clulab/assembly/grammars/intersentential.yml"
+
     // If the full Event is nested within another mention, pull it out
     def correctScope(m: Mention): Mention = {
       m match {
@@ -238,9 +251,6 @@ class PrecedenceSieves extends Sieves {
       }
     }
 
-    val p = "/org/clulab/assembly/grammars/intersentential.yml"
-
-    val name = "betweenRbPrecedence"
     // find rule-based inter-sentence PrecedenceRelations
     for {
       rel <- assemblyViaRules(p, mentions)
@@ -267,6 +277,9 @@ class PrecedenceSieves extends Sieves {
   def featureBasedClassifier(mentions: Seq[Mention], manager: AssemblyManager): AssemblyManager = {
 
     val sieveName = "featureBasedClassifier"
+
+    logger.debug(s"\tapplying $sieveName sieve...")
+
     val validMentions = mentions.filter(validPrecedenceCandidate)
     for {
       e1 <- validMentions


### PR DESCRIPTION
I've added logging to `reach`.  The two properties defined in `logback.xml` (`logfile` and `loglevel`) can be configured via changes to `application.conf`.  An example of using the logger can be seen in the `assembly.sieves.Sieves.scala` which now extends `com.typesafe.scalalogging.LazyLogging`.  The `LazyLogging` mixin allows the use of `logger.info("some message here")`, `logger.debug()`, etc.

This is a starting point, but I believe the `INFO`-level logging coming in from `processors` could be better configured.  I believe one way to do that would be something like:

```xml
    <logger name="name.of.talkative.logger.in.processors" level="INFO">
        <appender-ref ref="file"/>
    </logger>
```

There is probably a better way to do this, though.  Anyone know?  In any case, it would be nice to have more control over the logging behavior of `BioNLPProcessor` in `reach`.