### PR TITLE
Exclude target from copula rule

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/events/pos-reg_template.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/events/pos-reg_template.yml
@@ -205,7 +205,7 @@
   label: ${ label }
   action: ${ actionFlow }
   pattern: |
-    trigger = [lemma=/be/ & tag=/^V/] []? []? [lemma=/${ triggers }/ & tag=/^N/]
+    trigger = [lemma=/be/ & tag=/^V/] []? []? [lemma=/${ triggers }/ & tag=/^N/ & !word=/(?i)^(target)/]
     controller:${ controllerType } = nsubj
     controlled:${ controlledType } = /prep_of|prep_in$/
 


### PR DESCRIPTION
This PR avoids "target" as a trigger for the Positive_X_copula_1 rule. I found that "A is the target of B" is extracted with the wrong argument order i.e. A becomes the controller and B the controlled instead of the other way around.

Here is an example from the shell before the PR
```
EVENTS:   1

MENTION TEXT:  BRAF is a target of KRAS
LABELS:        List(Positive_activation, ActivationEvent, ComplexEvent, Event, PossibleController)
DISPLAY LABEL: Positive_activation
	------------------------------
	RULE => Positive_activation_copula_1
	TYPE => CorefEventMention
	------------------------------

	------------------------------
	TRIGGER => is a target
	controller (List(Gene_or_gene_product, MacroMolecule, Equivalable, BioChemicalEntity, BioEntity, Entity, PossibleController)) => BRAF
	controlled (List(Gene_or_gene_product, MacroMolecule, Equivalable, BioChemicalEntity, BioEntity, Entity, PossibleController)) => KRAS
CONTEXT: NONE
	------------------------------
```
and after the PR
```
EVENTS:   0
```
