### PR TITLE
Update to use Processors 6.1.2 and Bioresources 1.1.24

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,3 @@
--J-Xmx5G
+-J-Xmx6G
 -J-XX:+CMSClassUnloadingEnabled
 -J-XX:+UseConcMarkSweepGC

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 #Changes
 =======
 
++ **1.3.5** - Update to use Processors 6.1.2 and Bioresources 1.1.24, which includes the Harvard BioEntities updates of 8/22/2017.
 + **1.3.4** - Refactor internal Akka servers, resources, and file locations. Add configurable mainClass for FAT JAR.
 + **1.3.4** - Added Akka-based processors client and updated processor-client classes. Updated to use Processors 6.0.7.
 + **1.3.3** - Updated to use Bioresource 1.1.23 and Processors 6.0.6.

--- a/main/build.sbt
+++ b/main/build.sbt
@@ -3,7 +3,7 @@ name := "reach-main"
 libraryDependencies ++= {
   val akkaV = "2.5.3"
   val luceVer = "5.3.1"
-  val procVer = "6.1.1"
+  val procVer = "6.1.2-SNAPSHOT"
 
   Seq(
     "ai.lum"              %%  "nxmlreader"  % "0.0.9",

--- a/main/build.sbt
+++ b/main/build.sbt
@@ -3,7 +3,7 @@ name := "reach-main"
 libraryDependencies ++= {
   val akkaV = "2.5.3"
   val luceVer = "5.3.1"
-  val procVer = "6.1.2-SNAPSHOT"
+  val procVer = "6.1.2"
 
   Seq(
     "ai.lum"              %%  "nxmlreader"  % "0.0.9",
@@ -14,7 +14,7 @@ libraryDependencies ++= {
     "org.apache.lucene"    %  "lucene-analyzers-common"  % luceVer,
     "org.apache.lucene"    %  "lucene-queryparser"       % luceVer,
     "org.biopax.paxtools"  %  "paxtools-core"            % "4.3.1",
-    "org.clulab"           %  "bioresources"             % "1.1.23",
+    "org.clulab"           %  "bioresources"             % "1.1.24",
     "org.clulab"          %%  "processors-main"          % procVer,
     "org.clulab"          %%  "processors-corenlp"       % procVer,
     "org.clulab"          %%  "processors-models"        % procVer,

--- a/main/src/test/scala/org/clulab/reach/TestComplexResolutions.scala
+++ b/main/src/test/scala/org/clulab/reach/TestComplexResolutions.scala
@@ -14,7 +14,7 @@ import org.clulab.reach.grounding.ReachKBUtils._
 /**
   * Unit tests to ensure protein complex resolutions are working for KB grounding.
   *   Written by: Tom Hicks. 11/17/2016.
-  *   Last Modified: Update for changed arguments of KB key transforms group.
+  *   Last Modified: Update for updated BE families and complexes of 8/22/2017.
   */
 class TestComplexResolutions extends FlatSpec with Matchers {
 
@@ -72,14 +72,6 @@ class TestComplexResolutions extends FlatSpec with Matchers {
   }
 
   "BE-PC resolve" should "fail for protein complex Bioentities" in {
-    // in NER Override only:
-    (bePC.resolve("Activin A")) should be (empty)
-    (bePC.resolve("activin a")) should be (empty)
-    (bePC.resolve("Activin AB")) should be (empty)
-    (bePC.resolve("AMPK alpha2beta2gamma2")) should be (empty)
-    (bePC.resolve("AMPK a2b2g2")) should be (empty)
-    (bePC.resolve("alpha2beta2gamma2")) should be (empty)
-
     (bePC.resolve("AMPK-alpha1")) should be (empty) // GGP
     (bePC.resolve("FOXP3")) should be (empty)       // GGP
   }

--- a/main/src/test/scala/org/clulab/reach/TestOverrides.scala
+++ b/main/src/test/scala/org/clulab/reach/TestOverrides.scala
@@ -9,7 +9,7 @@ import TestUtils._
 /**
   * Test that our override KB works properly for NER and grounding.
   *   Written by: Tom Hicks. 7/8/2016.
-  *   Last Modified: Minor comment update on AA short test.
+  *   Last Modified: Update for updated BE families and complexes of 8/22/2017.
   */
 class TestOverrides extends FlatSpec with Matchers {
 
@@ -117,14 +117,14 @@ class TestOverrides extends FlatSpec with Matchers {
   // A few sample previous Override Family entries, replaced by BE family KB.
   val be5f = """ACAD, ACSL, ACTN, ADCY, ADH,
                 ADRA, ADRA2, ADRB, ADRBK, ALDH,
-                ALDO, APOA, ARRB, ATP2A, ATP5G,
+                ALDO, APOA, ARRB, ATP5G,
                 BIRC, CAPN, Carboxylesterase, CD16, CD64,
                 MAPK, MEK, MEK1/2, MEK 1/2, ERK,
                 CSNK1, CSNK2, CTNNA, CUL, Cyclophilin are sample families."""
   val be5f_ids = Seq(
     "ACAD", "ACSL", "ACTN", "ADCY", "ADH",
     "ADRA", "ADRA2", "ADRB", "ADRBK", "ALDH",
-    "ALDO", "APOA", "ARRB", "ATP2A", "ATP5G",
+    "ALDO", "APOA", "ARRB", "ATP5G",
     "BIRC", "CAPN", "Carboxylesterase", "CD16", "CD64",
     "ERK", "MEK", "MEK", "MEK", "ERK",
     "CSNK1", "CSNK2", "CTNNA", "CUL", "Cyclophilin"


### PR DESCRIPTION
These updates includes the Harvard BioEntities updates of 8/22/2017.