### PR TITLE
Remove catalysis from activation rule trigger

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/events/pos-reg_template.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/events/pos-reg_template.yml
@@ -15,7 +15,7 @@
   label: ${ label }
   action: ${ actionFlow }
   pattern: |
-    trigger = [word=/(?i)^(${ triggers })/ & tag=/^V|RB/] [lemma=/^(${ auxtriggers })/ & tag=/^V/]?
+    trigger = [word=/(?i)^(${ triggers })/ & !word=/^cataly/ & tag=/^V|RB/] [lemma=/^(${ auxtriggers })/ & tag=/^V/]?
     controlled:${ controlledType } = prepc_by? (dobj | xcomp | ccomp) /conj|dep|dobj|cc|nn|prep_of|prep_in$|amod/{,2}
     controller:${ controllerType } = <xcomp? (nsubj | nsubjpass | agent | <vmod) /appos|nn|conj_|cc|prep_of|prep_in$/{,2}
 


### PR DESCRIPTION
This PR, I hope, fixes issue #516 by removing catalysis from the trigger, which currently takes all posTriggers from events_master.yml.