### PR TITLE
Drug KB added to Reach

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ pomExtra := (
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.15",
+  "org.clulab" % "bioresources" % "1.1.16-SNAPSHOT",
   "org.clulab" %% "processors" % "5.9.6",
   "org.clulab" %% "processors" % "5.9.6" classifier "models",
   "com.typesafe" % "config" % "1.2.1",

--- a/src/main/scala/org/clulab/reach/grounding/EntityChecker.scala
+++ b/src/main/scala/org/clulab/reach/grounding/EntityChecker.scala
@@ -14,7 +14,7 @@ import org.clulab.reach.grounding.ReachKBConstants._
 /**
   * Program to lookup/check incoming BioPax model entities against local knowledge bases.
   *   Author: by Tom Hicks. 5/14/2015.
-  *   Last Modified: Replace ChEBI and HMDB KBs with PubChem.
+  *   Last Modified: Update for HMS drug KB.
   */
 object EntityChecker extends App {
 
@@ -26,7 +26,7 @@ object EntityChecker extends App {
                                        staticProteinKBLookup )
 
   /** Search sequence for small molecules. */
-  protected val chemSearcher = Seq( staticChemicalKBLookup )
+  protected val chemSearcher = Seq( staticChemicalKBLookup, staticDrugKBLookup )
 
   /** Search sequence for sub cellular locations terms. */
   protected val cellLocationSearcher = Seq( staticCellLocationKBLookup )

--- a/src/main/scala/org/clulab/reach/grounding/ReachContextKBLister.scala
+++ b/src/main/scala/org/clulab/reach/grounding/ReachContextKBLister.scala
@@ -5,12 +5,13 @@ import org.clulab.reach.grounding.ReachIMKBMentionLookups._
 /**
   * Object implementing logic to enumerate context related KB entries.
   *   Written by Tom Hicks. 2/19/2016.
-  *   Last Modified: Add tissue type KB.
+  *   Last Modified: Update for secondary cell line KB.
   */
 object ReachContextKBLister {
   /** A sequence of the context related KB instances, whose values are to be listed. */
   val ContextKBs = Seq(
     (ContextCellLine, "CellLine"),
+    (ContextCellLine2, "CellLine"),
     (ContextCellType, "CellType"),
     (ContextSpecies, "Species"),
     (ContextTissueType, "TissueType"),

--- a/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
+++ b/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
@@ -15,7 +15,7 @@ import org.clulab.reach.grounding.ReachIMKBMentionLookups._
 /**
   * Class which implements project internal methods to ground entities.
   *   Written by Tom Hicks. 11/9/2015.
-  *   Last Modified: Fix: allow overrides to work on Sites.
+  *   Last Modified: Update for secondary cell line KB.
   */
 class ReachEntityLookup {
 
@@ -84,8 +84,12 @@ class ReachEntityLookup {
 
   // instantiate the various search sequences, each sequence for a different label:
   val bioProcessSeq: KBSearchSequence = extraKBs ++ Seq( StaticBioProcess )
-  val cellLineSeq: KBSearchSequence = extraKBs ++ Seq( ContextCellLine )
   val cellTypeSeq: KBSearchSequence = extraKBs ++ Seq( ContextCellType )
+
+  val cellLineSeq: KBSearchSequence = extraKBs ++ Seq(
+    ContextCellLine,                        // Cellosaurus
+    ContextCellLine2                        // atcc
+  )
 
   val cellComponentSeq: KBSearchSequence = extraKBs ++ Seq(
     StaticCellLocation,                 // GO subcellular KB

--- a/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
+++ b/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
@@ -15,7 +15,7 @@ import org.clulab.reach.grounding.ReachIMKBMentionLookups._
 /**
   * Class which implements project internal methods to ground entities.
   *   Written by Tom Hicks. 11/9/2015.
-  *   Last Modified: Update for secondary cell line KB.
+  *   Last Modified: Update for HMS drug KB.
   */
 class ReachEntityLookup {
 
@@ -98,7 +98,8 @@ class ReachEntityLookup {
   )
 
   val chemicalSeq: KBSearchSequence = extraKBs ++ Seq(
-    StaticChemical,
+    StaticChemical,                         // PubChem
+    StaticDrug,                             // HMS LINCS drugs
     // StaticMetabolite,                    // REPLACED by PubChem
     ModelGendChemical
   )

--- a/src/main/scala/org/clulab/reach/grounding/ReachIMKBLookups.scala
+++ b/src/main/scala/org/clulab/reach/grounding/ReachIMKBLookups.scala
@@ -5,7 +5,7 @@ import org.clulab.reach.grounding.ReachKBConstants._
 /**
   * Object which implements all Reach KB Lookup instances.
   *   Written by: Tom Hicks. 10/23/2015.
-  *   Last Modified: Update for context tissue types KB.
+  *   Last Modified: Update for HMS drug KB.
   */
 object ReachIMKBLookups {
 
@@ -31,7 +31,14 @@ object ReachIMKBLookups {
   def staticChemicalKBLookup: IMKBLookup = {
     val metaInfo = new IMKBMetaInfo("http://identifiers.org/pubchem.compound/", "MIR:00000034")
     metaInfo.put("file", StaticChemicalFilename)
-    new IMKBLookup(tsvIMKBFactory.make("PubChem", StaticChemicalFilename, metaInfo))
+    new IMKBLookup(tsvIMKBFactory.make("pubchem", StaticChemicalFilename, metaInfo))
+  }
+
+  /** KB lookup to resolve small molecule (drug) names via static KB. */
+  def staticDrugKBLookup: IMKBLookup = {
+    val metaInfo = new IMKBMetaInfo("http://identifiers.org/pubchem.compound/", "MIR:00000034")
+    metaInfo.put("file", StaticDrugFilename)
+    new IMKBLookup(tsvIMKBFactory.make("pubchem", StaticDrugFilename, metaInfo))
   }
 
   /** KB lookup to resolve small molecule (chemical) names via static KB. */

--- a/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
+++ b/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
@@ -5,7 +5,7 @@ import org.clulab.reach.grounding.ReachKBConstants._
 /**
   * Object which implements all Reach KB Mention Lookup creators and instances.
   *   Written by: Tom Hicks. 10/28/2015.
-  *   Last Modified: Replace use of manual files.
+  *   Last Modified: Update for secondary cell line KB.
   */
 object ReachIMKBMentionLookups {
 
@@ -18,6 +18,7 @@ object ReachIMKBMentionLookups {
   // Singleton instances of the Reach KBs
 
   val ContextCellLine = contextCellLineKBML
+  val ContextCellLine2 = contextCellLine2KBML
   val ContextCellType = contextCellTypeKBML
   val ContextOrgan = contextOrganKBML
   val ContextSpecies = contextSpeciesKBML
@@ -25,7 +26,7 @@ object ReachIMKBMentionLookups {
 
   val StaticBioProcess = staticBioProcessKBML
   val StaticCellLocation = staticCellLocationKBML   // GO subcellular KB
-  val StaticCellLocation2 = staticCellLocationKBML2 // Uniprot subcellular KB
+  val StaticCellLocation2 = staticCellLocation2KBML // Uniprot subcellular KB
   val StaticChemical = staticChemicalKBML
   // val StaticMetabolite = staticMetaboliteKBML    // REPLACED by PubChem
   val StaticProtein = staticProteinKBML
@@ -67,7 +68,7 @@ object ReachIMKBMentionLookups {
   }
 
   /** KB accessor to resolve alternate subcellular location names via static KB. */
-  def staticCellLocationKBML2: IMKBMentionLookup = {
+  def staticCellLocation2KBML: IMKBMentionLookup = {
     val metaInfo = new IMKBMetaInfo("http://identifiers.org/uniprot/", "MIR:00000005")
     metaInfo.put("file", StaticCellLocation2Filename)
     new IMKBMentionLookup(TsvIMKBFactory.make("uniprot", StaticCellLocation2Filename, metaInfo))
@@ -166,6 +167,13 @@ object ReachIMKBMentionLookups {
     val metaInfo = new IMKBMetaInfo()
     metaInfo.put("file", ContextCellLineFilename)
     new IMKBMentionLookup(TsvIMKBFactory.make("cellosaurus", ContextCellLineFilename, hasSpeciesInfo = true, metaInfo))
+  }
+
+  /** KB accessor to resolve alternate cell lines via a context KB. */
+  def contextCellLine2KBML: IMKBMentionLookup = {
+    val metaInfo = new IMKBMetaInfo()
+    metaInfo.put("file", ContextCellLine2Filename)
+    new IMKBMentionLookup(TsvIMKBFactory.make("atcc", ContextCellLine2Filename, metaInfo))
   }
 
   /** KB accessor to resolve cell types via a context KB. */

--- a/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
+++ b/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
@@ -5,7 +5,7 @@ import org.clulab.reach.grounding.ReachKBConstants._
 /**
   * Object which implements all Reach KB Mention Lookup creators and instances.
   *   Written by: Tom Hicks. 10/28/2015.
-  *   Last Modified: Update for secondary cell line KB.
+  *   Last Modified: Update for HMS drug KB.
   */
 object ReachIMKBMentionLookups {
 
@@ -28,6 +28,7 @@ object ReachIMKBMentionLookups {
   val StaticCellLocation = staticCellLocationKBML   // GO subcellular KB
   val StaticCellLocation2 = staticCellLocation2KBML // Uniprot subcellular KB
   val StaticChemical = staticChemicalKBML
+  val StaticDrug = staticDrugKBML
   // val StaticMetabolite = staticMetaboliteKBML    // REPLACED by PubChem
   val StaticProtein = staticProteinKBML
   val StaticProteinFamily = staticProteinFamilyKBML
@@ -96,7 +97,14 @@ object ReachIMKBMentionLookups {
   def staticChemicalKBML: IMKBMentionLookup = {
     val metaInfo = new IMKBMetaInfo("http://identifiers.org/pubchem.compound/", "MIR:00000034")
     metaInfo.put("file", StaticChemicalFilename)
-    new IMKBMentionLookup(TsvIMKBFactory.make("PubChem", StaticChemicalFilename, metaInfo))
+    new IMKBMentionLookup(TsvIMKBFactory.make("pubchem", StaticChemicalFilename, metaInfo))
+  }
+
+  /** KB accessor to resolve small molecule (drug) names via static KB. */
+  def staticDrugKBML: IMKBMentionLookup = {
+    val metaInfo = new IMKBMetaInfo("http://identifiers.org/pubchem.compound/", "MIR:00000034")
+    metaInfo.put("file", StaticDrugFilename)
+    new IMKBMentionLookup(TsvIMKBFactory.make("pubchem", StaticDrugFilename, metaInfo))
   }
 
   /** KB accessor to resolve small molecule (chemical) names via static KB. */

--- a/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
+++ b/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
@@ -3,7 +3,7 @@ package org.clulab.reach.grounding
 /**
   * Trait for defining constants used by grounding and entity checking code.
   *   Written by Tom Hicks. 10/22/2015.
-  *   Last Modified: Update for secondary cell line KB.
+  *   Last Modified: Update for HMS drug KB.
   */
 object ReachKBConstants {
 
@@ -61,6 +61,9 @@ object ReachKBConstants {
 
   /** Filename of the static small molecule (chemical) file. */
   val StaticChemicalFilename = "PubChem.tsv.gz"
+
+  /** Filename of the static small molecule (drug) file. */
+  val StaticDrugFilename = "hms-drugs.tsv.gz"
 
   /** Filename of the static small molecule (metabolite) file. */
   val StaticMetaboliteFilename = "hmdb.tsv.gz"

--- a/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
+++ b/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
@@ -3,7 +3,7 @@ package org.clulab.reach.grounding
 /**
   * Trait for defining constants used by grounding and entity checking code.
   *   Written by Tom Hicks. 10/22/2015.
-  *   Last Modified: Rename protein kinases and protein domains file.
+  *   Last Modified: Update for secondary cell line KB.
   */
 object ReachKBConstants {
 
@@ -80,6 +80,9 @@ object ReachKBConstants {
 
   /** Filename of the context cell lines file */
   val ContextCellLineFilename = "Cellosaurus.tsv.gz"
+
+  /** Filename of the secondary context cell lines file */
+  val ContextCellLine2Filename = "atcc.tsv.gz"
 
   /** Filename of the context cell types file */
   val ContextCellTypeFilename = "CellOntology.tsv.gz"

--- a/src/test/scala/org/clulab/reach/TestNERLabeling.scala
+++ b/src/test/scala/org/clulab/reach/TestNERLabeling.scala
@@ -11,7 +11,7 @@ import TestUtils._
 /**
   * Test the labeling of various types of mentions identified by the NER.
   *   Written by: Tom Hicks. 4/21/2016.
-  *   Last Modified: Cleanup scalatest syntax.
+  *   Last Modified: Add tests for new drug KB.
   */
 class TestNERLabeling extends FlatSpec with Matchers {
 
@@ -30,6 +30,10 @@ class TestNERLabeling extends FlatSpec with Matchers {
   val chemical = "endoxifen sulfate, Juvamine, Adenosine-phosphate, Xitix, and Monic acid cause cancer"
   val sites = "ALOG domain, AMIN domain, KIP1-like, KEN domain, and HAS subgroup cause cancer"
   val species = "Potato, wheat, Yerba-mate, Danio rerio, zebrafish, Rats, Gallus gallus, and chickens cause cancer"
+
+  val drug = "Alvocidib, Anacardic acid, L-779450, Masitinib, and  Withaferin A are known drugs. "
+  val drug_ids = Seq("5287969", "167551", "9950176", "10074640", "265237")
+
 
   bioProcess should "have BioProcess label" in {
     val mentions = getBioMentions(bioProcess)
@@ -191,6 +195,29 @@ class TestNERLabeling extends FlatSpec with Matchers {
   it should "match expected grounding IDs" in {
     val m = mentions274f(0)
     (m.grounding.isDefined && (m.grounding.get.id == "UAZ-PF-214")) should be (true)
+  }
+
+
+  // Drug KB Simple_chemical Tests
+  val drug_mentions = getBioMentions(drug)
+  drug should "have expected number of results" in {
+    drug_mentions should not be (empty)
+    // printMentions(Try(drug_mentions), true)      // DEBUGGING
+    drug_mentions should have size (drug_ids.size)
+  }
+
+  it should "have labeled all mentions as Simple_chemical" in {
+    drug_mentions.count(_ matches "Simple_chemical") should be (drug_ids.size)
+  }
+
+  it should "have display labeled all mentions as Simple_chemical" in {
+    drug_mentions.count(_.displayLabel == "Simple_chemical") should be (drug_ids.size)
+  }
+
+  it should "match expected grounding IDs" in {
+    for ((m, ndx) <- drug_mentions.zipWithIndex) {
+      m.grounding.isDefined && (m.grounding.get.id == drug_ids(ndx)) should be (true)
+    }
   }
 
 }


### PR DESCRIPTION
Added grounding code for HMS LINCS drug KB. Also adds code for ATCC cell line KB. Both KBs already in released Bioresources 1.1.17.