### PR TITLE
Produce multiple output formats per input file

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ The most common usage of Reach is to parse a directory containing one or more pa
 In order to run the system on such a directory of papers, you must create a `.conf` file.  See `src/main/resources/application.conf` for an example configuration file.  The directory containing the files to be processed should be specified using the `papersDir` variable.
 
 ```scala
-sbt "runMain org.clulab.reach.ReachCLI /path/to/yourapplication.conf"
+sbt "runMain org.clulab.reach.RunReachCLI /path/to/yourapplication.conf"
 ```
 
 If the configuration file is omitted, Reach uses the default `.conf`. That is, the command:
 
 ```scala
-sbt "runMain org.clulab.reach.ReachCLI"
+sbt "runMain org.clulab.reach.RunReachCLI"
 ```
 
 will run the system using the `.conf` file under `src/main/resources/application.conf`.
@@ -125,7 +125,7 @@ Marco A. Valenzuela-Esc\'{a}rcega and Mihai Surdeanu},
 
 The sieve-based assembly system can be run over a directory of `.nxml` and/or `.csv` files:
  ```scala
- sbt "runMain org.clulab.reach.ReachCLI"
+ sbt "runMain org.clulab.reach.RunReachCLI"
  ```
 
 In `src/main/resources/application.conf`, you will need to...

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The sieve-based assembly system can be run over a directory of `.nxml` and/or `.
 
 In `src/main/resources/application.conf`, you will need to...
 
-1. set `outputType` to "assembly-tsv"
+1. set `outputTypes` to `["assembly-tsv"]`
 2. set your input directory of papers via `papersDir`
 3. set your output directory via `outDir`
 

--- a/main/src/main/resources/application.conf
+++ b/main/src/main/resources/application.conf
@@ -14,9 +14,12 @@ papersDir = ${rootDir}/papers
 # if this directory doesn't exist it will be created
 outDir = ${rootDir}/output
 
-# the output format for mentions: "fries" (multiple json files per paper) or
-# "arizona" (a column-based file per paper), or "text" (non-JSON textual format).
-outputType = "fries"
+# the output formats for mentions:
+# "fries" (multiple json files per paper)
+# "text" (non-JSON textual format)
+# "arizona" (a column-based file per paper)
+# "cmu" (a column-based file per paper)
+outputTypes = ["fries"]
 
 # whether or not assembly should be run
 withAssembly = false

--- a/src/test/scala/org/clulab/reach/export/TestReachCLI.scala
+++ b/src/test/scala/org/clulab/reach/export/TestReachCLI.scala
@@ -42,7 +42,7 @@ class TestReachCLI extends FlatSpec with Matchers {
   // Tests usage of a single output type
   it should "output FRIES correctly on NXML papers with Assembly" in {
     println(s"Will output FRIES with Assembly output in directory ${friesWithAssemblyDir.getAbsolutePath}")
-    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = friesWithAssemblyDir, outputFormat = "fries")
+    val cli = ReachCLI(papersDir = nxmlDir, outputDir = friesWithAssemblyDir, outputFormat = "fries")
     val errorCount = cli.processPapers(threadLimit = nThreads, withAssembly = true)
     errorCount should be (0)
   }

--- a/src/test/scala/org/clulab/reach/export/TestReachCLI.scala
+++ b/src/test/scala/org/clulab/reach/export/TestReachCLI.scala
@@ -17,9 +17,11 @@ class TestReachCLI extends FlatSpec with Matchers {
   val nxmlDir = readResourceAsFile("inputs/test-nxml")
   val nThreads = Some(2)
 
-  // FRIES no assembly
-  lazy val tmpFriesDir = Files.mkTmpDir("tmpFries", deleteOnExit = true)
-  lazy val friesDir = new File(tmpFriesDir)
+  // Text + FRIES no assembly
+  lazy val comboDir: File = {
+    val tmpComboDir = Files.mkTmpDir("tmpCombo", deleteOnExit = true)
+    new File(tmpComboDir)
+  }
 
   // FRIES + assembly
   lazy val tmpFriesWithAssemblyDir = Files.mkTmpDir("tmpWithAssemblyFries", deleteOnExit = true)
@@ -29,25 +31,15 @@ class TestReachCLI extends FlatSpec with Matchers {
   lazy val tmpICDir = Files.mkTmpDir("tmpIC", deleteOnExit = true)
   lazy val icDir = new File(tmpICDir)
 
-  // Text
-  lazy val tmpTxtDir = Files.mkTmpDir("tmpTxt", deleteOnExit = true)
-  lazy val txtDir = new File(tmpTxtDir)
-
-
-  "ReachCLI" should "output TEXT correctly on NXML papers" in {
-    println(s"Will output TEXT output in directory ${txtDir.getAbsolutePath}")
-    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = txtDir, outputFormat = "text")
+  // Tests usage of multiple output types
+  "ReachCLI" should "output TEXT and FRIES correctly on NXML papers without assembly" in {
+    println(s"Will output TEXT and FRIES output in directory ${comboDir.getAbsolutePath}")
+    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = comboDir, outputFormats = Seq("text", "fries"))
     val errorCount = cli.processPapers(threadLimit = nThreads, withAssembly = false)
     errorCount should be (0)
   }
 
-  it should "output FRIES correctly on NXML papers without assembly" in {
-    println(s"Will output FRIES output in directory ${friesDir.getAbsolutePath}")
-    val cli = new ReachCLI(papersDir = nxmlDir, outputDir = friesDir, outputFormat = "fries")
-    val errorCount = cli.processPapers(threadLimit = nThreads, withAssembly = false)
-    errorCount should be (0)
-  }
-
+  // Tests usage of a single output type
   it should "output FRIES correctly on NXML papers with Assembly" in {
     println(s"Will output FRIES with Assembly output in directory ${friesWithAssemblyDir.getAbsolutePath}")
     val cli = new ReachCLI(papersDir = nxmlDir, outputDir = friesWithAssemblyDir, outputFormat = "fries")


### PR DESCRIPTION
This closes #475.

Note that `sbt "runMain org.clulab.reach.ReachCLI"` is now `sbt "runMain org.clulab.reach.RunReachCLI"` 