### PR TITLE
Create Gordo (fat jar) without running tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val root = (project in file("."))
     name := "reach-exe",
     aggregate in test := false,
     aggregate in assembly := false,
+    test in assembly := {},
     assemblyJarName in assembly := s"reach-gordo-${version.value}.jar"
   )
 


### PR DESCRIPTION
Assembly task appears to be including the test classes and running all the tests before it builds the Uber JAR. Since we will *never* create an Uber JAR without having thoroughly tested the code :), I added a line to the build file to prevent testing within the assembly task. 