### PR TITLE
X homolog Y rules and tests

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/coref/alias_template.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/coref/alias_template.yml
@@ -121,3 +121,15 @@
     ([word=/^,|\/|or$/]+ ${ bCapture })*
     [tag=/^\.|,|:$/]
 
+- name: alias_${ aLabel }-${ bLabel }_homolog
+  example: "We studied the effects of the Pax6 homologs eyeless and eyegone."
+  label: Alias
+  action: mkBioMention
+  priority: ${ priority }
+  type: token
+  pattern: |
+    ${ aCapture }
+    [lemma="homolog"]
+    ${ bCapture }
+    (("," ${ bCapture })* ","? and ${ bCapture })?
+

--- a/main/src/main/resources/org/clulab/reach/biogrammar/coref/alias_template.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/coref/alias_template.yml
@@ -133,3 +133,18 @@
     ${ bCapture }
     (("," ${ bCapture })* ","? and ${ bCapture })?
 
+- name: alias_${ aLabel }-${ bLabel }_homolog2
+  example: "Eyeless, a homolog of Pax6, is the subject of this work."
+  label: Alias
+  action: mkBioMention
+  priority: ${ priority }
+  type: token
+  pattern: |
+    ${ aCapture }
+    (("," ${ aCapture })* ","? and ${ aCapture })?
+    ","
+    (the | a)?
+    [lemma="homolog"]
+    of
+    ${ bCapture }
+

--- a/main/src/main/resources/org/clulab/reach/biogrammar/entities_master.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/entities_master.yml
@@ -13,11 +13,11 @@ rules:
       aLabel: "Equivalable"
       aCapture: "@aliasSource:Equivalable"
       bLabel: "Nonce"
-      bCapture: "(?<aliasTarget> [!mention=/.*/ & tag=/NNP?/]{1,2})"
+      bCapture: "(?<aliasTarget> [!mention=/.*/ & tag=/^(JJ|NNP?)$/]{1,2})"
   - import: org/clulab/reach/biogrammar/coref/alias_template.yml
     vars:
       priority: "7"
       aLabel: "Nonce"
-      aCapture: "(?<aliasTarget> [!mention=/.*/ & tag=/NNP?/]{1,2})"
+      aCapture: "(?<aliasTarget> [!mention=/.*/ & tag=/^(JJ|NNP?)$/]{1,2})"
       bLabel: "Equivalable"
       bCapture: "@aliasSource:Equivalable"

--- a/main/src/main/scala/org/clulab/coref/Coref.scala
+++ b/main/src/main/scala/org/clulab/coref/Coref.scala
@@ -378,6 +378,7 @@ class Coref extends LazyLogging {
       }
     }
 
+    val default = ReachKBConstants.DefaultNamespace
     for {
       mentions <- orderedMentions
     } {
@@ -395,11 +396,10 @@ class Coref extends LazyLogging {
         val ag = a.grounding.get
         val bg = b.grounding.get
         // one or the other is effectively ungrounded
-        if (ag.namespace == ReachKBConstants.DefaultNamespace) aliases(ag.entry) = b.candidates
-        else if (bg.namespace == ReachKBConstants.DefaultNamespace) aliases(bg.entry) = a.candidates
+        if (ag.namespace == default && bg.namespace != default) aliases(ag.entry) = b.candidates
+        else if (bg.namespace == default && ag.namespace != default) aliases(bg.entry) = a.candidates
         // both are grounded, but maybe one's grounding is correct for both
-        else if (ag.namespace != ReachKBConstants.DefaultNamespace &&
-          bg.namespace != ReachKBConstants.DefaultNamespace) {
+        else if (ag.namespace != default && bg.namespace != default) {
           // combine candidates in order -- important to maintain correct first choice
           val ab = a.candidates.getOrElse(Nil) ++ b.candidates.getOrElse(Nil)
           val ba = b.candidates.getOrElse(Nil) ++ a.candidates.getOrElse(Nil)

--- a/main/src/test/scala/org/clulab/reach/TestCoreference.scala
+++ b/main/src/test/scala/org/clulab/reach/TestCoreference.scala
@@ -700,4 +700,15 @@ class TestCoreference extends FlatSpec with Matchers {
     mentions.filter(_.text == "eyefull").foreach(_.candidates.get.toSet should equal(targetGrounding))
     mentions.filter(_.text == "eyegone").foreach(_.candidates.get.toSet should equal(targetGrounding))
   }
+
+  val sent63 = "Eyeless and eyegone, homologs of Pax6, are the subject of this work."
+  sent63 should "contain grounded mentions for eyeless and eyegone" in {
+    val mentions = getBioMentions(sent63)
+    mentions should have size 3
+    val pax = mentions.find(_.text == "Pax6")
+    pax should not be empty
+    val targetGrounding = pax.get.candidates.get.toSet
+    mentions.filter(_.text.toLowerCase == "eyeless").foreach(_.candidates.get.toSet should equal(targetGrounding))
+    mentions.filter(_.text == "eyegone").foreach(_.candidates.get.toSet should equal(targetGrounding))
+  }
 }

--- a/main/src/test/scala/org/clulab/reach/TestCoreference.scala
+++ b/main/src/test/scala/org/clulab/reach/TestCoreference.scala
@@ -677,4 +677,27 @@ class TestCoreference extends FlatSpec with Matchers {
     val aspCands = asp.get.candidates.get.toSet
     nonces.foreach(nonce => nonce.candidates.get.toSet should equal (aspCands))
   }
+
+  val sent62a = "We studied the effects of the Pax6 homologs eyeless and eyegone."
+  sent62a should "contain grounded mentions for eyeless and eyegone" in {
+    val mentions = getBioMentions(sent62a)
+    mentions should have size 3
+    val pax = mentions.find(_.text == "Pax6")
+    pax should not be empty
+    val targetGrounding = pax.get.candidates.get.toSet
+    mentions.filter(_.text == "eyeless").foreach(_.candidates.get.toSet should equal(targetGrounding))
+    mentions.filter(_.text == "eyegone").foreach(_.candidates.get.toSet should equal(targetGrounding))
+  }
+
+  val sent62b = "The Pax6 homologs eyeless, eyefull, and eyegone were found in established lines."
+  sent62b should "contain grounded mentions for eyeless, eyefull, and eyegone" in {
+    val mentions = getBioMentions(sent62b)
+    mentions should have size 4
+    val pax = mentions.find(_.text == "Pax6")
+    pax should not be empty
+    val targetGrounding = pax.get.candidates.get.toSet
+    mentions.filter(_.text == "eyeless").foreach(_.candidates.get.toSet should equal(targetGrounding))
+    mentions.filter(_.text == "eyefull").foreach(_.candidates.get.toSet should equal(targetGrounding))
+    mentions.filter(_.text == "eyegone").foreach(_.candidates.get.toSet should equal(targetGrounding))
+  }
 }


### PR DESCRIPTION
'homolog' as in "the Pax6 homologs eyeless and eyegone" introduces an Alias relation that can be used to capture and ground otherwise uncaptured entities. Tests are provided.

This closes #349 