### PR TITLE
Trigger inclusion in "arizona" output

### DIFF
--- a/assembly/build.sbt
+++ b/assembly/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies ++= {
   val akkaV = "2.4.3"
   Seq(
     "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-    "ai.lum" %% "common" % "0.0.3",
+    "ai.lum" %% "common" % "0.0.5",
     //"com.typesafe" % "config" % "1.2.1",
     //"commons-io" % "commons-io" % "2.4",
     // logging

--- a/assembly/src/main/scala/org/clulab/reach/assembly/export/AssemblyExporter.scala
+++ b/assembly/src/main/scala/org/clulab/reach/assembly/export/AssemblyExporter.scala
@@ -3,11 +3,12 @@ package org.clulab.reach.assembly.export
 import org.apache.commons.io.FileUtils
 import org.clulab.reach.assembly.AssemblyManager
 import org.clulab.reach.assembly.representations._
-import org.clulab.odin.Mention
+import org.clulab.odin.{EventMention, Mention}
 import org.clulab.reach.assembly._
 import org.clulab.reach.grounding.ReachKBConstants
 import org.clulab.reach.mentions._
 import com.typesafe.scalalogging.LazyLogging
+
 import scala.util.matching.Regex
 import java.io.File
 
@@ -110,6 +111,7 @@ case class Row(
       AssemblyExporter.EVENT_LABEL -> label,
       AssemblyExporter.PRECEDED_BY -> setToString(precededBy),
       AssemblyExporter.NEGATED -> negated.toString,
+      AssemblyExporter.TRIGGERS -> AssemblyExporter.getSortedTriggers(evidence.toSeq),
       AssemblyExporter.SEEN -> seen.toString,
       AssemblyExporter.EVIDENCE -> getTextualEvidence.mkString(AssemblyExporter.CONCAT),
       AssemblyExporter.SEEN_IN -> setToString(docIDs),
@@ -273,7 +275,7 @@ class AssemblyExporter(val manager: AssemblyManager) extends LazyLogging {
       ce.controller.map {
         case entity: SimpleEntity => createSimpleEntityText(entity)
         case complex: Complex => createInput(complex)
-        case c => s"${createOutput(c)}.${ce.polarity}"
+        case c => createOutput(c)
       }.mkString(", ")
 
     case _ => NONE
@@ -421,6 +423,7 @@ object AssemblyExporter {
   val CONTEXT_CELL_TYPE = "CONTEXT (CELL TYPE)"
   val CONTEXT_CELLULAR_COMPONENT = "CONTEXT (CELLULAR COMPONENT)"
   val CONTEXT_TISSUE_TYPE = "CONTEXT (TISSUE TYPE)"
+  val TRIGGERS = "TRIGGERS"
 
   val SEP = "\t"
   val CONCAT = " ++++ "
@@ -441,6 +444,8 @@ object AssemblyExporter {
     AssemblyExporter.CONTEXT_CELL_TYPE,
     AssemblyExporter.CONTEXT_CELLULAR_COMPONENT,
     AssemblyExporter.CONTEXT_TISSUE_TYPE,
+    // trigger
+    AssemblyExporter.TRIGGERS,
     // evidence
     AssemblyExporter.SEEN,
     AssemblyExporter.EVIDENCE,
@@ -488,6 +493,23 @@ object AssemblyExporter {
     //case comp: Complex => "entity"
     // filter these out later
     case entity => "entity"
+  }
+
+  def getTrigger(m: Mention): Option[String] = m match {
+    case em: EventMention => em.trigger.lemmas.map(_.mkString(" "))
+    case _ => None
+  }
+
+  def getSortedTriggers(mns: Seq[Mention]): String = {
+    val triggerCounts: Seq[(Int, String)] = for {
+      trig: String <- mns.flatMap(getTrigger)
+      cnt = mns.count(_ == trig)
+    } yield cnt -> trig
+
+    // sort by counts
+    triggerCounts.sortBy(_._1).reverse
+      .map(_._2) // get the triggers
+      .mkString(AssemblyExporter.CONCAT) // concatenate
   }
 }
 

--- a/assembly/src/main/scala/org/clulab/reach/assembly/export/AssemblyExporter.scala
+++ b/assembly/src/main/scala/org/clulab/reach/assembly/export/AssemblyExporter.scala
@@ -1,6 +1,6 @@
 package org.clulab.reach.assembly.export
 
-import org.apache.commons.io.FileUtils
+import ai.lum.common.FileUtils._
 import org.clulab.reach.assembly.AssemblyManager
 import org.clulab.reach.assembly.representations._
 import org.clulab.odin.{EventMention, Mention}
@@ -8,7 +8,6 @@ import org.clulab.reach.assembly._
 import org.clulab.reach.grounding.ReachKBConstants
 import org.clulab.reach.mentions._
 import com.typesafe.scalalogging.LazyLogging
-
 import scala.util.matching.Regex
 import java.io.File
 
@@ -303,7 +302,7 @@ class AssemblyExporter(val manager: AssemblyManager) extends LazyLogging {
 
     val results = rowsToString(cols, sep, rowFilter)
     // write the output to disk
-    FileUtils.writeStringToFile(f, results)
+    f.writeString(results, java.nio.charset.StandardCharsets.UTF_8)
   }
 
   def rowsToString(

--- a/assembly/src/main/scala/org/clulab/reach/assembly/export/AssemblyExporter.scala
+++ b/assembly/src/main/scala/org/clulab/reach/assembly/export/AssemblyExporter.scala
@@ -500,9 +500,12 @@ object AssemblyExporter {
   }
 
   def getSortedTriggers(mns: Seq[Mention]): String = {
+    // attempt to get the lemmatized trigger for each mention
+    val triggers = mns.flatMap(getTrigger)
     val triggerCounts: Seq[(Int, String)] = for {
-      trig: String <- mns.flatMap(getTrigger)
-      cnt = mns.count(_ == trig)
+      // count each distinct trigger
+      trig: String <- triggers.distinct
+      cnt = triggers.count(_ == trig)
     } yield cnt -> trig
 
     // sort by counts

--- a/assembly/src/main/scala/org/clulab/reach/assembly/relations/classifier/ClassifyAssemblyRelations.scala
+++ b/assembly/src/main/scala/org/clulab/reach/assembly/relations/classifier/ClassifyAssemblyRelations.scala
@@ -3,7 +3,8 @@ package org.clulab.reach.assembly.relations.classifier
 import org.clulab.reach.assembly.relations.corpus.CorpusReader._
 import org.clulab.reach.assembly.relations.corpus.{CorpusReader, EventPair}
 import org.clulab.learning._
-import org.apache.commons.io.{FileUtils, FilenameUtils}
+import ai.lum.common.FileUtils._
+import org.apache.commons.io.FilenameUtils
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.util.Random
 import com.typesafe.scalalogging.LazyLogging
@@ -137,7 +138,7 @@ object Evaluator {
          |$rows
        """.stripMargin
 
-    FileUtils.writeStringToFile(f, content)
+    f.writeString(content, java.nio.charset.StandardCharsets.UTF_8)
   }
 
 }

--- a/assembly/src/main/scala/org/clulab/reach/assembly/relations/corpus/Corpus.scala
+++ b/assembly/src/main/scala/org/clulab/reach/assembly/relations/corpus/Corpus.scala
@@ -11,6 +11,7 @@ import org.json4s.JsonDSL._
 import org.json4s._
 import scala.util.hashing.MurmurHash3._
 import com.typesafe.scalalogging.LazyLogging
+import ai.lum.common.FileUtils._
 import org.apache.commons.io.FileUtils
 import java.io.File
 
@@ -155,10 +156,11 @@ case class Corpus(instances: Seq[EventPair]) extends JSONSerialization {
     // for each doc, write doc + mentions to a json file
     for ((paperID, cms) <- dmLUT) {
       val of = new File(mentionDataDir, s"$paperID-mention-data.json")
-      FileUtils.write(of, cms.json(pretty))
+      of.writeString(cms.json(pretty), java.nio.charset.StandardCharsets.UTF_8)
     }
     // write event pair info to json file
-    FileUtils.write(new File(corpusDir, s"${Corpus.EVENT_PAIRS}.json"), this.json(pretty))
+    val f = new File(corpusDir, s"${Corpus.EVENT_PAIRS}.json")
+    f.writeString(this.json(pretty), java.nio.charset.StandardCharsets.UTF_8)
   }
 }
 

--- a/export/src/main/scala/org/clulab/reach/export/arizona/ArizonaOutputter.scala
+++ b/export/src/main/scala/org/clulab/reach/export/arizona/ArizonaOutputter.scala
@@ -1,0 +1,60 @@
+package org.clulab.reach.export.arizona
+
+import org.clulab.odin.Mention
+import org.clulab.reach.assembly.AssemblyManager
+import org.clulab.reach.assembly.export.{AssemblyExporter, ExportFilters, Row}
+import org.clulab.reach.assembly.sieves.{AssemblySieve, DeduplicationSieves}
+
+
+/**
+  * Outputter for Arizona's tabular format
+  */
+object ArizonaOutputter {
+
+  val columns = Seq(
+    AssemblyExporter.INPUT,
+    AssemblyExporter.OUTPUT,
+    AssemblyExporter.CONTROLLER,
+    AssemblyExporter.EVENT_ID,
+    AssemblyExporter.EVENT_LABEL,
+    AssemblyExporter.NEGATED,
+    AssemblyExporter.INDIRECT,
+    // context
+    AssemblyExporter.CONTEXT_SPECIES,
+    AssemblyExporter.CONTEXT_ORGAN,
+    AssemblyExporter.CONTEXT_CELL_LINE,
+    AssemblyExporter.CONTEXT_CELL_TYPE,
+    AssemblyExporter.CONTEXT_CELLULAR_COMPONENT,
+    AssemblyExporter.CONTEXT_TISSUE_TYPE,
+    // triggers
+    AssemblyExporter.TRIGGERS,
+    // evidence
+    AssemblyExporter.SEEN,
+    AssemblyExporter.EVIDENCE,
+    AssemblyExporter.SEEN_IN
+  )
+
+  def arizonaFilter(rows: Set[Row]): Set[Row] = rows.filter { r =>
+    // remove unseen
+    (r.seen > 0) &&
+      // keep only the events
+      ExportFilters.isEvent(r)
+  }
+
+  def tabularOutput(mentions: Seq[Mention]): String = {
+    val ae = createExporter(mentions)
+    ae.rowsToString(columns, AssemblyExporter.SEP, arizonaFilter)
+  }
+
+  def createExporter(mentions: Seq[Mention]): AssemblyExporter = {
+    // perform deduplication
+    val dedup = new DeduplicationSieves()
+    val orderedSieves =
+    // track relevant mentions
+      AssemblySieve(dedup.trackMentions)
+    val am: AssemblyManager = orderedSieves.apply(mentions)
+    val ae = new AssemblyExporter(am)
+
+    ae
+  }
+}

--- a/src/main/scala/org/clulab/reach/ReachCLI.scala
+++ b/src/main/scala/org/clulab/reach/ReachCLI.scala
@@ -203,6 +203,8 @@ class ReachCLI(
           AssemblyExporter.CONTEXT_CELL_TYPE,
           AssemblyExporter.CONTEXT_CELLULAR_COMPONENT,
           AssemblyExporter.CONTEXT_TISSUE_TYPE,
+          // triggers
+          AssemblyExporter.TRIGGERS,
           // evidence
           AssemblyExporter.SEEN,
           AssemblyExporter.EVIDENCE,

--- a/src/main/scala/org/clulab/reach/ReachCLI.scala
+++ b/src/main/scala/org/clulab/reach/ReachCLI.scala
@@ -72,7 +72,7 @@ class ReachCLI(
                |
             |==========
                |""".stripMargin
-          FileUtils.writeStringToFile(logFile, report, true)
+          logger.error(report)
           1
       }
       error
@@ -94,14 +94,12 @@ class ReachCLI(
     val startNS = System.nanoTime
     val startTime = ReachCLI.now
 
-    FileUtils.writeStringToFile(logFile, s"$startTime: Starting $paperId\n", true)
-
+    logger.info(s"$startTime: Starting $paperId\n")
     logger.debug(s"  ${nsToS(startNS, System.nanoTime)}s: $paperId: starting reading")
 
     // entry must be kept around for outputter
     val entry = PaperReader.getEntryFromPaper(file)
     val mentions = PaperReader.getMentionsFromEntry(entry)
-
 
     logger.debug(s"  ${nsToS(startNS, System.nanoTime)}s: $paperId: finished reading")
 
@@ -113,10 +111,8 @@ class ReachCLI(
     val endNS = System.nanoTime
 
     logger.debug(s"  ${nsToS(startNS, System.nanoTime)}s: $paperId: finished writing JSON to ${outputDir.getCanonicalPath}")
+    logger.info(s"$endTime: Finished $paperId successfully (${nsToS(startNS, endNS)} seconds)\n")
 
-    FileUtils.writeStringToFile(
-      logFile, s"$endTime: Finished $paperId successfully (${nsToS(startNS, endNS)} seconds)\n", true
-    )
   }
 
   /**
@@ -211,7 +207,7 @@ object ReachCLI extends App with LazyLogging {
   if (logFile.exists) {
     FileUtils.forceDelete(logFile)
   }
-  FileUtils.writeStringToFile(logFile, s"$now: ReachCLI (${if (withAssembly) "w/" else "w/o"} assembly) begins ...\n")
+  logger.info(s"$now: ReachCLI (${if (withAssembly) "w/" else "w/o"} assembly) begins ...\n")
 
   // if papersDir does not exist there is nothing to do
   if (!papersDir.exists) {

--- a/src/main/scala/org/clulab/reach/export/server/FileProcessorWebUI.scala
+++ b/src/main/scala/org/clulab/reach/export/server/FileProcessorWebUI.scala
@@ -7,20 +7,18 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.stream.scaladsl._
 import akka.stream.{ActorMaterializer, Materializer}
-import java.io.{File, FileOutputStream}
 import akka.event.{Logging, LoggingAdapter}
 import akka.util.ByteString
+import java.io.{File, FileOutputStream}
 import com.typesafe.config.{Config, ConfigValueFactory}
 import org.clulab.reach.assembly.server._
 import org.clulab.reach.mentions._
 import org.clulab.reach.mentions.serialization.json._
 import org.clulab.reach.PaperReader
-import org.clulab.reach.assembly.AssemblyManager
-import org.clulab.reach.assembly.export.{AssemblyExporter, ExportFilters, Row}
-import org.clulab.reach.assembly.sieves.{AssemblySieve, DeduplicationSieves}
+import org.clulab.reach.export.arizona.ArizonaOutputter
 import org.json4s.{DefaultFormats, native}
 import scala.concurrent.{ExecutionContextExecutor, Future}
-import scala.util.{Success, Failure}
+import scala.util.{Failure, Success}
 
 
 trait FileUpload {
@@ -123,45 +121,8 @@ object FileProcessorWebUI extends App with FileUpload {
     val cms = PaperReader.getMentionsFromPaper(tempFile).map(_.toCorefMention)
 
     outputType match {
-      case ARIZONA =>
-        // perform deduplication
-        val dedup = new DeduplicationSieves()
-        val orderedSieves =
-        // track relevant mentions
-          AssemblySieve(dedup.trackMentions)
-        val am: AssemblyManager = orderedSieves.apply(cms)
-        val ae = new AssemblyExporter(am)
-
-        val cols = Seq(
-          AssemblyExporter.INPUT,
-          AssemblyExporter.OUTPUT,
-          AssemblyExporter.CONTROLLER,
-          AssemblyExporter.EVENT_ID,
-          AssemblyExporter.EVENT_LABEL,
-          AssemblyExporter.NEGATED,
-          AssemblyExporter.INDIRECT,
-          // context
-          AssemblyExporter.CONTEXT_SPECIES,
-          AssemblyExporter.CONTEXT_ORGAN,
-          AssemblyExporter.CONTEXT_CELL_LINE,
-          AssemblyExporter.CONTEXT_CELL_TYPE,
-          AssemblyExporter.CONTEXT_CELLULAR_COMPONENT,
-          AssemblyExporter.CONTEXT_TISSUE_TYPE,
-          // evidence
-          AssemblyExporter.SEEN,
-          AssemblyExporter.EVIDENCE,
-          AssemblyExporter.SEEN_IN
-        )
-        def arizonaFilter(rows: Set[Row]): Set[Row] = rows.filter { r =>
-          // remove unseen
-          (r.seen > 0) &&
-            // keep only the events
-            ExportFilters.isEvent(r)
-        }
-        ae.rowsToString(cols, AssemblyExporter.SEP, arizonaFilter)
-
-      case JSON =>
-        cms.json(false)
+      case ARIZONA => ArizonaOutputter.tabularOutput(cms)
+      case JSON => cms.json(false)
     }
   }
 


### PR DESCRIPTION
These changes resolve #435.  The elements of the`Triggers` column are lemmatized and sorted by frequency.

An example of the changes to the output format can be found here: https://gist.github.com/myedibleenso/2da0a2f101e89712115e116c4a98a6d4#file-pmc16533949-arizona-output-tsv