### PR TITLE
Antecedent selection more restricted by grounding

### DIFF
--- a/main/src/main/scala/org/clulab/coref/AntecedentSelector.scala
+++ b/main/src/main/scala/org/clulab/coref/AntecedentSelector.scala
@@ -21,7 +21,7 @@ class LinearSelector extends AntecedentSelector {
 
     while (i >= 0 && rightMost - i <= sentenceLimit && selected.length < numToSelect) {
       val oneChunk = candidates.filter(x => x.sentence == i)
-        .filter(x => !selected.exists(y => y.grounding == x.grounding)).sorted[Mention]
+        .filter(x => !selected.exists(y => y.sharesGroundingWith(x))).sorted[Mention]
       selected ++= oneChunk.take(math.min(oneChunk.length, numToSelect - selected.length))
       if (oneChunk.isEmpty) i -= 1
     }

--- a/main/src/main/scala/org/clulab/coref/CorefUtils.scala
+++ b/main/src/main/scala/org/clulab/coref/CorefUtils.scala
@@ -167,21 +167,20 @@ object CorefUtils {
     case impossible => 0
   }
 
+  /**
+    * Return all the text-bound mentions of this mention's arguments (recursively)
+    */
   def collapseArguments(mention: Mention): Set[Mention] = {
     if (mention.isInstanceOf[CorefTextBoundMention]) return Set(mention)
-    Set(mention) ++ mention.arguments.values.flatten.flatMap(m => collapseArguments(m)).toSet
+    mention.arguments.values.flatten.flatMap(m => collapseArguments(m)).toSet
   }
 
-  /**
-    * Given two [[Mention]]s, determine whether any event has both as (nested) arguments.
-    * @param a
-    * @param b
-    * @param evts
-    * @return
-    */
+  /** Return true if at least one event has both as (nested) arguments, given two [[Mention]]s */
   def coArguments(generic: Mention, nonGeneric: Mention, evts: Seq[Mention]): Boolean = {
     val argSets = evts.map(collapseArguments(_))
-    argSets.exists(args => args.contains(generic) &&
-      args.exists(_.toBioMention.grounding == nonGeneric.toBioMention.grounding))
+    argSets.exists(args =>
+      args.contains(generic) &&
+      args.exists(a => a.toBioMention.sharesGroundingWith(nonGeneric.toBioMention))
+    )
   }
 }

--- a/main/src/main/scala/org/clulab/reach/mentions/Grounding.scala
+++ b/main/src/main/scala/org/clulab/reach/mentions/Grounding.scala
@@ -63,4 +63,17 @@ trait Grounding {
   //   _candidates = None                      // final grounding done: remove candidates
   // }
 
+  /** Return true if this and other share at least one candidates */
+  def sharesGroundingWith(other: Grounding): Boolean = {
+    // necessary because normal equals includes .key, normally the text of the candidate
+    def candsToTuples(cands: Option[Seq[KBResolution]]): Set[(String, String, String)] = {
+      val comparisonInfo = cands.getOrElse(Nil).map{ kb =>
+        (kb.namespace, kb.id, kb.species)
+      }
+      comparisonInfo.toSet
+    }
+
+    val overlap = candsToTuples(_candidates) & candsToTuples(other.candidates())
+    overlap.nonEmpty
+  }
 }

--- a/main/src/test/scala/org/clulab/reach/TestCoreference.scala
+++ b/main/src/test/scala/org/clulab/reach/TestCoreference.scala
@@ -609,12 +609,20 @@ class TestCoreference extends FlatSpec with Matchers {
     posreg.head.arguments("controlled").head == posact.head should be (true)
   }
 
-  val sent56 = "Akta and HSP20 are common. It phosphorylates Akta."
-  sent56 should "match 'It' to 'HSP20' (not 'Akta')" in {
-    val mentions = getBioMentions(sent56)
+  val sent56a = "Akta and HSP20 are common. It phosphorylates Akta."
+  sent56a should "match 'It' to 'HSP20' (not 'Akta')" in {
+    val mentions = getBioMentions(sent56a)
     val it = mentions.find(_.text == "It")
     //it should not be empty
     it.get.antecedentOrElse(it.get).text should be ("HSP20")
+  }
+
+  val sent56b = "ASPP1 binds Mek. It then binds KIAA0771."
+  sent56b should "match 'It' to 'Mek' (not 'ASPP1')" in {
+    val mentions = getBioMentions(sent56b)
+    val it = mentions.find(_.text == "It")
+    //it should not be empty
+    it.get.antecedentOrElse(it.get).text should be ("Mek")
   }
 
   val sent57 = "It is possible that the effects of HSP20 on AKT might differ between normal cardiomyocytes or " +


### PR DESCRIPTION
Consider this fictitious example:
> ASPP1 binds Mek. It then binds KIAA0771.

We already restrict antecedent selection by grounding in the following way. If `KIAA077` and `ASPP1` have any candidate groundings in common, we count them as referring to the same real-world entity. Therefore, `ASPP1` cannot corefer with `It`, because we assume that it is ungrammatical for a generic (non-reflexive) expression to corefer with another entity that is an argument of the same event. That is, we require
> It<sub>1</sub> then binds KIAA0771<sub>2</sub>.

where the subscripts identify a real-world entity, rather than 
> *It<sub>1</sub> then binds KIAA0771<sub>1</sub>.

If this isn't clear, compare
> John<sub>1</sub> likes him<sub>2</sub>.
> *John<sub>1</sub> likes him<sub>1</sub>.

However, the way that we are checking for shared grammar is faulty. Candidates are only equal if their `key` value is equal, which is normally the name of the entity in text. Therefore, even though the knowledge base, id, and species of `ASPP1` and `KIAA0771` are the same, they are not counted as equivalent, and `It` is wrongly allowed to corefer with `ASPP1`.

This pull request fixes this by doing a more stringent check. _Any_ overlapping candidates on the basis of knowledge base, id, and species disqualifies coreference between a potential antecedent and a co-argument of the anaphor. A test is provided.