### PR TITLE
Issue459: Complex formation is direct

### DIFF
--- a/main/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
+++ b/main/src/main/scala/org/clulab/reach/darpa/DarpaActions.scala
@@ -215,7 +215,7 @@ class DarpaActions extends Actions with LazyLogging {
       // note that they could be called either "theme1" or "theme2"
       val themes = m.arguments.getOrElse("theme1", Nil) ++ m.arguments.getOrElse("theme2", Nil)
       val arguments = Map("theme" -> themes)
-      m.copy(arguments = arguments)
+      new BioEventMention(m.copy(arguments = arguments), isDirect = true)
   }
 
   def mkBinding(mentions: Seq[Mention], state: State): Seq[Mention] = mentions flatMap {
@@ -255,7 +255,7 @@ class DarpaActions extends Actions with LazyLogging {
       new BioEventMention(original.copy(labels = taxonomy.hypernymsFor("Ubiquitination"), arguments = arguments))
     } else {
       val arguments = Map("theme" -> Seq(theme1, theme2))
-      new BioEventMention(original.copy(arguments = arguments))
+      new BioEventMention(original.copy(arguments = arguments), isDirect = true)
     }
   }
 
@@ -315,7 +315,7 @@ class DarpaActions extends Actions with LazyLogging {
         theme <- themes
       } yield {
         val evArgs = m.arguments - "cause" - "theme" ++ Map("theme" -> Seq(theme))
-        val ev = new BioEventMention(m.copy(arguments = evArgs), direct = true)
+        val ev = new BioEventMention(m.copy(arguments = evArgs), isDirect = true)
         // modifications other than negations belong to the SimpleEvent
         ev.modifications = otherMods
         ev
@@ -435,7 +435,7 @@ object DarpaActions {
           // trigger labels should match event labels
           val newTrigger = ce.trigger.copy(labels = newLabels)
           // return new mention with flipped label
-          new BioEventMention(ce.copy(labels = newLabels, trigger = newTrigger))
+          new BioEventMention(ce.copy(labels = newLabels, trigger = newTrigger), ce.isDirect)
         // return mention unmodified
         case false => ce
       }

--- a/main/src/main/scala/org/clulab/reach/mentions/BioMention.scala
+++ b/main/src/main/scala/org/clulab/reach/mentions/BioMention.scala
@@ -44,8 +44,8 @@ class BioEventMention(
   def this(m: EventMention) =
     this(m.labels, m.trigger, m.arguments, m.paths, m.sentence, m.document, m.keep, m.foundBy)
 
-  def this(m: EventMention, direct: Boolean) =
-    this(m.labels, m.trigger, m.arguments, m.paths, m.sentence, m.document, m.keep, m.foundBy, direct)
+  def this(m: EventMention, isDirect: Boolean) =
+    this(m.labels, m.trigger, m.arguments, m.paths, m.sentence, m.document, m.keep, m.foundBy, isDirect = isDirect)
 }
 
 class BioRelationMention(

--- a/main/src/test/scala/org/clulab/reach/TestBindingEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestBindingEvents.scala
@@ -27,6 +27,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
     for (b <- bindings) {
       b.arguments.get("theme").get should have size (2) // each binding must have exactly two themes
       b.arguments.get("theme").get.exists(_.text == "Ras") should be (true) // Ras is a theme in all these
+      b.asInstanceOf[BioEventMention].isDirect should be (true)
     }
   }
 
@@ -41,6 +42,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
     for (b <- bindings) {
       b.arguments.get("theme").get should have size (2) // each binding must have exactly two themes
       b.arguments.get("theme").get.exists(_.text == "Ras") should be (true) // Ras is a theme
+      b.asInstanceOf[BioEventMention].isDirect should be (true)
     }
   }
 
@@ -80,6 +82,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
     for (b <- bs) {
       b.arguments.get("theme").get should have size (2) // each binding must have exactly two themes
       b.arguments.get("theme").get.exists(_.text == "Ras") should be (true) // Ras is a theme in all these
+      b.asInstanceOf[BioEventMention].isDirect should be (true)
     }
 
     mentions = getBioMentions(sent5b)
@@ -88,6 +91,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
     for (b <- bs) {
       b.arguments.get("theme").get should have size (2) // each binding must have exactly two themes
       b.arguments.get("theme").get.exists(_.text == "Ras") should be (true) // Ras is a theme in all these
+      b.asInstanceOf[BioEventMention].isDirect should be (true)
     }
   }
 


### PR DESCRIPTION
Per Ben Gyori in #459, complex formation should be assumed to be direct. Both the `mkBinding` and `mkNaryBinding` now create `BioEventMention`s with `isDirect = true`. Some existing tests have been altered to ensure that this remains the case. This closes #459 