### PR TITLE
Allow lists and lists and lists of sites

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
@@ -417,7 +417,7 @@
   label: ${ label }
   action: ${ actionFlow }
   pattern: |
-    (@cause:BioChemicalEntity)? (?<trigger> [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/ & !mention=ModificationTrigger]) [!tag=/^(V|JJ)/ & !word=by]{,2}? @theme:BioChemicalEntity []{1,10} @site:Site
+    (@cause:BioChemicalEntity)? (?<trigger> [lemma=/${ verbalTriggerLemma }/ & ${triggerPrefix} & tag=/^(V|JJ)/ & !mention=ModificationTrigger]) [!tag=/^(V|JJ)/ & !word=by]{,2}? @theme:BioChemicalEntity protein? at (@site:Site ("," | and | as well as){,2})* @site:Site
 
 
 # This is the only way to get this, due to horrible misparsing.

--- a/main/src/test/scala/org/clulab/reach/TestTemplaticSimpleEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestTemplaticSimpleEvents.scala
@@ -605,4 +605,11 @@ class TestTemplaticSimpleEvents extends FlatSpec with Matchers {
     val mentions = getBioMentions(sent43)
     hasEventWithArguments("Ubiquitination", Seq("MEK5D"), mentions) should be (true)
   }
+
+  val sent44 = "Activated Akt phosphorylates FoxO3a protein at Ser-318 and Ser-321 and Ser 253"
+  sent44 should "contain three controlled phosphorylations" in {
+    val mentions = getBioMentions(sent44)
+    mentions.filter(_ matches "Phosphorylation") should have size (3)
+    mentions.filter(_ matches "Positive_regulation") should have size (3)
+  }
 }


### PR DESCRIPTION
Phrases such as 
> Activated Akt phosphorylates FoxO3a protein at Ser-318/Ser-321 and Ser-253

are tokenized as
> Activated Akt phosphorylates FoxO3a protein at Ser-318 and Ser-321 and Ser 253

This previously led to our not capturing all three sites, since we were assuming lists of form `A, B(,)? and C`. Presumably, `Ser-318/Ser-321` means something different from `Ser-318 and Ser-321`, but until such time as our parsing practices change, we should capture these. A rule change and test are provided.

This closes #432 
