### PR TITLE
Hide embedded implementation of KB resolution from users.

### DIFF
--- a/main/src/main/scala/org/clulab/reach/grounding/KBResolution.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/KBResolution.scala
@@ -3,22 +3,30 @@ package org.clulab.reach.grounding
 /**
   * Class holding information about a specific resolution from the in-memory Knowledge Base.
   *   Written by: Tom Hicks. 10/25/2015.
-  *   Last Modified: Make class serializable.
+  *   Last Modified: Hide embedded implementation from users.
   */
 class KBResolution (
 
   /** KB entry containing relevant resolution information. */
-  val entry: KBEntry,
+  private val entry: KBEntry,
 
   /** Meta information about the KB from which this resolution was created. */
   val metaInfo: Option[KBMetaInfo] = None
 
 ) extends Serializable {
 
+  /** Alternate constructors which do not require access to embedded KBEntry. */
+  def this (text: String, key: String, namespace: String, id: String) =
+    this(new KBEntry(text, key, namespace, id))
+
+  def this (text: String, key: String, namespace: String, id: String, species: String) =
+    this(new KBEntry(text, key, namespace, id, species))
+
+
   // Facade functions for field access:
-  def namespace: String = entry.namespace
   def text: String = entry.text
   def key: String = entry.key
+  def namespace: String = entry.namespace
   def id: String = entry.id
   def species: String = entry.species
 

--- a/main/src/main/scala/org/clulab/reach/mentions/serialization/json/JSONSerializer.scala
+++ b/main/src/main/scala/org/clulab/reach/mentions/serialization/json/JSONSerializer.scala
@@ -4,7 +4,7 @@ import org.clulab.serialization.json.DocOps
 import org.clulab.serialization.json.JSONSerializer._
 import org.clulab.odin
 import org.clulab.odin._
-import org.clulab.reach.grounding.{KBEntry, KBResolution}
+import org.clulab.reach.grounding.{KBResolution}
 import org.clulab.reach.mentions._
 import org.clulab.struct.{DirectedGraph, Edge, Interval}
 import org.json4s.JsonDSL._
@@ -350,15 +350,14 @@ object JSONSerializer extends LazyLogging {
   private def toKBResolution(json: JValue): Option[KBResolution] = json \ "grounding" match {
     case JNothing => None
     case grounding =>
-      // build entry
-      val entry = new KBEntry(
+      // build KB resolution object
+      val kbr = new KBResolution(
         text = (grounding \ "text").extract[String],
         key = (grounding \ "key").extract[String],
         namespace = (grounding \ "namespace").extract[String],
         id = (grounding \ "id").extract[String],
         species = (grounding \ "species").extract[String]
       )
-      val kbr = new KBResolution(entry)
       Some(kbr)
   }
 

--- a/main/src/main/scala/org/clulab/reach/mentions/serialization/json/package.scala
+++ b/main/src/main/scala/org/clulab/reach/mentions/serialization/json/package.scala
@@ -251,12 +251,12 @@ package object json {
 
   implicit class KBResolutionOps(kbr: KBResolution) extends JSONSerialization {
     def jsonAST: JValue = {
-      // components needed to construct KBEntry (KBResolution.entry)
-      ("text" -> kbr.entry.text) ~
-      ("key" -> kbr.entry.key) ~
-      ("namespace" -> kbr.entry.namespace) ~
-      ("id" -> kbr.entry.id) ~
-      ("species" -> kbr.entry.species)
+      // components needed to construct KBResolution
+      ("text" -> kbr.text) ~
+      ("key" -> kbr.key) ~
+      ("namespace" -> kbr.namespace) ~
+      ("id" -> kbr.id) ~
+      ("species" -> kbr.species)
     }
   }
 


### PR DESCRIPTION
KBResolutions were meant to be read-only, opaque objects returned out of the grounding package. As such, it's bad practice to peek inside them and manipulate their internal implementation (e.g., KBEntry) since that couples external code to class internals and prevents me changing those internals. I changed the visibility to prevent this. The mention serializing package needed to write them, however, so I've added an alternate constructor which doesn't require access to the internal representations. I've updated any code I found which previously "peeked".