### PR TITLE
Issue 325: Remove prep_in from rule inhibition of

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/events/neg-reg_template.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/events/neg-reg_template.yml
@@ -108,7 +108,7 @@
   action: ${ actionFlow }
   pattern: |
     trigger = [word=/(?i)^(${ triggers })/ & tag=/^N/ & !outgoing=prep_by] [lemma=/^(${ auxtriggers })/ & tag=/^N/]?
-    controlled:${ controlledType } = /prep_of|prep_in$/ /conj_|cc|nn|amod/{,2}
+    controlled:${ controlledType } = /prep_of/ /conj_|cc|nn|amod/{,2}
     controller:${ controllerType } = /cc|nn|amod/{1,2} | conj_or prep_by nn?
 
 - name: Negative_${ ruleType }_syntax_5_noun

--- a/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
@@ -316,6 +316,7 @@ class TestActivationEvents extends FlatSpec with Matchers {
   sent45 should "contain no activations" in {
     val mentions = getBioMentions(sent45)
     mentions.filter(_ matches "Positive_activation") should have size (0)
+  }
 
   val sent46 = "BRAF inhibition in NF1 deficient cells"
   sent46 should "contain no activations" in {

--- a/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
@@ -316,5 +316,10 @@ class TestActivationEvents extends FlatSpec with Matchers {
   sent45 should "contain no activations" in {
     val mentions = getBioMentions(sent45)
     mentions.filter(_ matches "Positive_activation") should have size (0)
+
+  val sent46 = "BRAF inhibition in NF1 deficient cells"
+  sent46 should "contain no activations" in {
+    val mentions = getBioMentions(sent46)
+    mentions.filter(_ matches "Negative_activation") should have size (0)
   }
 }


### PR DESCRIPTION
In Negative_${ ruleType }_syntax_3_noun, prep_in is one of the possible edges from the trigger but inhibition "in", I don't think makes sense. This fixes part of issue #325 and doesn't break any tests (I hope). Is there any known example where prep_in is needed?