### PR TITLE
Save all grounding resolutions in the FRIES output

### DIFF
--- a/src/main/scala/org/clulab/reach/extern/export/fries/FriesOutput.scala
+++ b/src/main/scala/org/clulab/reach/extern/export/fries/FriesOutput.scala
@@ -26,7 +26,7 @@ import org.clulab.serialization.json.JSONSerializer.formats
 /**
   * Defines classes and methods used to build and output the FRIES format.
   *   Written by: Mihai Surdeanu and Tom Hicks.
-  *   Last Modified: Sort mention maps by sentence order.
+  *   Last Modified: Output alternate candidate groundings and grounding species.
   */
 class FriesOutput extends JsonOutputter {
 
@@ -358,6 +358,15 @@ class FriesOutput extends JsonOutputter {
   }
 
 
+  /** Create and return a list of alternate grounding candidates. */
+  private def makeAltGroundings (mention: BioMention): FrameList = {
+    val altGroundings = new FrameList
+    mention.candidates.foreach(cands =>
+      cands.tail.foreach(cand => altGroundings += makeGrounding(cand)))
+    altGroundings
+  }
+
+
   private def makeArgumentFrame (name: String,
                                  arg: Mention,
                                  argIndex: Int,
@@ -516,9 +525,17 @@ class FriesOutput extends JsonOutputter {
     f("end-pos") = makeRelativePosition(paperId, passageMeta, mention.endOffset)
     f("text") = mention.text
     f("type") = prettifyLabel(mention.displayLabel)
+
+    // add best grounding
     val groundings = new FrameList
     mention.grounding.foreach(grnd => groundings += makeGrounding(grnd))
     f("xrefs") = groundings
+
+    // add other grounding candidates
+    val altGroundings = makeAltGroundings(mention)
+    if (altGroundings.nonEmpty)
+      f("alt-xrefs") = altGroundings
+
     if (mention.isModified) {
       val ms = new FrameList
       for (m <- mention.modifications) {
@@ -635,6 +652,8 @@ class FriesOutput extends JsonOutputter {
     pm("object-type") = "db-reference"
     pm("namespace") = grounding.namespace
     pm("id") = grounding.id
+    if (grounding.hasSpecies)
+      pm("species") = grounding.species
     pm
   }
 


### PR DESCRIPTION
The alternate grounding candidates are now output in the FRIES output in a JSON list titled 'alt-xrefs' (since the preferred grounding uses 'xrefs'). In order to make sense of and to use the alternate grounding candidates, however, it was also necessary to output the species in groundings, so this was added, too.
