### PR TITLE
Issue 346

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -43,7 +43,7 @@ contextEngine {
 
 logging {
   # defines project-wide logging level
-  loglevel = INFO
+  loglevel = DEBUG # INFO
   logfile = ${HOME}/.reach.log
 }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -43,7 +43,7 @@ contextEngine {
 
 logging {
   # defines project-wide logging level
-  loglevel = DEBUG # INFO
+  loglevel = INFO
   logfile = ${HOME}/.reach.log
 }
 

--- a/src/main/scala/org/clulab/coref/Coref.scala
+++ b/src/main/scala/org/clulab/coref/Coref.scala
@@ -219,8 +219,11 @@ class Coref {
       s -> Seq(s)
     }).toMap
 
+    var resolvedMap = resolved ++ solidMap
+
     val inspectedMap = (for {
-      evt <- toInspect
+      evt <- toInspect.sortBy(depth)
+      //_=println(s"inspecting ${evt.text}")
 
       // Check already-made maps for previously resolved arguments
       resolvedArgs = (for {
@@ -228,7 +231,7 @@ class Coref {
         //_=println(s"lbl: $lbl\nargs: ${arg.map(_.text).mkString("\n")}")
         argMs = arg.map(m => {
           evt.sieves ++= sieveMap.getOrElse(m.toCorefMention, Set.empty)
-          resolved.getOrElse(m.toCorefMention, Nil)
+          resolvedMap.getOrElse(m.toCorefMention, Nil)
         })
         argsAsEntities = argMs.map(ms => ms.map(m =>
           if (lbl == "controller" && m.isInstanceOf[EventMention] && m.isGeneric) {
@@ -291,11 +294,11 @@ class Coref {
         }
         else Nil
       )
+      //println(s"${evt.text} => ${value.map(v => v.text).mkString(", ")}")
+      resolvedMap += evt -> value
       evt -> value
     }).toMap
 
-    // Note: we intentionally avoid generic complex events; recursive complex events are rare in any case, and
-    // complicated enough to be likely to induce errors
     solidMap ++ inspectedMap ++ createdComplexes.map(c => c -> Seq(c)).toMap
   }
 
@@ -409,6 +412,7 @@ class Coref {
           CorefFlow(links.nounPhraseMatch) andThen
           CorefFlow(links.simpleEventMatch)
 
+        //resolve(allLinks(orderedMentions, new LinearSelector)).filter(_.isComplete)
         resolve(allLinks(orderedMentions, new LinearSelector)).filter(_.isComplete)
       }
     }

--- a/src/main/scala/org/clulab/coref/CorefUtils.scala
+++ b/src/main/scala/org/clulab/coref/CorefUtils.scala
@@ -138,4 +138,32 @@ object CorefUtils {
       aContext.keySet.intersect(bContext.keySet)
         .forall(k => aContext(k).toSet.intersect(bContext(k).toSet).nonEmpty) // FIXME: Too strict?
   }
+
+  def depth(m: CorefMention): Int = m match {
+    case tbm: CorefTextBoundMention => 0
+
+    case evt: CorefEventMention =>
+      val argDepths = evt
+      .antecedentOrElse(evt)
+      .arguments
+      .values
+      .flatten
+      .map(arg => depth(arg.toCorefMention))
+      .toList
+
+      if (argDepths.isEmpty) 0 else 1 + argDepths.max
+
+    case rel: CorefRelationMention =>
+      val argDepths = rel
+      .antecedentOrElse(rel)
+      .arguments
+      .values
+      .flatten
+      .map(arg => depth(arg.toCorefMention))
+      .toList
+
+      if (argDepths.isEmpty) 0 else 1 + argDepths.max
+
+    case impossible => 0
+  }
 }

--- a/src/main/scala/org/clulab/reach/ReachSystem.scala
+++ b/src/main/scala/org/clulab/reach/ReachSystem.scala
@@ -86,7 +86,11 @@ class ReachSystem(
     display.displayMentions(events, doc)
     contextEngine.update(events)
     val eventsWithContext = contextEngine.assign(events)
+    logger.debug(s"${eventsWithContext.size} events after contextEngine.assign")
+    display.displayMentions(eventsWithContext, doc)
     val grounded = grounder(eventsWithContext)
+    logger.debug(s"${grounded.size} events after grounder")
+    display.displayMentions(grounded, doc)
     // Coref expects to get all mentions grouped
     // we group according to the standoff, if there is one
     // else we just make one group with all the mentions
@@ -94,6 +98,8 @@ class ReachSystem(
       case Some(nxml) => groupMentionsByStandoff(grounded, nxml)
       case None => Seq(grounded)
     }
+    logger.debug(s"${groundedAndGrouped.flatten.size} events after groundedAndGrouped")
+    display.displayMentions(groundedAndGrouped.flatten, doc)
     val resolved = resolveCoref(groundedAndGrouped)
     logger.debug(s"${resolved.size} events after coref:")
     display.displayMentions(resolved, doc)

--- a/src/main/scala/org/clulab/reach/ReachSystem.scala
+++ b/src/main/scala/org/clulab/reach/ReachSystem.scala
@@ -12,6 +12,7 @@ import scala.collection.mutable
 import org.clulab.reach.context._
 import org.clulab.reach.context.ContextEngineFactory.Engine._
 import ai.lum.nxmlreader.NxmlDocument
+import com.typesafe.scalalogging.LazyLogging
 import org.clulab.reach.darpa.{DarpaActions, MentionFilter, NegationHandler}
 
 
@@ -20,7 +21,7 @@ class ReachSystem(
     proc: Option[BioNLPProcessor] = None,
     contextEngineType: Engine = Dummy,
     contextParams: Map[String, String] = Map()
-) {
+) extends LazyLogging {
 
   import ReachSystem._
 
@@ -78,7 +79,11 @@ class ReachSystem(
     contextEngine.infer(entities)
     val entitiesWithContext = contextEngine.assign(entities)
     val unfilteredEvents = extractEventsFrom(doc, entitiesWithContext)
+    logger.debug(s"${unfilteredEvents.size} unfilteredEvents:")
+    display.displayMentions(unfilteredEvents,doc)
     val events = MentionFilter.keepMostCompleteMentions(unfilteredEvents, State(unfilteredEvents))
+    logger.debug(s"${events.size} events after MentionFilter.keepMostCompleteMentions:")
+    display.displayMentions(events, doc)
     contextEngine.update(events)
     val eventsWithContext = contextEngine.assign(events)
     val grounded = grounder(eventsWithContext)
@@ -90,10 +95,13 @@ class ReachSystem(
       case None => Seq(grounded)
     }
     val resolved = resolveCoref(groundedAndGrouped)
+    logger.debug(s"${resolved.size} events after coref:")
+    display.displayMentions(resolved, doc)
     // Coref introduced incomplete Mentions that now need to be pruned
     val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
-    // val complete = MentionFilter.keepMostCompleteMentions(eventsWithContext, State(eventsWithContext)).map(_.toBioMention)
-
+    logger.debug(s"${complete.size} events after coref + 2nd MentionFilter.keepMostCompleteMentions:")
+    display.displayMentions(complete, doc)
+    logger.debug(s"Resolving display...")
     resolveDisplay(complete)
   }
 

--- a/src/main/scala/org/clulab/reach/ReachSystem.scala
+++ b/src/main/scala/org/clulab/reach/ReachSystem.scala
@@ -79,18 +79,14 @@ class ReachSystem(
     contextEngine.infer(entities)
     val entitiesWithContext = contextEngine.assign(entities)
     val unfilteredEvents = extractEventsFrom(doc, entitiesWithContext)
-    logger.debug(s"${unfilteredEvents.size} unfilteredEvents:")
-    display.displayMentions(unfilteredEvents,doc)
+    logger.debug(s"${unfilteredEvents.size} unfilteredEvents: ${display.summarizeMentions(unfilteredEvents,doc)}")
     val events = MentionFilter.keepMostCompleteMentions(unfilteredEvents, State(unfilteredEvents))
-    logger.debug(s"${events.size} events after MentionFilter.keepMostCompleteMentions:")
-    display.displayMentions(events, doc)
+    logger.debug(s"${events.size} events after MentionFilter.keepMostCompleteMentions: ${display.summarizeMentions(events, doc)}")
     contextEngine.update(events)
     val eventsWithContext = contextEngine.assign(events)
-    logger.debug(s"${eventsWithContext.size} events after contextEngine.assign")
-    display.displayMentions(eventsWithContext, doc)
+    logger.debug(s"${eventsWithContext.size} events after contextEngine.assign: ${display.summarizeMentions(eventsWithContext, doc)}")
     val grounded = grounder(eventsWithContext)
-    logger.debug(s"${grounded.size} events after grounder")
-    display.displayMentions(grounded, doc)
+    logger.debug(s"${grounded.size} events after grounder: ${display.summarizeMentions(grounded, doc)}")
     // Coref expects to get all mentions grouped
     // we group according to the standoff, if there is one
     // else we just make one group with all the mentions
@@ -98,15 +94,12 @@ class ReachSystem(
       case Some(nxml) => groupMentionsByStandoff(grounded, nxml)
       case None => Seq(grounded)
     }
-    logger.debug(s"${groundedAndGrouped.flatten.size} events after groundedAndGrouped")
-    display.displayMentions(groundedAndGrouped.flatten, doc)
+    logger.debug(s"${groundedAndGrouped.flatten.size} events after groundedAndGrouped: ${display.summarizeMentions(groundedAndGrouped.flatten, doc)}")
     val resolved = resolveCoref(groundedAndGrouped)
-    logger.debug(s"${resolved.size} events after coref:")
-    display.displayMentions(resolved, doc)
+    logger.debug(s"${resolved.size} events after coref: ${display.summarizeMentions(resolved, doc)}")
     // Coref introduced incomplete Mentions that now need to be pruned
     val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
-    logger.debug(s"${complete.size} events after coref + 2nd MentionFilter.keepMostCompleteMentions:")
-    display.displayMentions(complete, doc)
+    logger.debug(s"${complete.size} events after coref + 2nd MentionFilter.keepMostCompleteMentions: ${display.summarizeMentions(complete, doc)}")
     logger.debug(s"Resolving display...")
     resolveDisplay(complete)
   }

--- a/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
@@ -1,5 +1,6 @@
 package org.clulab.reach.darpa
 
+import com.typesafe.scalalogging.LazyLogging
 import org.clulab.odin._
 import org.clulab.reach._
 import org.clulab.reach.mentions._
@@ -7,7 +8,7 @@ import org.clulab.struct.DirectedGraph
 import scala.annotation.tailrec
 
 
-class DarpaActions extends Actions {
+class DarpaActions extends Actions with LazyLogging {
 
   import DarpaActions._
 
@@ -181,6 +182,8 @@ class DarpaActions extends Actions {
     if hasDistinctControllerControlled(regulation)
     // If the Mention has both a controller and controlled, their token spans should NOT overlap
     if ! overlappingSpansControllerControlled(regulation)
+    _ = logger.debug(s"mkRegulation yields:")
+    _ = display.displayMention(mention.toBioMention)
   } yield regulation
 
   /**
@@ -337,6 +340,7 @@ class DarpaActions extends Actions {
 
   /** global action for EventEngine */
   def cleanupEvents(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    logger.debug("Running global action cleanupEvents...")
     val r1 = siteSniffer(mentions, state)
     val r2 = keepIfValidArgs(r1, state)
     val r3 = NegationHandler.detectNegations(r2, state)

--- a/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
@@ -182,8 +182,7 @@ class DarpaActions extends Actions with LazyLogging {
     if hasDistinctControllerControlled(regulation)
     // If the Mention has both a controller and controlled, their token spans should NOT overlap
     if ! overlappingSpansControllerControlled(regulation)
-    _ = logger.debug(s"mkRegulation yields:")
-    _ = display.displayMention(regulation)
+    _ = logger.debug(s"mkRegulation yields: ${display.summarizeMentions(regulation)}")
   } yield regulation
 
   /**

--- a/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
@@ -182,7 +182,7 @@ class DarpaActions extends Actions with LazyLogging {
     if hasDistinctControllerControlled(regulation)
     // If the Mention has both a controller and controlled, their token spans should NOT overlap
     if ! overlappingSpansControllerControlled(regulation)
-    _ = logger.debug(s"mkRegulation yields: ${display.summarizeMentions(regulation)}")
+    _ = logger.debug(s"mkRegulation yields: ${display.summarizeMention(regulation)}")
   } yield regulation
 
   /**

--- a/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
@@ -183,7 +183,7 @@ class DarpaActions extends Actions with LazyLogging {
     // If the Mention has both a controller and controlled, their token spans should NOT overlap
     if ! overlappingSpansControllerControlled(regulation)
     _ = logger.debug(s"mkRegulation yields:")
-    _ = display.displayMention(mention.toBioMention)
+    _ = display.displayMention(regulation)
   } yield regulation
 
   /**

--- a/src/main/scala/org/clulab/reach/display/package.scala
+++ b/src/main/scala/org/clulab/reach/display/package.scala
@@ -2,117 +2,184 @@ package org.clulab.reach
 
 import org.clulab.odin._
 import org.clulab.reach.mentions._
-import org.clulab.processors.{ Document, Sentence }
+import org.clulab.processors.{Document, Sentence}
+import scala.util.matching.Regex
+
 
 package object display {
 
-  def displayMentions(mentions: Seq[Mention], doc: Document): Unit = {
+  val WHITESPACE = new Regex("^\\s+")
+
+  def summarizeMentions(mentions: Seq[Mention], doc: Document): String = {
+
     val mentionsBySentence = mentions groupBy (_.sentence) mapValues (_.sortBy(_.start)) withDefaultValue Nil
-    for ((s, i) <- doc.sentences.zipWithIndex) {
-      println(s"sentence #$i")
-      println(s.getSentenceText)
-      println("Tokens: " + (s.words.indices, s.words, s.tags.get).zipped.mkString(", "))
-      printSyntacticDependencies(s)
-      println
+
+    val sentenceSummaries = for ((s, i) <- doc.sentences.zipWithIndex) yield {
 
       val sortedMentions = mentionsBySentence(i).filter(!_.toCorefMention.isGeneric).sortBy(_.label)
       val (events, entities) = sortedMentions.partition(_ matches "Event")
       val (tbs, rels) = entities.partition(_.isInstanceOf[TextBoundMention])
       val sortedEntities = tbs ++ rels.sortBy(_.label)
-      println("entities:")
-      sortedEntities foreach displayMention
-
-      println
-      println("events:")
+      val entitySummaries = sortedEntities map summarizeMention
+      val eventSummaries = events map summarizeMention
       events foreach displayMention
-      println("=" * 50)
+      val boundary = "=" * 50
+
+      s"""
+         |sentence #$i
+         |TEXT:   ${s.getSentenceText}
+         |TOKENS: ${(s.words.indices, s.words, s.tags.get).zipped.mkString(", ")}
+         |${syntacticDependenciesToString(s)}
+         |ENTITIES: ${sortedEntities.size}
+         |${entitySummaries.mkString("\n")}
+         |EVENTS:   ${events.size}
+         |${eventSummaries.mkString("\n")}
+         |$boundary
+       """.stripMargin
     }
+
+    sentenceSummaries.mkString("\n")
+  }
+
+  def displayMentions(mentions: Seq[Mention], doc: Document): Unit = {
+    println(summarizeMentions(mentions, doc))
   }
 
   def printSyntacticDependencies(s:Sentence): Unit = {
-    println(s.lemmas.get.mkString(" "))
-    if(s.dependencies.isDefined) {
-      println(s.dependencies.get.toString)
-    }
+    println(syntacticDependenciesToString(s))
   }
 
-  def displayMention(mention: Mention) {
-    val printMention = mention.antecedentOrElse(mention)
+  def syntacticDependenciesToString(s:Sentence): String = {
+
+    val lemmas = s.lemmas.get.mkString(" ")
+
+    val summaryOfDependencies = s.dependencies match {
+      case Some(deps) => deps.toString
+      case None => ""
+    }
+
+    s"""
+       |LEMMAS: $lemmas
+       |$summaryOfDependencies
+     """.stripMargin
+  }
+
+  /** Remove entries containing only whitespace */
+  private def filterEntries(entries: List[String]): String = entries.filterNot{ entry =>
+    WHITESPACE.pattern.matcher(entry).matches
+  }.mkString("\n")
+
+  def summarizeMention(mention: Mention): String = {
+    val mentionForDisplay = mention.antecedentOrElse(mention).toBioMention
     val boundary = s"\t${"-" * 30}"
-    println(s"mention text: ${printMention.text}")
-    println(printMention.labels)
-    println(boundary)
-    println(s"\tRule => ${printMention.foundBy}")
-    val mentionType = printMention.getClass.toString.split("""\.""").last
-    println(s"\tType => $mentionType")
-    println(boundary)
-    printMention match {
+    val mentionType = mentionForDisplay.getClass.toString.split("""\.""").last
+
+    val summaryOfMods = summarizeModifications(mentionForDisplay)
+    val summaryOfArgs = summarizeArguments(mentionForDisplay)
+    val summaryOfContext = summarizeContext(mentionForDisplay)
+
+    val mentionContents = mentionForDisplay match {
       case tb: BioTextBoundMention =>
-        println(s"\t${tb.asInstanceOf[Display].displayLabel}|${tb.labels} => ${tb.text}")
-        if (tb.isGrounded) println(s"\tgrounding: ${tb.grounding.get}")
-        displayModifications(tb)
-        if (tb.hasContext()) displayContext(tb)
+         List(
+           s"""\tGROUNDING: ${if (tb.isGrounded) tb.grounding.get else "NONE"}""",
+           summaryOfMods,
+           summaryOfContext
+         )
       case em: BioEventMention =>
-        displayModifications(em)
-        println(boundary)
-        println(s"\ttrigger => ${em.trigger.text}")
-        displayArguments(em)
-        if (em.hasContext()) displayContext(em)
+        List(
+          summaryOfMods,
+          s"$boundary",
+          s"\tTRIGGER => ${em.trigger.text}",
+          summaryOfArgs,
+          summaryOfContext
+        )
       case rel: BioRelationMention =>
-        displayModifications(rel)
-        println(boundary)
-        displayArguments(rel)
-        if (rel.hasContext()) displayContext(rel)
-      case _ => ()
+        List(
+          summaryOfMods,
+          boundary,
+          summaryOfArgs,
+          summaryOfContext
+        )
+      case _ => Nil
     }
-    println(s"$boundary\n")
+
+      s"""
+        |MENTION TEXT:  ${mentionForDisplay.text}
+        |LABELS:        ${mentionForDisplay.labels}
+        |DISPLAY LABEL: ${mentionForDisplay.displayLabel}
+        |$boundary
+        |\tRULE => ${mentionForDisplay.foundBy}
+        |\tTYPE => $mentionType
+        |$boundary
+        |${filterEntries(mentionContents).replaceFirst("\\s+$", "")}
+        |$boundary
+        |
+        |""".stripMargin
   }
 
+  def displayMention(mention: Mention): Unit = {
+    println(summarizeMention(mention))
+  }
+
+  def summarizeArguments(b: BioMention): String = {
+    val argSummaries = for {
+      (k, vs) <- b.arguments
+      v <- vs
+      vm = v.antecedentOrElse(v.toCorefMention)
+    } yield s"\t$k (${vm.labels}) => ${vm.text}${summarizeModifications(vm)}"
+    argSummaries.mkString("\n")
+  }
 
   def displayArguments(b: BioMention): Unit = {
-    b.arguments foreach {
-      case (k, vs) =>
-        vs foreach { v =>
-          val vm = v.antecedentOrElse(v.toCorefMention)
-          println(s"\t$k (${vm.labels}) => ${vm.text}")
-          displayModifications(vm)
-        }
-    }
+    println(summarizeArguments(b))
+  }
+
+  def summarizeContext(b: BioMention): String = b.context match {
+    case Some(context) =>
+      val contextSummary = for {
+        (k, vs) <- context
+      } yield s"\tCONTEXT: $k => $vs"
+      contextSummary.mkString("\n")
+    case None => s"CONTEXT: NONE"
   }
 
   def displayContext(b: BioMention): Unit = {
-    b.context.get foreach {
-      case (k, vs) =>
-        println(s"\tcontext: ${k} => ${vs}")
-    }
+    println(summarizeContext(b))
   }
 
-  def displayModifications(b: BioMention, level:Int = 0): Unit = {
+  def summarizeModifications(b: BioMention, level:Int = 0): String = {
     val indent = "\t" * level
-    b.modifications.size match {
+    val modCountString = b.modifications.size match {
       case 1 =>
-        println(s"$indent\twith 1 modification =>")
+        s"\n$indent\twith 1 modification =>"
       case x if x > 1 =>
-        println(s"$indent\twith $x modifications =>")
-      case _ => ()
+        s"\n$indent\twith $x modifications =>"
+      case _ => ""
     }
-    b.modifications foreach {
+    val summaryOfMods = b.modifications map {
       case Negation(evidence) =>
-        println(s"""$indent\t\tNegated by \"${evidence.text}\"""")
+        s"""$indent\t\tNegated by \"${evidence.text}\""""
       case Hypothesis(evidence) =>
-        println(s"""$indent\t\tHypothesis by \"${evidence.text}\"""")
+        s"""$indent\t\tHypothesis by \"${evidence.text}\""""
       case Mutant(evidence, foundBy) =>
-        println(s"""$indent\t\t${evidence.label} by \"${evidence.text}\"\n"""
-          + s"""$indent\t\t\tMutation rule: ${evidence.foundBy}\n"""
-          + s"""$indent\t\t\tMutation attachment rule: $foundBy""")
+        s"""$indent\t\t${evidence.label} by \"${evidence.text}\"
+           |$indent\t\t\tMutation rule: ${evidence.foundBy}
+           |$indent\t\t\tMutation attachment rule: $foundBy""".stripMargin
       case PTM(mod, evidence, site, negated) =>
         val siteText = if (site.nonEmpty) {s" @ ${site.get.text}"} else ""
         val evidenceText = if (evidence.nonEmpty) {s""" based on \"${evidence.get.text}\""""} else ""
-        println(s"""$indent\t\t$PTM (negated=$negated) = \"$mod\"$siteText$evidenceText""")
+        s"""$indent\t\t$PTM (negated=$negated) = \"$mod\"$siteText$evidenceText"""
       case EventSite(site) =>
-        println(s"""$indent\t\twith Site \"${site.text}\"""")
-      case _ => ()
+        s"""$indent\t\twith Site \"${site.text}\""""
+      case _ => ""
     }
+
+    val entries: List[String] = List(modCountString) ++ summaryOfMods
+    filterEntries(entries)
+  }
+
+  def displayModifications(b: BioMention, level: Int = 0): Unit = {
+    println(summarizeModifications(b, level))
   }
 
   def cleanVerbose(s:String):String = {

--- a/src/test/scala/org/clulab/reach/TestCoreference.scala
+++ b/src/test/scala/org/clulab/reach/TestCoreference.scala
@@ -600,4 +600,14 @@ class TestCoreference extends FlatSpec with Matchers {
     entities should have size (4)
     entities.combinations(2).forall(pair => pair.head.grounding.get.equals(pair.last.grounding.get)) should be (true)
   }
+
+  val sent55 = "Gab1 mutant protein enhances EGF induced activation of the PI-3"
+  sent55 should "contain a two-level complex event" in {
+    val mentions = getBioMentions(sent55)
+    val posreg = mentions.filter(_ matches "Positive_regulation")
+    val posact = mentions.filter(_ matches "Positive_activation")
+    posreg should have size (1)
+    posact should have size (1)
+    posreg.head.arguments("controlled").head == posact.head should be (true)
+  }
 }


### PR DESCRIPTION
These changes handle the string "Gab1 mutant protein enhances EGF induced activation of the PI-3" and others like it that 
* should contain a `ComplexEvent` with another `ComplexEvent` as an argument and/or
* should contain an unresolved mutation (whereas other events containing unresolved anaphora get filtered out)

A test with the relevant string has been added, and a prior test that explicitly checked our previous prohibition on nested `ComplexEvent`s was edited.

This closes #346 