### PR TITLE
Issue325: exclude X sensitivity/resistance from activation

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/events/pos-reg_template.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/events/pos-reg_template.yml
@@ -16,7 +16,8 @@
   action: ${ actionFlow }
   pattern: |
     trigger = [word=/(?i)^(${ triggers })/ & !word=/^cataly/ & tag=/^V|RB/] [lemma=/^(${ auxtriggers })/ & tag=/^V/]?
-    controlled:${ controlledType } = prepc_by? (dobj | xcomp | ccomp) /conj|dep|dobj|cc|nn|prep_of|prep_in$|amod/{,2}
+    controlled:${ controlledType } = prepc_by? (/dobj|xcomp|ccomp/ [!lemma=/resistance|sensitivity/])
+      (/conj|dep|dobj|cc|nn|prep_of|prep_in$|amod/){,2}
     controller:${ controllerType } = <xcomp? (nsubj | nsubjpass | agent | <vmod) /appos|nn|conj_|cc|prep_of|prep_in$/{,2}
 
 

--- a/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
@@ -305,4 +305,16 @@ class TestActivationEvents extends FlatSpec with Matchers {
     val mentions = getBioMentions(sent43)
     mentions.filter(_ matches "Positive_activation") should have size (0)
   }
+
+  val sent44 = "AR function increases docetaxel sensitivity."
+  sent44 should "contain no activations" in {
+    val mentions = getBioMentions(sent44)
+    mentions.filter(_ matches "Positive_activation") should have size (0)
+  }
+
+  val sent45 = "The consequences of increased AR function might then increase docetaxel resistance via increasing p21 expression."
+  sent45 should "contain no activations" in {
+    val mentions = getBioMentions(sent45)
+    mentions.filter(_ matches "Positive_activation") should have size (0)
+  }
 }

--- a/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
@@ -299,4 +299,10 @@ class TestActivationEvents extends FlatSpec with Matchers {
     mentions.filter(_ matches "Transcription") should have size (1)
     mentions.filter(_ matches "Positive_activation") should have size (1)
   }
+
+  val sent43 = "GAPDH catalyzes the conversion of glyceraldehyde-3-phosphate to 1,3-bisphosphoglycerate."
+  sent43 should "contain no activations" in {
+    val mentions = getBioMentions(sent43)
+    mentions.filter(_ matches "Positive_activation") should have size (0)
+  }
 }


### PR DESCRIPTION
This is one step towards solving #325, it excludes cases where the statement is about X sensitivity/resistance, not about X itself. Here X will typically be a drug.