### PR TITLE
Json serialization of CorefMention

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 #Changes
 =======
++ **1.3.3** - Uses bioresources 1.1.15 and processors 5.9.6.  Introduces [`json` serialization/deserialization of `CorefMention` (including grounding, modifications, etc.)](https://gist.github.com/myedibleenso/8383af789b37ba598ff64ddd12c8b35b).
 + **1.3.3** - Better handling of nested events.
 + **1.3.2** - Update to use Bioresources 1.1.15 and Processors 5.9.5.
 + **1.3.1** - Update of all edu.arizona.sista packages to org.clulab

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please scroll down to the bottom of this page for additional resources, includin
 All our own code is licensed under Apache License Version 2.0. **However, some of the libraries used here, most notably CoreNLP, are GPL v2.** If `BioNLPProcessor` is not removed from this package, technically our whole code becomes GPL v2 since `BioNLPProcessor` builds on Stanford's `CoreNLP` functionality. Soon, we will split the code into multiple components, so licensing becomes less ambiguous.
 
 # Changes
-+ **1.3.0** - Use Bioresources 1.1.9, Processors 5.8.5. Allow regulations of regulations. Identify X inhibitors as chemicals. Use MITRE model for NER/grounding. Add NER stop list. Add Translocation mention support to Assembly. Various rule fixes and enhancements. Allow PaperReader to read .csv files.
++ **1.3.3** - Uses bioresources 1.1.15 and processors 5.9.6.  Introduces [`json` serialization/deserialization of `CorefMention` (including grounding, modifications, etc.)](https://gist.github.com/myedibleenso/8383af789b37ba598ff64ddd12c8b35b).
 + [more...](CHANGES.md)
 
 # Authors  
@@ -60,7 +60,7 @@ The `jar` is available on Maven Central. To use, simply add the following depend
 <dependency>
    <groupId>org.clulab</groupId>
    <artifactId>reach_2.11</artifactId>
-   <version>1.3.0</version>
+   <version>1.3.2</version>
 </dependency>
 ```
 
@@ -68,7 +68,7 @@ The `jar` is available on Maven Central. To use, simply add the following depend
 
 ```scala
 libraryDependencies ++= Seq(
-    "org.clulab" %% "reach" % "1.3.0"
+    "org.clulab" %% "reach" % "1.3.2"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -82,8 +82,8 @@ pomExtra := (
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "org.clulab" % "bioresources" % "1.1.15",
-  "org.clulab" %% "processors" % "5.9.5",
-  "org.clulab" %% "processors" % "5.9.5" classifier "models",
+  "org.clulab" %% "processors" % "5.9.6-SNAPSHOT",
+  "org.clulab" %% "processors" % "5.9.6-SNAPSHOT" classifier "models",
   "com.typesafe" % "config" % "1.2.1",
   "commons-io" % "commons-io" % "2.4",
   "org.biopax.paxtools" % "paxtools-core" % "4.3.1",

--- a/build.sbt
+++ b/build.sbt
@@ -82,8 +82,8 @@ pomExtra := (
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "org.clulab" % "bioresources" % "1.1.15",
-  "org.clulab" %% "processors" % "5.9.6-SNAPSHOT",
-  "org.clulab" %% "processors" % "5.9.6-SNAPSHOT" classifier "models",
+  "org.clulab" %% "processors" % "5.9.6",
+  "org.clulab" %% "processors" % "5.9.6" classifier "models",
   "com.typesafe" % "config" % "1.2.1",
   "commons-io" % "commons-io" % "2.4",
   "org.biopax.paxtools" % "paxtools-core" % "4.3.1",

--- a/src/main/scala/org/clulab/coref/Coref.scala
+++ b/src/main/scala/org/clulab/coref/Coref.scala
@@ -96,6 +96,7 @@ class Coref {
             specific.labels,
             specific.trigger,
             argSet,
+            specific.paths,
             specific.sentence,
             specific.document,
             specific.keep,
@@ -238,6 +239,7 @@ class Coref {
               m.labels,
               m.asInstanceOf[CorefEventMention].trigger,
               m.asInstanceOf[CorefEventMention].arguments,
+              m.paths,
               m.sentence,
               m.document,
               m.keep,
@@ -270,6 +272,7 @@ class Coref {
               val generated = new CorefRelationMention(
                 evt.labels,
                 argSet,
+                evt.paths,
                 evt.sentence,
                 evt.document,
                 evt.keep,
@@ -281,6 +284,7 @@ class Coref {
                 evt.labels,
                 evt.asInstanceOf[CorefEventMention].trigger,
                 argSet,
+                evt.paths,
                 evt.sentence,
                 evt.document,
                 evt.keep,
@@ -317,8 +321,8 @@ class Coref {
     val tbmSieveMap = tbmSieves(tbms.filter(_.isGeneric))
     if (verbose) resolvedTBMs.foreach { case (k, v) => println(s"TBM: ${k.text} => (" + v.map(vcopy => vcopy.text + vcopy.antecedents.map(_.text).mkString("[", ",", "]")).mkString(",") + ")") }
 
-    val resolvedSimple = resolveSimpleEvents(sevts, resolvedTBMs, tbmSieveMap)
-    val evtSieveMap = evtSieves(sevts.filter(_.isGeneric))
+    val resolvedSimple = resolveSimpleEvents(sevts, resolvedTBMs, tbmSieveMap).asInstanceOf[Map[CorefMention, Seq[CorefMention]]]
+    val evtSieveMap = evtSieves(sevts.filter(_.isGeneric)).asInstanceOf[Map[CorefMention, Set[String]]]
     if (verbose) resolvedSimple.foreach { case (k, v) => println(s"SimpleEvent: ${k.text} => (" + v.map(vcopy => vcopy.text + vcopy.antecedents.map(_.text).mkString("[", ",", "]")).mkString(",") + ")") }
 
     val resolvedComplex = resolveComplexEvents(cevts, resolvedTBMs ++ resolvedSimple, tbmSieveMap ++ evtSieveMap)

--- a/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
@@ -151,7 +151,7 @@ class DarpaActions extends Actions {
         // use cause of SimpleEvent to create a Regulation
         reg = new BioRelationMention(
           DarpaActions.REG_LABELS,
-          Map("controller" -> Seq(c), "controlled" -> Seq(ev)),
+          Map("controller" -> Seq(c), "controlled" -> Seq(ev)), Map.empty,
           e.sentence, e.document, e.keep, e.foundBy
         )
         // negations should be propagated to the newly created Positive_regulation
@@ -649,6 +649,7 @@ object DarpaActions {
       new BioRelationMention(
         taxonomy.hypernymsFor("Complex"),
         binding.arguments,
+        binding.paths,
         binding.sentence,
         binding.document,
         binding.keep,

--- a/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
+++ b/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
@@ -88,6 +88,7 @@ object MentionFilter {
                   new CorefRelationMention(
                     relReg.labels,
                     updatedArgs,
+                    relReg.paths,
                     relReg.sentence,
                     relReg.document,
                     relReg.keep,
@@ -108,6 +109,7 @@ object MentionFilter {
                     eventReg.labels,
                     eventReg.trigger,
                     updatedArgs,
+                    eventReg.paths,
                     eventReg.sentence,
                     eventReg.document,
                     eventReg.keep,

--- a/src/main/scala/org/clulab/reach/extern/export/JsonOutputter.scala
+++ b/src/main/scala/org/clulab/reach/extern/export/JsonOutputter.scala
@@ -9,6 +9,7 @@ import org.clulab.reach.ReachConstants._
 import ai.lum.nxmlreader.NxmlDocument
 import org.clulab.assembly.Assembler
 import org.clulab.reach.FriesEntry
+import org.clulab.serialization.json._
 
 
 /**

--- a/src/main/scala/org/clulab/reach/extern/export/fries/FriesOutput.scala
+++ b/src/main/scala/org/clulab/reach/extern/export/fries/FriesOutput.scala
@@ -19,6 +19,8 @@ import org.clulab.reach.extern.export.JsonOutputter._
 import org.clulab.reach.extern.export.MentionManager._
 import org.clulab.reach.grounding.KBResolution
 import org.clulab.reach.mentions._
+import org.clulab.serialization.json
+import org.clulab.serialization.json.JSONSerializer.formats
 
 
 /**
@@ -384,7 +386,7 @@ class FriesOutput extends JsonOutputter {
             if (!isTextBoundMention(p))
               throw new RuntimeException(s"Complex participant [${p}] is not an instance of TextBoundMention")
             if (!entityMap.contains(p))
-              throw new RuntimeException(s"Complex participant [${p.text} [mods: ${p.toCorefMention.modifications.map(_.toString).mkString(" ")}}]] not in entityMap \nin event [$parent.text] \nin sentence[${p.document.sentences(p.sentence).words.mkString(" ")}]:\n" + p.json(pretty = true))
+              throw new RuntimeException(s"Complex participant [${p.text} [mods: ${p.toCorefMention.modifications.map(_.toString).mkString(" ")}}]] not in entityMap \nin event [$parent.text] \nin sentence[${p.document.sentences(p.sentence).words.mkString(" ")}]:\n" + json.MentionOps(p).json(pretty = true))
             // participant checks have passed
             participants(s"$key${i + 1}") = entityMap.get(p).get
           }
@@ -393,7 +395,7 @@ class FriesOutput extends JsonOutputter {
 
       case "entity" =>                      // an Entity: fetch its ID from the entity map
         if (!entityMap.contains(arg)) {
-          throw new RuntimeException(s"Entity argument [${arg.text} [mods: ${arg.toCorefMention.modifications.map(_.toString).mkString(" ")}]] not in entityMap \nin event [$parent.text] \nin sentence[${arg.document.sentences(arg.sentence).words.mkString(" ")}]:\n" + arg.json(pretty = true))
+          throw new RuntimeException(s"Entity argument [${arg.text} [mods: ${arg.toCorefMention.modifications.map(_.toString).mkString(" ")}]] not in entityMap \nin event [$parent.text] \nin sentence[${arg.document.sentences(arg.sentence).words.mkString(" ")}]:\n" + json.MentionOps(arg).json(pretty = true))
         }
         pm("arg") = entityMap.get(arg).get
 

--- a/src/main/scala/org/clulab/reach/mentions/BioMention.scala
+++ b/src/main/scala/org/clulab/reach/mentions/BioMention.scala
@@ -27,12 +27,13 @@ class BioEventMention(
   labels: Seq[String],
   trigger: TextBoundMention,
   arguments: Map[String, Seq[Mention]],
+  paths: Map[String, Map[Mention, SynPath]],
   sentence: Int,
   document: Document,
   keep: Boolean,
   foundBy: String,
   val isDirect: Boolean = false
-) extends EventMention(labels, trigger, arguments, sentence, document, keep, foundBy)
+) extends EventMention(labels, mkTokenInterval(trigger, arguments), trigger, arguments, paths, sentence, document, keep, foundBy)
     with Modifications with Grounding with Display with Context{
 
   override def hashCode: Int = {
@@ -41,20 +42,21 @@ class BioEventMention(
   }
 
   def this(m: EventMention) =
-    this(m.labels, m.trigger, m.arguments, m.sentence, m.document, m.keep, m.foundBy)
+    this(m.labels, m.trigger, m.arguments, m.paths, m.sentence, m.document, m.keep, m.foundBy)
 
   def this(m: EventMention, direct: Boolean) =
-    this(m.labels, m.trigger, m.arguments, m.sentence, m.document, m.keep, m.foundBy, direct)
+    this(m.labels, m.trigger, m.arguments, m.paths, m.sentence, m.document, m.keep, m.foundBy, direct)
 }
 
 class BioRelationMention(
   labels: Seq[String],
   arguments: Map[String, Seq[Mention]],
+  paths: Map[String, Map[Mention, SynPath]],
   sentence: Int,
   document: Document,
   keep: Boolean,
   foundBy: String
-) extends RelationMention(labels, arguments, sentence, document, keep, foundBy)
+) extends RelationMention(labels, mkTokenInterval(arguments), arguments, paths, sentence, document, keep, foundBy)
     with Modifications with Grounding with Display with Context {
 
   override def hashCode: Int = {
@@ -63,7 +65,7 @@ class BioRelationMention(
   }
 
   def this(m: RelationMention) =
-    this(m.labels, m.arguments, m.sentence, m.document, m.keep, m.foundBy)
+    this(m.labels, m.arguments, m.paths, m.sentence, m.document, m.keep, m.foundBy)
 }
 
 object BioMention{

--- a/src/main/scala/org/clulab/reach/mentions/CorefMention.scala
+++ b/src/main/scala/org/clulab/reach/mentions/CorefMention.scala
@@ -115,12 +115,13 @@ class CorefEventMention(
   labels: Seq[String],
   trigger: TextBoundMention,
   arguments: Map[String, Seq[Mention]],
+  paths: Map[String, Map[Mention, SynPath]],
   sentence: Int,
   document: Document,
   keep: Boolean,
   foundBy: String,
   isDirect: Boolean = false
-) extends BioEventMention(labels, trigger, arguments, sentence, document, keep, foundBy, isDirect) with Anaphoric {
+) extends BioEventMention(labels, trigger, arguments, paths, sentence, document, keep, foundBy, isDirect) with Anaphoric {
 
   def isGeneric: Boolean = labels contains "Generic_event"
 
@@ -140,6 +141,7 @@ class CorefEventMention(
             this.labels,
             this.trigger,
             this.arguments,
+            this.paths,
             this.sentence,
             this.document,
             this.keep,
@@ -195,11 +197,12 @@ class CorefEventMention(
 class CorefRelationMention(
   labels: Seq[String],
   arguments: Map[String, Seq[Mention]],
+  paths: Map[String, Map[Mention, SynPath]],
   sentence: Int,
   document: Document,
   keep: Boolean,
   foundBy: String
-) extends BioRelationMention(labels, arguments, sentence, document, keep, foundBy) with Anaphoric {
+) extends BioRelationMention(labels, arguments, paths, sentence, document, keep, foundBy) with Anaphoric {
 
   def isGeneric: Boolean = false
 

--- a/src/main/scala/org/clulab/reach/mentions/package.scala
+++ b/src/main/scala/org/clulab/reach/mentions/package.scala
@@ -27,6 +27,7 @@ package object mentions {
           m.labels,
           m.trigger,
           convertArguments(m.arguments),
+          m.paths,
           m.sentence,
           m.document,
           m.keep,
@@ -36,6 +37,7 @@ package object mentions {
         new BioRelationMention(
           m.labels,
           convertArguments(m.arguments),
+          m.paths,
           m.sentence,
           m.document,
           m.keep,
@@ -62,6 +64,7 @@ package object mentions {
           m.labels,
           m.trigger,
           corefArguments(m.arguments),
+          m.paths,
           m.sentence,
           m.document,
           m.keep,
@@ -76,6 +79,7 @@ package object mentions {
         val rel = new CorefRelationMention(
           m.labels,
           corefArguments(m.arguments),
+          m.paths,
           m.sentence,
           m.document,
           m.keep,

--- a/src/main/scala/org/clulab/reach/serialization/json/JSONSerializer.scala
+++ b/src/main/scala/org/clulab/reach/serialization/json/JSONSerializer.scala
@@ -1,0 +1,180 @@
+package org.clulab.reach.serialization.json
+
+import java.io.File
+import org.clulab.serialization.json.DocOps
+import org.clulab.serialization.json.JSONSerializer._
+import org.clulab.odin._
+import org.clulab.reach.grounding.{KBEntry, KBResolution}
+import org.clulab.reach.mentions._
+import org.clulab.struct.Interval
+import org.json4s.JsonDSL._
+import org.json4s._
+import org.json4s.native.JsonMethods._
+
+
+/** JSON serialization utilities */
+object JSONSerializer {
+
+  def jsonAST(biomentions: Seq[BioMention]): JValue = {
+    val docsMap = biomentions.map(m => m.document.equivalenceHash.toString -> m.document.jsonAST).toMap
+    val mentionList = JArray(biomentions.map(m => BioMentionOps(m).jsonAST).toList)
+
+    ("documents" -> docsMap) ~
+    ("mentions" -> mentionList)
+  }
+
+  def jsonAST(f: File): JValue = parse(scala.io.Source.fromFile(f).getLines.mkString)
+
+  /** Produce a sequence of biomentions from json */
+  def toBioMentions(json: JValue): Seq[BioMention] = {
+
+    require(json \ "documents" != JNothing, "\"documents\" key missing from json")
+    require(json \ "mentions" != JNothing, "\"mentions\" key missing from json")
+
+    val djson = json \ "documents"
+    val mmjson = (json \ "mentions").asInstanceOf[JArray]
+
+    mmjson.arr.map(mjson => toBioMention(mjson, djson)).map(_.toBioMention)
+  }
+  /** Produce a sequence of mentions from a json file */
+  def toBioMentions(file: File): Seq[BioMention] = toBioMentions(jsonAST(file))
+
+  /** Build mention from json of mention and corresponding json map of documents <br>
+    * Since a single Document can be quite large and may be shared by multiple mentions,
+    * only a reference to the document json is contained within each mention.
+    * A map from doc reference to document json is used to avoid redundancies and reduce file size during serialization.
+    * */
+  def toBioMention(mjson: JValue, djson: JValue): BioMention = {
+
+    val tokInterval = Interval(
+      (mjson \ "tokenInterval" \ "start").extract[Int],
+      (mjson \ "tokenInterval" \ "end").extract[Int]
+    )
+    // elements shared by all Mention types
+    val labels = (mjson \ "labels").extract[List[String]]
+    val sentence = (mjson \ "sentence").extract[Int]
+    val docHash = (mjson \ "document").extract[String]
+    val document = toDocument(docHash, djson)
+    val keep = (mjson \ "keep").extract[Boolean]
+    val foundBy = (mjson \ "foundBy").extract[String]
+
+    def mkArgumentsFromJsonAST(json: JValue): Map[String, Seq[Mention]] = try {
+      val args = json.extract[Map[String, JArray]]
+      val argPairs = for {
+        (k: String, v: JValue) <- args
+        mns: Seq[Mention] = v.arr.map(m => toBioMention(m, djson))
+      } yield (k, mns)
+      argPairs
+    } catch {
+      case e: org.json4s.MappingException => Map.empty[String, Seq[Mention]]
+    }
+
+    // build BioMention
+    val m = mjson \ "type" match {
+      case JString("BioEventMention") =>
+        new BioEventMention(
+          labels,
+          // trigger must be (Bio)TextBoundMention
+          toBioMention(mjson \ "trigger", djson).asInstanceOf[BioTextBoundMention],
+          mkArgumentsFromJsonAST(mjson \ "arguments"),
+          sentence,
+          document,
+          keep,
+          foundBy
+        )
+
+      case JString("BioRelationMention") =>
+        new BioRelationMention(
+          labels,
+          mkArgumentsFromJsonAST(mjson \ "arguments"),
+          sentence,
+          document,
+          keep,
+          foundBy
+        )
+
+      case JString("BioTextBoundMention") =>
+        new BioTextBoundMention(
+          labels,
+          tokInterval,
+          sentence,
+          document,
+          keep,
+          foundBy
+        )
+
+      case other => throw new Exception(s"unrecognized mention type '${other.toString}'")
+    }
+
+    // update grounding
+    toKBResolution(mjson) match {
+      case Some(kbr) => m.nominate(Some(Seq(kbr)))
+      case None => ()
+    }
+    // update context
+    toContext(mjson) match {
+      case Some(context) => m.context = Some(context)
+      case None => ()
+    }
+    // update mods
+    m.modifications = toModifications(mjson, djson)
+    m
+  }
+
+  def toModifications(mjson: JValue, djson: JValue): Set[Modification] = mjson \ "modifications" match {
+    case mods: JArray => mods.arr.map(json => toModification(json, djson)).toSet
+    case _ => Set.empty[Modification]
+  }
+
+  def toModification(mjson: JValue, djson: JValue): Modification = mjson \ "type" match {
+    case JString("PTM") =>
+      PTM(
+        label = (mjson \ "label").extract[String],
+        evidence = getMention("evidence", mjson, djson),
+        site = getMention("site", mjson, djson),
+        negated = (mjson \ "negated").extract[Boolean]
+      )
+    case JString("EventSite") =>
+      // site is required
+      EventSite(site = getMention("site", mjson, djson).get)
+    case JString("Mutant") =>
+      // evidence is required
+      Mutant(
+        // evidence is required
+        evidence = getMention("evidence", mjson, djson).get,
+        foundBy = (mjson \ "foundBy").extract[String]
+      )
+    case JString("Negation") =>
+      // evidence is required
+      Negation(evidence = getMention("evidence", mjson, djson).get)
+    case JString("Hypothesis") =>
+      // evidence is required
+      Hypothesis(evidence = getMention("evidence", mjson, djson).get)
+    case other => throw new Exception(s"unrecognized modification type '${other.toString}'")
+  }
+
+  private def getMention(key: String, json: JValue, djson: JValue): Option[Mention] = json \ key match {
+    case JNothing => None
+    case evidence => Some(toBioMention(json, djson))
+  }
+
+  def toKBResolution(json: JValue): Option[KBResolution] = json \ "grounding" match {
+    case JNothing => None
+    case grounding =>
+      // build entry
+      val entry = new KBEntry(
+        text = (grounding \ "text").extract[String],
+        key = (grounding \ "key").extract[String],
+        namespace = (grounding \ "namespace").extract[String],
+        id = (grounding \ "id").extract[String],
+        species = (grounding \ "species").extract[String]
+      )
+      val kbr = new KBResolution(entry)
+      Some(kbr)
+  }
+
+  def toContext(json: JValue): Option[Map[String, Seq[String]]] = json \ "context" match {
+    case JNothing => None
+    case context => Some(context.extract[Map[String, Seq[String]]])
+  }
+}

--- a/src/main/scala/org/clulab/reach/serialization/json/package.scala
+++ b/src/main/scala/org/clulab/reach/serialization/json/package.scala
@@ -1,0 +1,166 @@
+package org.clulab.reach.serialization
+
+import org.clulab.odin._
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import org.clulab.reach.grounding.KBResolution
+import org.clulab.reach.mentions._
+import org.clulab.serialization.json.JSONSerialization
+import org.json4s._
+import org.json4s.JsonDSL._
+
+
+package object json {
+
+  private def argsAST(arguments: Map[String, Seq[Mention]]): JObject = {
+    val args = arguments.map {
+      case (name, mentions) => name -> JArray(mentions.map(_.toBioMention.jsonAST).toList)
+    }
+    JObject(args.toList)
+  }
+
+  implicit val formats = org.json4s.DefaultFormats
+
+  implicit class BioMentionOps(m: BioMention) extends JSONSerialization {
+    def jsonAST: JValue = m match {
+      case tb: BioTextBoundMention => BioTextBoundMentionOps(tb).jsonAST
+      case em: BioEventMention => BioEventMentionOps(em).jsonAST
+      case rm: BioRelationMention => BioRelationMentionOps(rm).jsonAST
+    }
+
+    // A mention only only contains a pointer to a document, so
+    // create a Seq[Mention] whose jsonAST includes
+    // an accompanying json map of docEquivHash -> doc's json
+    def completeAST: JValue = Seq(m).jsonAST
+
+    /**
+      * Serialize mentions to json file
+      */
+    def saveJSON(file: String, pretty: Boolean): Unit = {
+      require(file.endsWith(".json"), "file should have .json extension")
+      Files.write(Paths.get(file), Seq(m).json(pretty).getBytes(StandardCharsets.UTF_8))
+    }
+    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
+  }
+
+  implicit class BioTextBoundMentionOps(btb: BioTextBoundMention) extends JSONSerialization {
+    def jsonAST: JValue = {
+      ("type" -> "BioTextBoundMention") ~
+      ("labels" -> btb.labels) ~
+      ("tokenInterval" -> Map("start" -> btb.tokenInterval.start, "end" -> btb.tokenInterval.end)) ~
+      ("characterStartOffset" -> btb.startOffset) ~
+      ("characterEndOffset" -> btb.endOffset) ~
+      ("sentence" -> btb.sentence) ~
+      ("document" -> btb.document.equivalenceHash.toString) ~
+      ("keep" -> btb.keep) ~
+      ("foundBy" -> btb.foundBy) ~
+      ("modifications" -> btb.modifications.jsonAST) ~
+      // grounding is optional
+      ("grounding" -> btb.grounding.map(_.jsonAST)) ~
+      // context is optional
+      ("context" -> btb.context.map(_.jsonAST))
+    }
+  }
+
+  implicit class BioEventMentionOps(bem: BioEventMention) extends JSONSerialization {
+    def jsonAST: JValue = {
+      ("type" -> "BioEventMention") ~
+      ("labels" -> bem.labels) ~
+      ("trigger" -> bem.trigger.asInstanceOf[BioTextBoundMention].jsonAST) ~
+      ("arguments" -> argsAST(bem.arguments)) ~
+      ("tokenInterval" -> Map("start" -> bem.tokenInterval.start, "end" -> bem.tokenInterval.end)) ~
+      ("characterStartOffset" -> bem.startOffset) ~
+      ("characterEndOffset" -> bem.endOffset) ~
+      ("sentence" -> bem.sentence) ~
+      ("document" -> bem.document.equivalenceHash.toString) ~
+      ("keep" -> bem.keep) ~
+      ("foundBy" -> bem.foundBy) ~
+      ("modifications" -> bem.modifications.jsonAST) ~
+      // grounding is optional
+      ("grounding" -> bem.grounding.map(_.jsonAST)) ~
+      // context is optional
+      ("context" -> bem.context.map(_.jsonAST))
+    }
+  }
+
+  implicit class BioRelationMentionOps(brm: BioRelationMention) extends JSONSerialization {
+    def jsonAST: JValue = {
+      ("type" -> "BioRelationMention") ~
+      ("labels" -> brm.labels) ~
+      ("arguments" -> argsAST(brm.arguments)) ~
+      ("tokenInterval" -> Map("start" -> brm.tokenInterval.start, "end" -> brm.tokenInterval.end)) ~
+      ("characterStartOffset" -> brm.startOffset) ~
+      ("characterEndOffset" -> brm.endOffset) ~
+      ("sentence" -> brm.sentence) ~
+      ("document" -> brm.document.equivalenceHash.toString) ~
+      ("keep" -> brm.keep) ~
+      ("foundBy" -> brm.foundBy) ~
+      ("modifications" -> brm.modifications.jsonAST) ~
+      // grounding is optional
+      ("grounding" -> brm.grounding.map(_.jsonAST)) ~
+      // context is optional
+      ("context" -> brm.context.map(_.jsonAST))
+    }
+  }
+
+  /** For sequences of biomentions */
+  implicit class BioMentionSeq(biomentions: Seq[BioMention]) extends JSONSerialization {
+
+    def jsonAST: JValue = JSONSerializer.jsonAST(biomentions)
+
+    /**
+      * Serialize mentions to json file
+      */
+    def saveJSON(file: String, pretty: Boolean): Unit = {
+      require(file.endsWith(".json"), "file should have .json extension")
+      Files.write(Paths.get(file), biomentions.json(pretty).getBytes(StandardCharsets.UTF_8))
+    }
+    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
+  }
+
+  implicit class ModificationOps(mod: Modification) extends JSONSerialization {
+    def jsonAST: JValue = mod match {
+      case PTM(label, evidenceOp, siteOp, negated) =>
+        ("type" -> "PTM") ~
+        ("label" -> label) ~
+        // evidence is optional
+        ("evidence" -> evidenceOp.map(_.toBioMention.jsonAST)) ~
+        // site is optional
+        ("site" -> siteOp.map(_.toBioMention.jsonAST)) ~
+        ("negated" -> negated)
+      case Mutant(evidence, foundBy) =>
+        ("type" -> "Mutant") ~
+        ("evidence" -> evidence.toBioMention.jsonAST) ~
+        ("foundBy" -> foundBy)
+      case EventSite(evidence) =>
+        ("type" -> "EventSite") ~
+        ("site" -> evidence.toBioMention.jsonAST)
+      case Negation(evidence) =>
+        ("type" -> "Negation") ~
+        ("evidence" -> evidence.toBioMention.jsonAST)
+      case Hypothesis(evidence) =>
+        ("type" -> "Hypothesis") ~
+        ("evidence" -> evidence.toBioMention.jsonAST)
+    }
+  }
+
+  implicit class ModificationsOps(mods: Set[Modification]) extends JSONSerialization {
+    def jsonAST: JValue = mods.map(_.jsonAST).toList
+  }
+
+  implicit class KBResolutionOps(kbr: KBResolution) extends JSONSerialization {
+    def jsonAST: JValue = {
+      // components needed to construct KBEntry (KBResolution.entry)
+      ("text" -> kbr.entry.text) ~
+      ("key" -> kbr.entry.key) ~
+      ("namespace" -> kbr.entry.namespace) ~
+      ("id" -> kbr.entry.id) ~
+      ("species" -> kbr.entry.species)
+    }
+  }
+
+  implicit class ContextOps(context: Map[String, Seq[String]]) extends JSONSerialization {
+    def jsonAST: JValue = context
+  }
+}

--- a/src/main/scala/org/clulab/reach/serialization/json/package.scala
+++ b/src/main/scala/org/clulab/reach/serialization/json/package.scala
@@ -74,7 +74,7 @@ package object json {
       // usually just labels.head...
       ("displayLabel" -> tb.displayLabel) ~
       ("antecedents" -> tb.antecedents.jsonAST) ~
-      ("sieves" -> tb.sieves)
+      ("sieves" -> tb.sieves.jsonAST)
     }
   }
 
@@ -85,7 +85,7 @@ package object json {
       ("id" -> em.id) ~
       ("text" -> em.text) ~
       ("labels" -> em.labels) ~
-      ("trigger" -> em.trigger.asInstanceOf[CorefTextBoundMention].jsonAST) ~
+      ("trigger" -> em.trigger.toCorefMention.asInstanceOf[CorefTextBoundMention].jsonAST) ~
       ("paths" -> pathsAST(em.paths)) ~
       ("arguments" -> argsAST(em.arguments)) ~
       ("tokenInterval" -> Map("start" -> em.tokenInterval.start, "end" -> em.tokenInterval.end)) ~
@@ -104,7 +104,7 @@ package object json {
       ("displayLabel" -> em.displayLabel) ~
       ("isDirect" -> em.isDirect) ~
       ("antecedents" -> em.antecedents.jsonAST) ~
-      ("sieves" -> em.sieves)
+      ("sieves" -> em.sieves.jsonAST)
     }
   }
 
@@ -132,7 +132,7 @@ package object json {
       // usually just labels.head...
       ("displayLabel" -> rm.displayLabel) ~
       ("antecedents" -> rm.antecedents.jsonAST) ~
-      ("sieves" -> rm.sieves)
+      ("sieves" -> rm.sieves.jsonAST)
     }
   }
 
@@ -178,7 +178,10 @@ package object json {
   }
 
   implicit class ModificationsOps(mods: Set[Modification]) extends JSONSerialization {
-    def jsonAST: JValue = mods.map(_.jsonAST).toList
+    def jsonAST: JValue = mods match {
+      case hasMods if hasMods.nonEmpty => hasMods.map(_.jsonAST).toList
+      case _ => JNothing
+    }
   }
 
   implicit class KBResolutionOps(kbr: KBResolution) extends JSONSerialization {
@@ -193,11 +196,24 @@ package object json {
   }
 
   implicit class ContextOps(context: Map[String, Seq[String]]) extends JSONSerialization {
-    def jsonAST: JValue = context
+    def jsonAST: JValue = context match {
+      case hasContext if hasContext.nonEmpty => hasContext
+      case _ => JNothing
+    }
   }
 
   implicit class AnaphoricOps(antecedents: Set[Anaphoric]) extends JSONSerialization {
-    def jsonAST: JValue = antecedents.map(m => m.asInstanceOf[CorefMention].jsonAST)
+    def jsonAST: JValue = antecedents match {
+      case hasAntecedents if hasAntecedents.nonEmpty => hasAntecedents.map(m => m.asInstanceOf[CorefMention].jsonAST)
+      case _ => JNothing
+    }
+  }
+
+  implicit class StringSetOps(ss: Set[String]) extends JSONSerialization {
+    def jsonAST: JValue = ss match {
+      case contents if contents.nonEmpty => contents
+      case _ => JNothing
+    }
   }
 
 

--- a/src/main/scala/org/clulab/reach/serialization/json/package.scala
+++ b/src/main/scala/org/clulab/reach/serialization/json/package.scala
@@ -1,122 +1,154 @@
 package org.clulab.reach.serialization
 
+import org.clulab.odin
 import org.clulab.odin._
-import java.io.File
+import org.clulab.serialization.json.{ MentionOps => JSONMentionOps, _ }
+import org.clulab.serialization.json.{ JSONSerializer => JSONSer }
+import org.clulab.reach.mentions.{ MentionOps => MOps, _ }
+import org.clulab.reach.grounding.KBResolution
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
-import org.clulab.reach.grounding.KBResolution
-import org.clulab.reach.mentions._
-import org.clulab.serialization.json.JSONSerialization
-import org.json4s._
+import java.io.File
 import org.json4s.JsonDSL._
+import org.json4s._
 
 
 package object json {
 
   private def argsAST(arguments: Map[String, Seq[Mention]]): JObject = {
     val args = arguments.map {
-      case (name, mentions) => name -> JArray(mentions.map(_.toBioMention.jsonAST).toList)
+      case (name, mentions) => name -> JArray(mentions.map(_.toCorefMention.jsonAST).toList)
     }
     JObject(args.toList)
   }
 
   implicit val formats = org.json4s.DefaultFormats
 
-  implicit class BioMentionOps(m: BioMention) extends JSONSerialization {
-    def jsonAST: JValue = m match {
-      case tb: BioTextBoundMention => BioTextBoundMentionOps(tb).jsonAST
-      case em: BioEventMention => BioEventMentionOps(em).jsonAST
-      case rm: BioRelationMention => BioRelationMentionOps(rm).jsonAST
+  implicit class CorefMentionOps(m: CorefMention) extends JSONMentionOps(m) {
+
+    override def jsonAST: JValue = m match {
+      case tb: CorefTextBoundMention => CorefTextBoundMentionOps(tb).jsonAST
+      case em: CorefEventMention => CorefEventMentionOps(em).jsonAST
+      case rm: CorefRelationMention => CorefRelationMentionOps(rm).jsonAST
     }
 
     // A mention only only contains a pointer to a document, so
     // create a Seq[Mention] whose jsonAST includes
     // an accompanying json map of docEquivHash -> doc's json
-    def completeAST: JValue = Seq(m).jsonAST
+    override def completeAST: JValue = Seq(m).jsonAST
 
     /**
       * Serialize mentions to json file
       */
-    def saveJSON(file: String, pretty: Boolean): Unit = {
+    override def saveJSON(file: String, pretty: Boolean): Unit = {
       require(file.endsWith(".json"), "file should have .json extension")
       Files.write(Paths.get(file), Seq(m).json(pretty).getBytes(StandardCharsets.UTF_8))
     }
-    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
+    override def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
   }
 
-  implicit class BioTextBoundMentionOps(btb: BioTextBoundMention) extends JSONSerialization {
-    def jsonAST: JValue = {
-      ("type" -> "BioTextBoundMention") ~
-      ("labels" -> btb.labels) ~
-      ("tokenInterval" -> Map("start" -> btb.tokenInterval.start, "end" -> btb.tokenInterval.end)) ~
-      ("characterStartOffset" -> btb.startOffset) ~
-      ("characterEndOffset" -> btb.endOffset) ~
-      ("sentence" -> btb.sentence) ~
-      ("document" -> btb.document.equivalenceHash.toString) ~
-      ("keep" -> btb.keep) ~
-      ("foundBy" -> btb.foundBy) ~
-      ("modifications" -> btb.modifications.jsonAST) ~
+  def pathsAST(paths: Map[String, Map[Mention, odin.SynPath]]): JValue = paths match {
+    case gps if gps.nonEmpty => gps.jsonAST
+    case _ => JNothing
+  }
+
+  implicit class CorefTextBoundMentionOps(tb: CorefTextBoundMention) extends TextBoundMentionOps(tb) {
+    override def jsonAST: JValue = {
+      ("type" -> CorefTextBoundMention.string) ~
+      // used for paths map
+      ("id" -> tb.id) ~
+      ("text" -> tb.text) ~
+      ("labels" -> tb.labels) ~
+      ("tokenInterval" -> Map("start" -> tb.tokenInterval.start, "end" -> tb.tokenInterval.end)) ~
+      ("characterStartOffset" -> tb.startOffset) ~
+      ("characterEndOffset" -> tb.endOffset) ~
+      ("sentence" -> tb.sentence) ~
+      ("document" -> tb.document.equivalenceHash.toString) ~
+      ("keep" -> tb.keep) ~
+      ("foundBy" -> tb.foundBy) ~
+      ("modifications" -> tb.modifications.jsonAST) ~
       // grounding is optional
-      ("grounding" -> btb.grounding.map(_.jsonAST)) ~
+      ("grounding" -> tb.grounding.map(_.jsonAST)) ~
       // context is optional
-      ("context" -> btb.context.map(_.jsonAST))
+      ("context" -> tb.context.map(_.jsonAST)) ~
+      // usually just labels.head...
+      ("displayLabel" -> tb.displayLabel) ~
+      ("antecedents" -> tb.antecedents.jsonAST) ~
+      ("sieves" -> tb.sieves)
     }
   }
 
-  implicit class BioEventMentionOps(bem: BioEventMention) extends JSONSerialization {
-    def jsonAST: JValue = {
-      ("type" -> "BioEventMention") ~
-      ("labels" -> bem.labels) ~
-      ("trigger" -> bem.trigger.asInstanceOf[BioTextBoundMention].jsonAST) ~
-      ("arguments" -> argsAST(bem.arguments)) ~
-      ("tokenInterval" -> Map("start" -> bem.tokenInterval.start, "end" -> bem.tokenInterval.end)) ~
-      ("characterStartOffset" -> bem.startOffset) ~
-      ("characterEndOffset" -> bem.endOffset) ~
-      ("sentence" -> bem.sentence) ~
-      ("document" -> bem.document.equivalenceHash.toString) ~
-      ("keep" -> bem.keep) ~
-      ("foundBy" -> bem.foundBy) ~
-      ("modifications" -> bem.modifications.jsonAST) ~
+  implicit class CorefEventMentionOps(em: CorefEventMention) extends EventMentionOps(em) {
+    override def jsonAST: JValue = {
+      ("type" -> CorefEventMention.string) ~
+      // used for paths map
+      ("id" -> em.id) ~
+      ("text" -> em.text) ~
+      ("labels" -> em.labels) ~
+      ("trigger" -> em.trigger.asInstanceOf[CorefTextBoundMention].jsonAST) ~
+      ("paths" -> pathsAST(em.paths)) ~
+      ("arguments" -> argsAST(em.arguments)) ~
+      ("tokenInterval" -> Map("start" -> em.tokenInterval.start, "end" -> em.tokenInterval.end)) ~
+      ("characterStartOffset" -> em.startOffset) ~
+      ("characterEndOffset" -> em.endOffset) ~
+      ("sentence" -> em.sentence) ~
+      ("document" -> em.document.equivalenceHash.toString) ~
+      ("keep" -> em.keep) ~
+      ("foundBy" -> em.foundBy) ~
+      ("modifications" -> em.modifications.jsonAST) ~
       // grounding is optional
-      ("grounding" -> bem.grounding.map(_.jsonAST)) ~
+      ("grounding" -> em.grounding.map(_.jsonAST)) ~
       // context is optional
-      ("context" -> bem.context.map(_.jsonAST))
+      ("context" -> em.context.map(_.jsonAST)) ~
+      // usually just labels.head...
+      ("displayLabel" -> em.displayLabel) ~
+      ("isDirect" -> em.isDirect) ~
+      ("antecedents" -> em.antecedents.jsonAST) ~
+      ("sieves" -> em.sieves)
     }
   }
 
-  implicit class BioRelationMentionOps(brm: BioRelationMention) extends JSONSerialization {
-    def jsonAST: JValue = {
-      ("type" -> "BioRelationMention") ~
-      ("labels" -> brm.labels) ~
-      ("arguments" -> argsAST(brm.arguments)) ~
-      ("tokenInterval" -> Map("start" -> brm.tokenInterval.start, "end" -> brm.tokenInterval.end)) ~
-      ("characterStartOffset" -> brm.startOffset) ~
-      ("characterEndOffset" -> brm.endOffset) ~
-      ("sentence" -> brm.sentence) ~
-      ("document" -> brm.document.equivalenceHash.toString) ~
-      ("keep" -> brm.keep) ~
-      ("foundBy" -> brm.foundBy) ~
-      ("modifications" -> brm.modifications.jsonAST) ~
+  implicit class CorefRelationMentionOps(rm: CorefRelationMention) extends RelationMentionOps(rm) {
+    override def jsonAST: JValue = {
+      ("type" -> CorefRelationMention.string) ~
+      // used for paths map
+      ("id" -> rm.id) ~
+      ("text" -> rm.text) ~
+      ("labels" -> rm.labels) ~
+      ("arguments" -> argsAST(rm.arguments)) ~
+      ("paths" -> pathsAST(rm.paths)) ~
+      ("tokenInterval" -> Map("start" -> rm.tokenInterval.start, "end" -> rm.tokenInterval.end)) ~
+      ("characterStartOffset" -> rm.startOffset) ~
+      ("characterEndOffset" -> rm.endOffset) ~
+      ("sentence" -> rm.sentence) ~
+      ("document" -> rm.document.equivalenceHash.toString) ~
+      ("keep" -> rm.keep) ~
+      ("foundBy" -> rm.foundBy) ~
+      ("modifications" -> rm.modifications.jsonAST) ~
       // grounding is optional
-      ("grounding" -> brm.grounding.map(_.jsonAST)) ~
+      ("grounding" -> rm.grounding.map(_.jsonAST)) ~
       // context is optional
-      ("context" -> brm.context.map(_.jsonAST))
+      ("context" -> rm.context.map(_.jsonAST)) ~
+      // usually just labels.head...
+      ("displayLabel" -> rm.displayLabel) ~
+      ("antecedents" -> rm.antecedents.jsonAST) ~
+      ("sieves" -> rm.sieves)
     }
   }
 
   /** For sequences of biomentions */
-  implicit class BioMentionSeq(biomentions: Seq[BioMention]) extends JSONSerialization {
+  implicit class CorefMentionSeq(corefmentions: Seq[CorefMention]) extends MentionSeq(corefmentions) {
 
-    def jsonAST: JValue = JSONSerializer.jsonAST(biomentions)
+    override def jsonAST: JValue = JSONSer.jsonAST(corefmentions)
 
     /**
       * Serialize mentions to json file
       */
-    def saveJSON(file: String, pretty: Boolean): Unit = {
+    override def saveJSON(file: String, pretty: Boolean): Unit = {
       require(file.endsWith(".json"), "file should have .json extension")
-      Files.write(Paths.get(file), biomentions.json(pretty).getBytes(StandardCharsets.UTF_8))
+      Files.write(Paths.get(file), corefmentions.json(pretty).getBytes(StandardCharsets.UTF_8))
     }
-    def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
+    override def saveJSON(file: File, pretty: Boolean): Unit = saveJSON(file.getAbsolutePath, pretty)
   }
 
   implicit class ModificationOps(mod: Modification) extends JSONSerialization {
@@ -125,23 +157,23 @@ package object json {
         ("type" -> "PTM") ~
         ("label" -> label) ~
         // evidence is optional
-        ("evidence" -> evidenceOp.map(_.toBioMention.jsonAST)) ~
+        ("evidence" -> evidenceOp.map(_.toCorefMention.jsonAST)) ~
         // site is optional
-        ("site" -> siteOp.map(_.toBioMention.jsonAST)) ~
+        ("site" -> siteOp.map(_.toCorefMention.jsonAST)) ~
         ("negated" -> negated)
       case Mutant(evidence, foundBy) =>
         ("type" -> "Mutant") ~
-        ("evidence" -> evidence.toBioMention.jsonAST) ~
+        ("evidence" -> evidence.toCorefMention.jsonAST) ~
         ("foundBy" -> foundBy)
       case EventSite(evidence) =>
         ("type" -> "EventSite") ~
-        ("site" -> evidence.toBioMention.jsonAST)
+        ("site" -> evidence.toCorefMention.jsonAST)
       case Negation(evidence) =>
         ("type" -> "Negation") ~
-        ("evidence" -> evidence.toBioMention.jsonAST)
+        ("evidence" -> evidence.toCorefMention.jsonAST)
       case Hypothesis(evidence) =>
         ("type" -> "Hypothesis") ~
-        ("evidence" -> evidence.toBioMention.jsonAST)
+        ("evidence" -> evidence.toCorefMention.jsonAST)
     }
   }
 
@@ -162,5 +194,25 @@ package object json {
 
   implicit class ContextOps(context: Map[String, Seq[String]]) extends JSONSerialization {
     def jsonAST: JValue = context
+  }
+
+  implicit class AnaphoricOps(antecedents: Set[Anaphoric]) extends JSONSerialization {
+    def jsonAST: JValue = antecedents.map(m => m.asInstanceOf[CorefMention].jsonAST)
+  }
+
+
+  object CorefTextBoundMention {
+    val string = "CorefTextBoundMention"
+    val shortString = "T"
+  }
+
+  object CorefEventMention {
+    val string = "CorefEventMention"
+    val shortString = "E"
+  }
+
+  object CorefRelationMention {
+    val string = "CorefRelationMention"
+    val shortString = "R"
   }
 }

--- a/src/test/scala/org/clulab/reach/TestUtils.scala
+++ b/src/test/scala/org/clulab/reach/TestUtils.scala
@@ -50,6 +50,10 @@ object TestUtils {
     m <- getMentionsFromText(text)
   } yield m.toBioMention
 
+  def getCorefmentionsFromText(text: String): Seq[CorefMention] = for {
+    m <- getMentionsFromText(text)
+  } yield m.toCorefMention
+
   def getFlattenedBioMentionsFromText(text: String): Seq[BioMention] = for {
     m <- getMentionsFromText(text)
   } yield OutputDegrader.flattenMention(m).toBioMention

--- a/src/test/scala/org/clulab/reach/serialization/TestJSONSerializer.scala
+++ b/src/test/scala/org/clulab/reach/serialization/TestJSONSerializer.scala
@@ -1,0 +1,41 @@
+package org.clulab.reach.serialization
+
+import org.scalatest._
+import org.clulab.reach.TestUtils._
+import org.clulab.reach.serialization.json._
+import org.json4s._
+import org.json4s.native.JsonMethods._
+import org.json4s.native._
+
+
+class TestJSONSerializer extends FlatSpec with Matchers {
+
+  val text = "Phosphorylated MEK activates K-RAS."
+  val mentions = getCorefmentionsFromText(text)
+
+  "JSONSerializer" should "serialize/deserialize a Seq[CorefMention] to/from json correctly" in {
+    val mentions2 = JSONSerializer.toCorefMentions(mentions.jsonAST)
+    mentions2 should have size mentions.size
+    mentions2.map(_.label) should equal (mentions.map(_.label))
+    mentions2.map(_.document.equivalenceHash) should equal (mentions.map(_.document.equivalenceHash))
+  }
+
+  it should "serialize/deserialize a CorefMention to/from json correctly " in {
+    val mns = JSONSerializer.toCorefMentions(mentions.head.completeAST)
+    mns should have size 1
+    val m = mns.head
+    //println(s"${m.json(true)}")
+    m.document.equivalenceHash should equal (mentions.head.document.equivalenceHash)
+    m.tokenInterval should equal (mentions.head.tokenInterval)
+  }
+
+  s"json for '$text'" should "contain a modifications field" in {
+    (mentions.jsonAST \\ "modifications") should not equal JNothing
+  }
+
+  val text2 = "MEK activates K-RAS."
+  s"json for '$text2'" should "NOT contain a modifications field" in {
+    val mns = getCorefmentionsFromText(text2)
+    (mns.jsonAST \\ "modifications") should equal(JObject(List()))
+  }
+}


### PR DESCRIPTION
This is an extension of the work in clulab/processors#90 that targets the three flavors of`CorefMention`.  We can now serialize/deserialize any `CorefMention` to `json`, including information encoding:
- modifications
- context
- grounding
- antecedents
- sieves
- displayLabel

You can find sample output and a minimal working example here: https://gist.github.com/myedibleenso/8383af789b37ba598ff64ddd12c8b35b

Note that this won't serialize `BioMentions`, unless you first convert them to `CorefMentions`.  I don't think this is really a problem, though, as the `CorefMention` is a proper superset of all the features in `BioMention`.

Everything is also in place to encode a record of the dependency paths used to link to Mentions (the `.paths` Map), but the paths seem to disappear by the time a `Mention` makes its way through `ReachSystem` (I tried it with an activation, and it didn't work).  I know this feature works with plain jane mentions, as there is a test in `processors` for this and it passes.  It would be nice to have this information kept around whenever possible, as it could be useful for figuring out faulty comments of rules.  I'd appreciate some help tracking down where this information gets erased.