### PR TITLE
Issue 334: Exclude special case for X phosphorylation

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/events/simple-event_template.yml
@@ -316,7 +316,7 @@
   label: ${ label }
   action: ${ actionFlow }
   pattern: |
-    @theme:BioChemicalEntity (?<trigger> [lemma=/${ nominalTriggerLemma }/ & ${triggerPrefix}]) (/^(on|at)$/ @site:Site)? (?! [lemma=of])
+    @theme:BioChemicalEntity (?<trigger> [lemma=/${ nominalTriggerLemma }/ & ${triggerPrefix}]) (/^(on|at)$/ @site:Site)? (?! [lemma=of|lemma=site])
 
 
 # relies on EventSite modifications

--- a/main/src/test/scala/org/clulab/reach/TestModifications.scala
+++ b/main/src/test/scala/org/clulab/reach/TestModifications.scala
@@ -1163,4 +1163,23 @@ class TestModifications extends FlatSpec with Matchers {
     akt should have size (1)
     akt.head.countMutations should be (1)
   }
+
+  val modSiteExcludeTest1 = "The PTEN protein contains a CK2 phosphorylation site."
+  modSiteExcludeTest1 should "not contain any phosphorylation of CK2" in {
+    val mentions = getBioMentions(modSiteExcludeTest1)
+    hasEventWithArguments("Phosphorylation", List("CK2"), mentions) should be (false)
+  }
+
+  val modSiteExcludeTest2 = "Mutations of the AKT1 phosphorylation site of RUNX3 decreased RUNX3 sumoylation."
+  modSiteExcludeTest2 should "not contain any phosphorylation of AKT1" in {
+    val mentions = getBioMentions(modSiteExcludeTest2)
+    hasEventWithArguments("Phosphorylation", List("AKT1"), mentions) should be (false)
+  }
+
+  val modSiteExcludeTest3 = "We studied the MEK phosphorlyation site of ERK."
+  modSiteExcludeTest3 should "not contain any phosphorylation of MEK" in {
+    val mentions = getBioMentions(modSiteExcludeTest3)
+    hasEventWithArguments("Phosphorylation", List("MEK"), mentions) should be (false)
+  }
+
 }


### PR DESCRIPTION
This PR attempts to fix issue #334, so we don't extract phosphorylation of CK2/AKT1/MEK from the following sentences:
- The PTEN protein contains a CK2 phosphorylation site.
- Mutations of the AKT1 phosphorylation site of RUNX3 decreased RUNX3 sumoylation.
- We studied the MEK phosphorlyation site of ERK.