### PR TITLE
binding11_token over-generates binding events

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/events/bind_events.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/events/bind_events.yml
@@ -139,18 +139,20 @@
       trigger = /cooperation|affinity|association|interaction/
       theme1:BioChemicalEntity+ = </prep_(of|to)/{,2} acomp? prep_between conj_and?
 
-- name: binding11_token
-  label: Binding
-  action: mkBinding
-  priority: ${ priority }
-  type: token
-  pattern: |
-      (?<trigger> /cooperation|affinity|association|interaction/ )
-      "between"
-      [tag="DT"]?
-      @theme1:BioChemicalEntity
-      "and"
-      @theme2:BioChemicalEntity
+## Commented out because of event overgeneration in cases like
+## "We analyze the associations between KRAS and BRAF mutations and patients' clinicopathological characteristics."
+#- name: binding11_token
+#  label: Binding
+#  action: mkBinding
+#  priority: ${ priority }
+#  type: token
+#  pattern: |
+#      (?<trigger> /cooperation|affinity|association|interaction/)
+#      "between"
+#      [tag="DT"]?
+#      @theme1:BioChemicalEntity
+#      "and"
+#      @theme2:BioChemicalEntity
 
 - name: binding12
   label: Binding

--- a/main/src/test/scala/org/clulab/reach/TestBindingEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestBindingEvents.scala
@@ -467,4 +467,10 @@ class TestBindingEvents extends FlatSpec with Matchers {
     mentions filter (_ matches "Binding") shouldBe empty
   }
 
+  val sent46 = "We analyze the associations between KRAS and BRAF mutations and patients ' clinicopathological characteristics."
+  sent46 should "not contain binding events" in {
+    val mentions = getBioMentions(sent46)
+    mentions filter (_ matches "Binding") shouldBe empty
+  }
+
 }


### PR DESCRIPTION
In a case like "We analyze the associations between KRAS and BRAF mutations and patients ' clinicopathological characteristics." there should be no binding, because the sentence is referring to the association between KRAS mutations and patient characteristics, not between KRAS and BRAF.

`binding11_token` produced a binding for this kind of sentence. Because it is a token rule, it was difficult to provide the syntactic negative lookahead that would allow this rule not to be triggered in this case. Commenting the rule out caused no test failures, and no obvious examples presented themselves that would only be covered by this rule. A test is provided.