### PR TITLE
Json fix

### DIFF
--- a/main/build.sbt
+++ b/main/build.sbt
@@ -1,19 +1,25 @@
 name := "reach-main"
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.clulab" % "bioresources" % "1.1.22",
-  "org.clulab" %% "processors-main" % "6.0.4",
-  "org.clulab" %% "processors-corenlp" % "6.0.4",
-  "org.clulab" %% "processors-models" % "6.0.4",
-  "commons-io" % "commons-io" % "2.4",
-  "org.biopax.paxtools" % "paxtools-core" % "4.3.1",
-  "jline" % "jline" % "2.12.1",
-  "org.apache.lucene" % "lucene-core" % "5.3.1",
-  "org.apache.lucene" % "lucene-analyzers-common" % "5.3.1",
-  "org.apache.lucene" % "lucene-queryparser" % "5.3.1",
-  "ai.lum" %% "nxmlreader" % "0.0.9",
-  // logging
-  "ch.qos.logback" %  "logback-classic" % "1.1.7",
-  "com.typesafe.scala-logging" %%  "scala-logging" % "3.4.0"
-)
+libraryDependencies ++= {
+
+  val procVer = "6.0.5"
+
+  Seq(
+    "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+    "org.clulab" % "bioresources" % "1.1.22",
+    "org.clulab" %% "processors-main" % procVer,
+    "org.clulab" %% "processors-corenlp" % procVer,
+    "org.clulab" %% "processors-models" % procVer,
+    "commons-io" % "commons-io" % "2.4",
+    "org.biopax.paxtools" % "paxtools-core" % "4.3.1",
+    "jline" % "jline" % "2.12.1",
+    "org.apache.lucene" % "lucene-core" % "5.3.1",
+    "org.apache.lucene" % "lucene-analyzers-common" % "5.3.1",
+    "org.apache.lucene" % "lucene-queryparser" % "5.3.1",
+    "ai.lum" %% "nxmlreader" % "0.0.9",
+    // logging
+    "ch.qos.logback" %  "logback-classic" % "1.1.7",
+    "com.typesafe.scala-logging" %%  "scala-logging" % "3.4.0"
+  )
+
+}

--- a/main/src/test/scala/org/clulab/reach/mentions/serialization/TestJSONSerializer.scala
+++ b/main/src/test/scala/org/clulab/reach/mentions/serialization/TestJSONSerializer.scala
@@ -94,7 +94,7 @@ class TestJSONSerializer extends FlatSpec with Matchers {
     val mekmns = corefmentions.filter(_.text == "MEK")
     mekmns should have size 1
     val mek = mekmns.head
-    (mek.jsonAST \ "modifications" \ "modification-type").extract[String] should equal ("PTM")
+    (mek.jsonAST \ "modifications" \\ "modification-type").extract[String] should equal ("PTM")
   }
 
   it should "still contain a PTM after serialization/deserialization" in {
@@ -102,7 +102,7 @@ class TestJSONSerializer extends FlatSpec with Matchers {
     val mekmns = deserializedCorefMentions.filter(_.text == "MEK")
     mekmns should have size 1
     val mek = mekmns.head
-    (mek.jsonAST \ "modifications" \ "modification-type").extract[String] should equal ("PTM")
+    (mek.jsonAST \ "modifications" \\ "modification-type").extract[String] should equal ("PTM")
   }
 
   val text2 = "MEK activates K-RAS."


### PR DESCRIPTION
# Changes
1. Upgrade to `processors` v6.0.5
2. Tweaks to `json` serialization/marshalling tests that became necessary after the recent `json4s` version bump in `processors`