### PR TITLE
"treated with" pattern for positive activations

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/events/pos-act-only_template.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/events/pos-act-only_template.yml
@@ -11,3 +11,19 @@
     trigger = [word=/(?i)^(${ triggers })/ & tag=/^N/] [lemma=/^(${ auxtriggers })/ & tag=/^N/]?
     controller:${ controllerType } = <prep_in [lemma=result] nsubj /nn|amod|conj_|cc/{,2}
     controlled:${ controlledType } = /nn|prep_of/
+
+
+- name: "Positive_activation_surface_treated_with"
+  priority: ${ priority }
+  example: "We now show that mTOR inhibition induces insulin receptor substrate-1 expression and abrogates feedback inhibition of the pathway , resulting in Akt activation both in cancer cell lines and in patient tumors treated with the rapamycin derivative , RAD001 ."
+  type: token
+  label: ${label}
+  action: ${ actionFlow }
+  pattern: |
+    @controlled:BioEntity [lemma=activation]?
+    # some number of interceding tokens
+    []{,10}
+    (?<trigger> treated with)
+    # determiners, etc.
+    []{,3}
+    @controller:BioEntity

--- a/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
@@ -299,4 +299,10 @@ class TestActivationEvents extends FlatSpec with Matchers {
     hasPositiveActivation("EGFR", "MAPK1", mentions) should be (true)
   }
 
+  val sent40 = "We now show that mTOR inhibition induces insulin receptor substrate-1 expression and abrogates feedback inhibition of the pathway , resulting in Akt activation both in cancer cell lines and in patient tumors treated with the rapamycin derivative , RAD001 ."
+  sent40 should "contain 1 positive activation" in {
+    val cms = getCorefmentionsFromText(sent40)
+    cms.count(_ matches "Positive_activation") should be (1)
+    hasPositiveActivation(controllerEntity = "rapamycin", controlledEntity = "Akt", cms)
+  }
 }

--- a/test_projects
+++ b/test_projects
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+sbt test
 sbt main/test
 sbt assembly/test
 sbt export/test


### PR DESCRIPTION
Includes a test for the noted example.  For the sentence,


>We now show that mTOR inhibition induces insulin receptor substrate-1 expression and abrogates feedback inhibition of the pathway , resulting in Akt activation both in cancer cell lines and in patient tumors treated with the rapamycin derivative , RAD001 .


...we produce the attached extractions (note that the transcription expression stuff hasn't yet been merged).

[PMC3193604-fragment.json.txt](https://github.com/clulab/reach/files/531405/PMC3193604-fragment.json.txt)