### PR TITLE
Add API server route to process args in body of POST

### DIFF
--- a/export/src/main/resources/org/clulab/reach/export/server/static/api.html
+++ b/export/src/main/resources/org/clulab/reach/export/server/static/api.html
@@ -110,7 +110,7 @@
                 <div>
                   <label class="kvKey">Options:</label>
                   <span class="kvValue">
-                    The optional form argument <code>output</code> selects an output format:
+                    The optional <b>form</b> argument <code>output</code> selects an output format:
                     arizona, cmu, csv, indexcard, serial-json, or fries (the default).
                   </span>
                 </div>
@@ -133,6 +133,60 @@
                     </div>
                   </span>
                   </div>
+                </div>
+              </td>
+            </tr>
+            <tr class="greyed">
+              <td class="recode">/api/textBody</td>
+              <td class="recode">POST</td>
+              <td></td>
+              <td>
+                Run Reach on the text string contained in the POST body and return the results.
+              </td>
+            </tr>
+            <tr class="">
+              <td colspan="4">
+                <div>
+                  <label class="kvKey">Notes:</label>
+                  <span class="kvValue">
+                    The <b>body</b> argument <code>text</code> must be URL-encoded.
+                    By default, results are returned in FRIES JSON format.
+                  </span>
+                </div>
+                <div>
+                  <label class="kvKey">Options:</label>
+                  <span class="kvValue">
+                    The optional <b>body</b> argument <code>output</code> selects an output format:
+                    arizona, cmu, csv, indexcard, serial-json, or fries (the default).
+                  </span>
+                </div>
+                <div>
+                  <label class="kvKey">Examples:</label>
+                  <span class="kvValue">&nbsp;</span>
+                  <label class="kvKey">&nbsp;</label>
+                  <span class="kvValue">
+                    <div class="example">
+                      curl -XPOST -d 'text=Akt1+phosphorylates+mek1' 'http://localhost:8080/api/textBody'
+                    </div>
+                    <div class="example">
+                      curl -XPOST -d 'text=Akt1%20phosphorylates%20mek1' 'http://localhost:8080/api/textBody'
+                    </div>
+                    <div class="example">
+                      curl -XPOST -d 'text=akt1+phosphorylates+mek1&output=csv' 'http://localhost:8080/api/textBody'
+                    </div>
+                    <div class="example">
+                      curl -XPOST -d 'text=akt1+phosphorylates+mek1' -d 'output=csv' 'http://localhost:8080/api/textBody'
+                    </div>
+                    <div class="example">
+                      curl -XPOST -d 'output=cmu' --data 'text=The+inhibition+of+AICAR+suppresses+the+phosphorylation+of+TBC1D1.' 'http://localhost:8080/api/textBody'
+                    </div>
+                    <div class="example">
+                      curl -XPOST -d 'output=cmu' --data-urlencode 'text=The inhibition of AICAR suppresses the phosphorylation of TBC1D1.' 'http://localhost:8080/api/textBody'
+                    </div>
+                    <div class="example">
+                      curl -XPOST --data-urlencode 'text=TopBP1 promotes the phosphorylation of cyclin-D1 by ATR.' 'http://localhost:8080/api/textBody'
+                    </div>
+                  </span>
                 </div>
               </td>
             </tr>

--- a/export/src/main/scala/org/clulab/reach/export/server/ApiServer.scala
+++ b/export/src/main/scala/org/clulab/reach/export/server/ApiServer.scala
@@ -27,7 +27,7 @@ import org.clulab.reach.export.apis.ApiRuler._
 /**
   * Server to implement RESTful Reach API via Akka HTTP service.
   *   Written by: Tom Hicks. 8/17/2017.
-  *   Last Modified: Implement download switch.
+  *   Last Modified: Add route to process text in body of a POST.
   */
 object ApiServer extends App {
   val argMap = buildServerArgMap(args.toList)
@@ -219,6 +219,12 @@ class ApiService (
             path("text") {
               parameters("text", "output" ? "fries") { (text, outputFormat) =>
                 logger.info(s"POST api/text -> ${text}, ${outputFormat}")
+                makeResponseRoute(doText(text, outputFormat), outputFormat)
+              }
+            } ~
+            path("textBody") {
+              formFields("text", "output" ? "fries") { (text, outputFormat) =>
+                logger.info(s"POST api/bodyText -> ${text}, ${outputFormat}")
                 makeResponseRoute(doText(text, outputFormat), outputFormat)
               }
             } ~

--- a/export/src/test/scala/org/clulab/reach/export/TestApiServer.scala
+++ b/export/src/test/scala/org/clulab/reach/export/TestApiServer.scala
@@ -22,7 +22,7 @@ import org.clulab.reach.export.server.ApiServer._
 /**
   * Unit tests of the API service class.
   *   Written by: Tom Hicks. 8/17/2017.
-  *   Last Modified: Update tests for consolidated file upload.
+  *   Last Modified: Add tests for new text body call.
   */
 class TestApiServer extends WordSpec
     with Matchers
@@ -165,6 +165,44 @@ class TestApiServer extends WordSpec
 
     "POST text, csv output" in {
       Post("/api/text?text=akt1%20dephosphorylates%20mek1&output=csv") ~> route ~> check {
+        status should equal(StatusCodes.OK)
+        val resp = responseAs[HttpResponse]
+        (resp) should not be (null)
+        val entity = resp.entity
+        // logger.info(s"resp.entity=${entity}") // DEBUGGING
+        (resp.entity) should not be (null)
+        contentType should equal(ContentTypes.`text/csv(UTF-8)`)
+        val entLen = entity.getContentLengthOption.orElse(-1L)
+        // logger.info(s"entity.length=${entLen}") // DEBUGGING
+        (entLen > 200) should be (true)
+      }
+    }
+
+
+    "POST text, args in body, default output" in {
+      Post("/api/textBody",
+        FormData(
+          "text" -> "The AICAR molecule increases TBC1D1 phosphorylation.")) ~> route ~> check
+      {
+        status should equal(StatusCodes.OK)
+        val resp = responseAs[HttpResponse]
+        (resp) should not be (null)
+        val entity = resp.entity
+        // logger.info(s"resp.entity=${entity}") // DEBUGGING
+        (resp.entity) should not be (null)
+        contentType should equal(ContentTypes.`application/json`)
+        val entLen = entity.getContentLengthOption.orElse(-1L)
+        // logger.info(s"entity.length=${entLen}") // DEBUGGING
+        (entLen > 200) should be (true)
+      }
+    }
+
+    "POST text, args in body, csv output" in {
+      Post("/api/textBody",
+        FormData(
+          "output" -> "csv",
+          "text" -> "The AICAR molecule increases TBC1D1 phosphorylation.")) ~> route ~> check
+      {
         status should equal(StatusCodes.OK)
         val resp = responseAs[HttpResponse]
         (resp) should not be (null)


### PR DESCRIPTION
Add API server route to process args in body of POST. Update API help and tests. This should answer issue #551.