### PR TITLE
 Only save nxml docs if no larger than maxSize (default 1MB)

### DIFF
--- a/main/src/main/scala/org/clulab/reach/indexer/NxmlSearcher.scala
+++ b/main/src/main/scala/org/clulab/reach/indexer/NxmlSearcher.scala
@@ -68,7 +68,7 @@ class NxmlSearcher(val indexDir:String) {
     sos.close()
   }
 
-  def saveDocs(resultDir:String, docIds:Set[(Int, Float)], maxDocs:Int, maxSize:Double = 1E9): Unit = {
+  def saveDocs(resultDir:String, docIds:Set[(Int, Float)], maxDocs:Int, maxSize:Double = 1E6): Unit = {
     val sos = new PrintWriter(new FileWriter(resultDir + File.separator + "scores.tsv"))
     var count = 0
     for(docId <- docIds if count < maxDocs) {

--- a/main/src/main/scala/org/clulab/reach/indexer/NxmlSearcher.scala
+++ b/main/src/main/scala/org/clulab/reach/indexer/NxmlSearcher.scala
@@ -68,7 +68,7 @@ class NxmlSearcher(val indexDir:String) {
     sos.close()
   }
 
-  def saveDocs(resultDir:String, docIds:Set[(Int, Float)], maxDocs:Int): Unit = {
+  def saveDocs(resultDir:String, docIds:Set[(Int, Float)], maxDocs:Int, maxSize:Double = 1E9): Unit = {
     val sos = new PrintWriter(new FileWriter(resultDir + File.separator + "scores.tsv"))
     var count = 0
     for(docId <- docIds if count < maxDocs) {
@@ -77,11 +77,13 @@ class NxmlSearcher(val indexDir:String) {
       val nxml = doc.get("nxml")
       val year = doc.get("year")
       val size = nxml.toString.length * 2 // in bytes
-      val os = new PrintWriter(new FileWriter(resultDir + File.separator + id + ".nxml"))
-      os.print(nxml)
-      os.close()
-      sos.println(s"$id\t${docId._2}\t$year\t$size")
-      count += 1
+      if(size <= maxSize) {
+        val os = new PrintWriter(new FileWriter(resultDir + File.separator + id + ".nxml"))
+        os.print(nxml)
+        os.close()
+        sos.println(s"$id\t${docId._2}\t$year\t$size")
+        count += 1
+      }
     }
     sos.close()
     logger.info(s"Saved $count documents.")


### PR DESCRIPTION
This is a change to allow users to specify a maximum size for NXML documents found by NxmlSearcher. Any document this large (such as a whole proceedings) will be too large to quickly process. The cutoff is 1MB by default.