### PR TITLE
Fix library clash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 #Changes
 =======
 
++ **1.3.3** - Fix lib clash: allow ai.lum.common to dicate typesafe.config version.
++ **1.3.3** - Use consistent SBT version across projects. Update ai.lum.nxmlreader to special release 0.0.9.
 + **1.3.3** - Find shortest path between heads in actions. Add/allow outputter for JSON serialization format.
 + **1.3.3** - Fix trigger affecting countSemanticNegatives. Add restart capability and more logging stats to ReachCLI.
 + **1.3.3** - Added a new tabular format for the DyCE CMU model. Update Phase3 use cases. Add/use root path in config.

--- a/assembly/build.sbt
+++ b/assembly/build.sbt
@@ -7,7 +7,6 @@ libraryDependencies ++= {
   Seq(
     "org.scalatest" %% "scalatest" % "2.2.4" % "test",
     "ai.lum" %% "common" % "0.0.7",
-    //"com.typesafe" % "config" % "1.2.1",
     //"commons-io" % "commons-io" % "2.4",
     // logging
     //"ch.qos.logback" %  "logback-classic" % "1.1.7",

--- a/main/build.sbt
+++ b/main/build.sbt
@@ -2,18 +2,17 @@ name := "reach-main"
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.19",
-  "org.clulab" %% "processors-main" % "6.0.1",
-  "org.clulab" %% "processors-corenlp" % "6.0.1",
-  "org.clulab" %% "processors-models" % "6.0.1",
-  "com.typesafe" % "config" % "1.2.1",
+  "org.clulab" % "bioresources" % "1.1.22",
+  "org.clulab" %% "processors-main" % "6.0.4",
+  "org.clulab" %% "processors-corenlp" % "6.0.4",
+  "org.clulab" %% "processors-models" % "6.0.4",
   "commons-io" % "commons-io" % "2.4",
   "org.biopax.paxtools" % "paxtools-core" % "4.3.1",
   "jline" % "jline" % "2.12.1",
   "org.apache.lucene" % "lucene-core" % "5.3.1",
   "org.apache.lucene" % "lucene-analyzers-common" % "5.3.1",
   "org.apache.lucene" % "lucene-queryparser" % "5.3.1",
-  "ai.lum" %% "nxmlreader" % "0.0.7",
+  "ai.lum" %% "nxmlreader" % "0.0.9",
   // logging
   "ch.qos.logback" %  "logback-classic" % "1.1.7",
   "com.typesafe.scala-logging" %%  "scala-logging" % "3.4.0"


### PR DESCRIPTION
allow ai.lum.common to dicate typesafe.config version. Use Processors 6.0.4.
Use consistent SBT version across projects. Update ai.lum.nxmlreader to special release 0.0.9.

This fixes issue #487