### PR TITLE
Ubiquitylation

### DIFF
--- a/src/main/resources/org/clulab/reach/biogrammar/events_master.yml
+++ b/src/main/resources/org/clulab/reach/biogrammar/events_master.yml
@@ -51,8 +51,8 @@ rules:
       eventName: "Ubiquitination"
       actionFlow: "mkUbiquitination"
       label: "Ubiquitination"
-      verbalTriggerLemma: "ubiquitinate"
-      nominalTriggerLemma: "ubiquitination"
+      verbalTriggerLemma: "ubiquit(in|yl)ate"
+      nominalTriggerLemma: "ubiquit(in|yl)ation"
       triggerPrefix: "!word=/(?i)^de/"
       priority: "5"
 
@@ -154,8 +154,8 @@ rules:
       eventName: "Deubiquitination"
       actionFlow: "mkUbiquitination"
       label: "Deubiquitination"
-      verbalTriggerLemma: "de-?ubiquitinate"
-      nominalTriggerLemma: "de-?ubiquitination"
+      verbalTriggerLemma: "de-?ubiquit(in|yl)ate"
+      nominalTriggerLemma: "de-?ubiquit(in|yl)ation"
       triggerPrefix: "word=/(?i)^de/"
       priority: "5"
 

--- a/src/test/scala/org/clulab/reach/TestTemplaticSimpleDeEvents.scala
+++ b/src/test/scala/org/clulab/reach/TestTemplaticSimpleDeEvents.scala
@@ -484,4 +484,10 @@ class TestTemplaticSimpleDeEvents extends FlatSpec with Matchers {
     // TODO: this fails because the *_token_8_noun rule over matches. Please fix
     hasEventWithArguments("Dephosphorylation", List("p35"), mentions) should be (false)
   }
+
+  val sent35 = "SIRT1 deubiquitylates MEK5D"
+  sent35 should "contain a deubiqutination" in {
+    val mentions = getBioMentions(sent35)
+    hasEventWithArguments("Deubiquitination", Seq("MEK5D"), mentions) should be (true)
+  }
 }

--- a/src/test/scala/org/clulab/reach/TestTemplaticSimpleEvents.scala
+++ b/src/test/scala/org/clulab/reach/TestTemplaticSimpleEvents.scala
@@ -599,4 +599,10 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
     val mentions = getBioMentions(sent42)
     hasEventWithArguments("Acetylation", Seq("SIRT1"), mentions) should be (false)
   }
+
+  val sent43 = "SIRT1 ubiquitylates MEK5D"
+  sent43 should "contain a ubiqutination" in {
+    val mentions = getBioMentions(sent43)
+    hasEventWithArguments("Ubiquitination", Seq("MEK5D"), mentions) should be (true)
+  }
 }


### PR DESCRIPTION
This is a very small change to allow the triggers `ubiquitylate` and `ubiquitylation` for Ubiquitinations, and similarly, `de-ubiquitylate` and `de-ubiquitylation` for Deubiquitinations. Two brief tests are provided.