### PR TITLE
Issue 342

### DIFF
--- a/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
@@ -84,18 +84,6 @@
     site:Site? = /pobj|prep_|conj_(and|or|nor)|nn/{1,2}
 
 
-- name: ${ eventName }_syntax_3d_verb
-  priority: ${ priority }
-  example: ""
-  label: ${ label }
-  action: ${ actionFlow }
-  pattern: |
-    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & !outgoing=nsubjpass & tag=/^(V|JJ)/ & !mention=ModificationTrigger] # verbal predicate
-    cause:BioChemicalEntity? = (prep_by) /nn|conj_(and|or|nor)|cc|prep_of/{,2}
-    theme:BioChemicalEntity = < /pobj|prep_|conj_(and|or|nor)|nn/{1,2} # NB: <
-    site:Site? = /pobj|prep_|conj_(and|or|nor)|nn/{1,2}
-
-
 - name: ${ eventName }_syntax_3e_verb
   priority: ${ priority }
   example: ""
@@ -117,30 +105,6 @@
     trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & !outgoing=nsubjpass & tag=/^(V|JJ)/ & !mention=ModificationTrigger] # verbal predicate
     cause:BioChemicalEntity? = (prep_by) /nn|conj_(and|or|nor)|cc|prep_of/{,2}
     theme:BioChemicalEntity = /pobj|prep_[^bt]|conj_(and|or|nor)|nn/{1,2}
-    site:Site? = < /pobj|prep_|conj_(and|or|nor)|nn/{1,2} # NB: <
-
-
-- name: ${ eventName }_syntax_3g_verb
-  priority: ${ priority }
-  example: ""
-  label: ${ label }
-  action: ${ actionFlow }
-  pattern: |
-    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & !outgoing=nsubjpass & tag=/^(V|JJ)/ & !mention=ModificationTrigger] # verbal predicate
-    cause:BioChemicalEntity? = <nn{,2}
-    theme:BioChemicalEntity = < /pobj|prep_|conj_(and|or|nor)|nn/{1,2} # NB: <
-    site:Site? = < /pobj|prep_|conj_(and|or|nor)|nn/{1,2} # NB: <
-
-
-- name: ${ eventName }_syntax_3h_verb
-  priority: ${ priority }
-  example: ""
-  label: ${ label }
-  action: ${ actionFlow }
-  pattern: |
-    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & !outgoing=nsubjpass & tag=/^(V|JJ)/ & !mention=ModificationTrigger] # verbal predicate
-    cause:BioChemicalEntity? = (prep_by) /nn|conj_(and|or|nor)|cc|prep_of/{,2}
-    theme:BioChemicalEntity = < /pobj|prep_|conj_(and|or|nor)|nn/{1,2} # NB: <
     site:Site? = < /pobj|prep_|conj_(and|or|nor)|nn/{1,2} # NB: <
 
 

--- a/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
@@ -84,18 +84,6 @@
     site:Site? = /pobj|prep_|conj_(and|or|nor)|nn/{1,2}
 
 
-- name: ${ eventName }_syntax_3c_verb
-  priority: ${ priority }
-  example: ""
-  label: ${ label }
-  action: ${ actionFlow }
-  pattern: |
-    trigger = [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & !outgoing=nsubjpass & tag=/^(V|JJ)/ & !mention=ModificationTrigger] # verbal predicate
-    cause:BioChemicalEntity? = <nn{,2}
-    theme:BioChemicalEntity = < /pobj|prep_|conj_(and|or|nor)|nn/{1,2} # NB: <
-    site:Site? = /pobj|prep_|conj_(and|or|nor)|nn/{1,2}
-
-
 - name: ${ eventName }_syntax_3d_verb
   priority: ${ priority }
   example: ""

--- a/src/test/scala/org/clulab/reach/TestTemplaticSimpleEvents.scala
+++ b/src/test/scala/org/clulab/reach/TestTemplaticSimpleEvents.scala
@@ -593,4 +593,10 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
     val mentions = getBioMentions(sent41)
     hasEventWithArguments("Phosphorylation", Seq("MEK5D"), mentions) should be (false)
   }
+
+  val sent42 = "Expression of SIRT1, SIRT2, and acetylated (Ac)-p53 in gastric cancer cell lines."
+  sent42 should "not contain an acetylation of SIRT1" in {
+    val mentions = getBioMentions(sent42)
+    hasEventWithArguments("Acetylation", Seq("SIRT1"), mentions) should be (false)
+  }
 }


### PR DESCRIPTION
The templatic simple event rule `${ eventName }_syntax_3_verb` had previously been overloaded with many disjunctions and consequently was split into `${ eventName }_syntax_3[a-h]_verb` for easier debugging. Several of these rules produced erroneous output when given sentences that contained `/conj_/ dobj` links, i.e. a token that had both an incoming conjunction link and an outgoing direct object link. By-hand tests seem to show no drawback to simply removing these rules. An additional test was added to ensure that this erroneous output was no longer produced. This closes #342 
