### PR TITLE
Find home from Java rather than environment

### DIFF
--- a/assembly/src/main/resources/reference.conf
+++ b/assembly/src/main/resources/reference.conf
@@ -27,9 +27,9 @@ assembly {
     # mentions with these labels may form an annotation pair
     validLabels = ["ComplexEvent", "Binding"]
     # a relation corpus (json)
-    corpusDir = ${HOME}/Downloads/causal-assembly
+    corpusDir = ${user.home}/Downloads/causal-assembly
     # directory of json files (doc + mentions)
-    jsonDir = ${HOME}/Downloads/causal-assembly/mention-data
+    jsonDir = ${user.home}/Downloads/causal-assembly/mention-data
   }
 
   # assembly relation classifier

--- a/main/src/main/resources/application.conf
+++ b/main/src/main/resources/application.conf
@@ -4,7 +4,7 @@
 
 # Default top-level root directory for input and output files and subdirectories.
 # All other paths are based on this path but any or all can be changed individually:
-rootDir = ${HOME}/Documents/reach
+rootDir = ${user.home}/Documents/reach
 
 # this is where the brat standoff and text files are dumped
 # if this directory does not exist it will be created

--- a/main/src/test/scala/org/clulab/reach/TestConfigFactory.scala
+++ b/main/src/test/scala/org/clulab/reach/TestConfigFactory.scala
@@ -1,0 +1,39 @@
+package org.clulab.reach
+
+import com.typesafe.config.ConfigFactory
+import org.clulab.reach.context._
+import org.clulab.reach.mentions._
+import org.clulab.reach.grounding._
+import org.scalatest.{Matchers, FlatSpec}
+import scala.util.Try                       // ignore IntelliJ: THIS IS USED!
+import TestUtils._
+
+/**
+  * Unit tests of the configuration factory.
+  */
+class TestConfigFactory extends FlatSpec with Matchers {
+
+  behavior of "user.home"
+  
+  it should "be defined" in {
+    val home = sys.props.get("user.home")
+    
+    home.isDefined should be (true)
+  }
+
+  behavior of "ConfigFactory"
+  
+  it should "load in general" in {
+    val config = ConfigFactory.load()
+  }
+
+  it should "load without ${HOME}" in {
+    val home = sys.env.get("HOME")
+    val withoutHome = home == None
+    
+    if (withoutHome) {
+      val config = ConfigFactory.load()
+    }
+  }
+
+}


### PR DESCRIPTION
ConfigFactory fails for environments that don't have ${HOME} defined (e.g., Windows).  Use ${user.home} instead.