### PR TITLE
Recurse down input dir for nxml and csv/tsv files

### DIFF
--- a/src/main/scala/org/clulab/reach/ReachCLI.scala
+++ b/src/main/scala/org/clulab/reach/ReachCLI.scala
@@ -70,7 +70,7 @@ class ReachCLI (
     logger.info("Initializing Reach ...")
 
     val _ = PaperReader.rs.extractFrom("Blah", "", "")
-    val files = papersDir.listFiles.par
+    val files = papersDir.listFilesByRegex(pattern = """.*\.(nxml|csv|tsv)$""", caseSensitive = false, recursive = true).toVector.par
 
     // limit parallelization
     if (threadLimit.nonEmpty) {


### PR DESCRIPTION
When we perform our OA runs, dumping all of our input files into a single directory isn't really an option.  

With this change we can instead recurse down a directory and find any files matching our supported input types.  Now you can simply point `reach` at an `ftp` clone of OA and run things more or less as-is.