### PR TITLE
Plain text reader

### DIFF
--- a/src/main/scala/org/clulab/reach/FriesEntry.scala
+++ b/src/main/scala/org/clulab/reach/FriesEntry.scala
@@ -36,3 +36,17 @@ case class FriesEntry(
     text = nxmldoc.standoff.text
   )
 }
+
+object FriesEntry {
+
+  def mkFriesEntry(paperID: String, text: String): FriesEntry = {
+    FriesEntry(
+      name = paperID,
+      chunkId = paperID,
+      sectionId = "",
+      sectionName = "",
+      isTitle = false,
+      text
+    )
+  }
+}

--- a/src/test/resources/inputs/plaintext/test.txt
+++ b/src/test/resources/inputs/plaintext/test.txt
@@ -1,0 +1,1 @@
+Ras phosphorylates TGF-β1.

--- a/src/test/scala/org/clulab/reach/TestPaperReader.scala
+++ b/src/test/scala/org/clulab/reach/TestPaperReader.scala
@@ -1,0 +1,16 @@
+package org.clulab.reach
+
+import org.scalatest.{FlatSpec, Matchers}
+import java.io.File
+
+
+class TestPaperReader extends FlatSpec with Matchers {
+
+  val examplePaper = new File(getClass.getResource("/inputs/plaintext/test.txt").toURI)
+
+  "PaperReader" should "read plain text files" in {
+    val mentions = PaperReader.getMentionsFromPaper(examplePaper)
+    mentions should not be empty
+  }
+
+}


### PR DESCRIPTION
These changes add support for processing plain text files.  The expected file encoding is read from `application.conf` (see `encoding`).