### PR TITLE
Problems with complex formation from ligation

### DIFF
--- a/src/main/resources/org/clulab/reach/biogrammar/events/bind_events.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/events/bind_events.yml
@@ -41,7 +41,7 @@
   action: mkBinding
   priority: ${ priority }
   pattern: |
-    trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment/] (?! [lemma="site"])
+    trigger = [word=/(?i)binding|dimerization|heterodimerization|recruitment/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = /conj_(and|or)/{,2} /prep_(with|to)/? /prep_of/{1,2} /conj_(and|or)/{,2}
     theme2:BioChemicalEntity+ = /conj_(and|or)/{,2} /prep_of/? /prep_(with|to)/{1,2} /conj_(and|or)/{,2} nn?
 
@@ -51,7 +51,7 @@
   type: token
   priority: ${ priority }
   pattern: |
-    (?<trigger> /(?i)binding|dimerization|heterodimerization|ligation|recruitment/) of
+    (?<trigger> /(?i)binding|dimerization|heterodimerization|recruitment/) of
     @theme1:BioChemicalEntity
     ((and | ",") @theme1:BioChemicalEntity)+
     (?! with)
@@ -61,7 +61,7 @@
   action: mkBinding
   priority: ${ priority }
   pattern: |
-      trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
+      trigger = [word=/(?i)binding|dimerization|heterodimerization|recruitment|interaction/] (?! [lemma="site"])
       theme1:BioChemicalEntity* = poss
       theme2:BioChemicalEntity+ = <nn (nn{,2} | <dep)
       #dummy: <nn >nn [word=/protein|domain|site/]
@@ -80,7 +80,7 @@
   action: mkBinding
   priority: ${ priority }
   pattern: |
-      trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
+      trigger = [word=/(?i)binding|dimerization|heterodimerization|recruitment|interaction/] (?! [lemma="site"])
       theme1:BioChemicalEntity+ = nn conj_and?
       theme2:BioChemicalEntity* = prep_to conj_and?
 
@@ -89,7 +89,7 @@
   action: mkBinding
   priority: ${ priority }
   pattern: |
-      trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site" | lemma=to])
+      trigger = [word=/(?i)binding|dimerization|heterodimerization|recruitment|interaction/] (?! [lemma="site" | lemma=to])
       theme1:BioChemicalEntity* = nn conj_and?
       theme2:BioChemicalEntity+ = prep_to conj_and?
 
@@ -98,7 +98,7 @@
   action: mkBinding
   priority: ${ priority }
   pattern: |
-      trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
+      trigger = [word=/(?i)binding|dimerization|heterodimerization|recruitment|interaction/] (?! [lemma="site"])
       theme1:BioChemicalEntity+ = nn conj_and?
       theme2:BioChemicalEntity+ = prep_to conj_and?
 
@@ -206,7 +206,7 @@
   action: mkBinding
   priority: ${ priority }
   pattern: |
-    trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] partner
+    trigger = [word=/(?i)binding|dimerization|heterodimerization|recruitment|interaction/] partner
     theme1:BioChemicalEntity+ = <appos
     theme2:BioChemicalEntity+ = /prep_of|prep_with/
 
@@ -215,7 +215,7 @@
   action: mkBinding
   priority: ${ priority }
   pattern: |
-    trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
+    trigger = [word=/(?i)binding|dimerization|heterodimerization|recruitment|interaction/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = rcmod{,2} prep_between
 
 - name: binding_21
@@ -253,7 +253,7 @@
   action: mkBinding
   priority: ${ priority }
   pattern: |
-    trigger = [word=/(?i)binding|dimerization|heterodimerization|ligation|recruitment|interaction/] (?! [lemma="site"])
+    trigger = [word=/(?i)binding|dimerization|heterodimerization|recruitment|interaction/] (?! [lemma="site"])
     theme1:BioChemicalEntity+ = poss
     theme2:BioChemicalEntity* = (prep_to|prep_with|prep_of|prep_by) [!(lemma=member)] nn{,2} | (prep_to|prep_with|prep_of|prep_by) [lemma=member] nn{1,2}
 

--- a/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
+++ b/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
@@ -245,6 +245,7 @@ class DarpaActions extends Actions with LazyLogging {
   def mkBindingsFromPairs(pairs: Seq[Seq[BioMention]], original: EventMention): Seq[Mention] = for {
     Seq(theme1, theme2) <- pairs
     if !sameEntityID(theme1, theme2)
+    if !(theme1.tokenInterval overlaps theme2.tokenInterval)
   } yield {
     if (theme1.text.toLowerCase == "ubiquitin") {
       val arguments = Map("theme" -> Seq(theme2))


### PR DESCRIPTION
This pull request fixes #338 by:
- disallowing overlapping binding participants
- removing the word "ligation" from the binding triggers

Note that "ligate" used as a verb was not removed. See for example rule "binding_16"
https://github.com/clulab/reach/blob/0206ec288cd1fae1372b21e8c5cd01d0a19959a0/src/main/resources/org/clulab/reach/biogrammar/events/bind_events.yml#L177-L184