### PR TITLE
Mention filter for issue #605

### DIFF
--- a/main/src/main/scala/org/clulab/reach/ReachSystem.scala
+++ b/main/src/main/scala/org/clulab/reach/ReachSystem.scala
@@ -103,9 +103,10 @@ class ReachSystem(
     val resolved = resolveCoref(groundedAndGrouped)
     logger.debug(s"${resolved.size} events after coref: ${display.summarizeMentions(resolved, doc)}")
     // Coref introduced incomplete Mentions that now need to be pruned
-    val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention))
-    //val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
-   // val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention), doc) //doc passed as arg to check paths other than the shortest
+    //val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention))
+    //val complete1 = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
+    //val test = MentionFilter.applyFilterOverlappingMentionsPerSent(complete1, doc)
+    val complete = MentionFilter.applyFilterOverlappingMentionsPerSent(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention), doc) //doc passed as arg to check paths other than the shortest
     logger.debug(s"${complete.size} events after coref + 2nd MentionFilter.keepMostCompleteMentions: ${display.summarizeMentions(complete, doc)}")
     logger.debug(s"Resolving display...")
     resolveDisplay(complete)
@@ -134,8 +135,8 @@ class ReachSystem(
     // Coref expects to get all mentions grouped by document
     val resolved = resolveCoref(groupMentionsByDocument(grounded, documents))
     // Coref introduced incomplete Mentions that now need to be pruned
-    //val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
-    val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention))
+    val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
+    //val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention))
 
     resolveDisplay(complete)
   }

--- a/main/src/main/scala/org/clulab/reach/ReachSystem.scala
+++ b/main/src/main/scala/org/clulab/reach/ReachSystem.scala
@@ -103,10 +103,7 @@ class ReachSystem(
     val resolved = resolveCoref(groundedAndGrouped)
     logger.debug(s"${resolved.size} events after coref: ${display.summarizeMentions(resolved, doc)}")
     // Coref introduced incomplete Mentions that now need to be pruned
-    //val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention))
-    //val complete1 = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
-    //val test = MentionFilter.applyFilterOverlappingMentionsPerSent(complete1, doc)
-    val complete = MentionFilter.applyFilterOverlappingMentionsPerSent(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention), doc) //doc passed as arg to check paths other than the shortest
+    val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention))
     logger.debug(s"${complete.size} events after coref + 2nd MentionFilter.keepMostCompleteMentions: ${display.summarizeMentions(complete, doc)}")
     logger.debug(s"Resolving display...")
     resolveDisplay(complete)
@@ -135,8 +132,8 @@ class ReachSystem(
     // Coref expects to get all mentions grouped by document
     val resolved = resolveCoref(groupMentionsByDocument(grounded, documents))
     // Coref introduced incomplete Mentions that now need to be pruned
-    val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
-    //val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention))
+    //val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
+    val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention))
 
     resolveDisplay(complete)
   }

--- a/main/src/main/scala/org/clulab/reach/ReachSystem.scala
+++ b/main/src/main/scala/org/clulab/reach/ReachSystem.scala
@@ -103,8 +103,9 @@ class ReachSystem(
     val resolved = resolveCoref(groundedAndGrouped)
     logger.debug(s"${resolved.size} events after coref: ${display.summarizeMentions(resolved, doc)}")
     // Coref introduced incomplete Mentions that now need to be pruned
-    val complete1 = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
-    val complete = MentionFilter.filterOverlappingMentions(complete1)
+    val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention))
+    //val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
+   // val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention), doc) //doc passed as arg to check paths other than the shortest
     logger.debug(s"${complete.size} events after coref + 2nd MentionFilter.keepMostCompleteMentions: ${display.summarizeMentions(complete, doc)}")
     logger.debug(s"Resolving display...")
     resolveDisplay(complete)
@@ -133,7 +134,8 @@ class ReachSystem(
     // Coref expects to get all mentions grouped by document
     val resolved = resolveCoref(groupMentionsByDocument(grounded, documents))
     // Coref introduced incomplete Mentions that now need to be pruned
-    val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
+    //val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
+    val complete = MentionFilter.filterOverlappingMentions(MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention))
 
     resolveDisplay(complete)
   }

--- a/main/src/main/scala/org/clulab/reach/ReachSystem.scala
+++ b/main/src/main/scala/org/clulab/reach/ReachSystem.scala
@@ -104,7 +104,7 @@ class ReachSystem(
     logger.debug(s"${resolved.size} events after coref: ${display.summarizeMentions(resolved, doc)}")
     // Coref introduced incomplete Mentions that now need to be pruned
     val complete1 = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
-    val complete = MentionFilter.filterOverlappingMentions(complete1)git
+    val complete = MentionFilter.filterOverlappingMentions(complete1)
     logger.debug(s"${complete.size} events after coref + 2nd MentionFilter.keepMostCompleteMentions: ${display.summarizeMentions(complete, doc)}")
     logger.debug(s"Resolving display...")
     resolveDisplay(complete)

--- a/main/src/main/scala/org/clulab/reach/ReachSystem.scala
+++ b/main/src/main/scala/org/clulab/reach/ReachSystem.scala
@@ -103,7 +103,8 @@ class ReachSystem(
     val resolved = resolveCoref(groundedAndGrouped)
     logger.debug(s"${resolved.size} events after coref: ${display.summarizeMentions(resolved, doc)}")
     // Coref introduced incomplete Mentions that now need to be pruned
-    val complete = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
+    val complete1 = MentionFilter.keepMostCompleteMentions(resolved, State(resolved)).map(_.toCorefMention)
+    val complete = MentionFilter.filterOverlappingMentions(complete1)git
     logger.debug(s"${complete.size} events after coref + 2nd MentionFilter.keepMostCompleteMentions: ${display.summarizeMentions(complete, doc)}")
     logger.debug(s"Resolving display...")
     resolveDisplay(complete)

--- a/main/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
+++ b/main/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
@@ -26,7 +26,8 @@ object MentionFilter {
 
   def filterOverlappingMentions(ms: Seq[CorefMention]): Seq[CorefMention] = {
     // For each mention, check to see if any other mention has argument overlap and if there is arg overlap,
-    // check if the path from the trigger to the overlapping argument contains a trigger of the other mention
+    // check if the path from the trigger to the overlapping argument contains a trigger of the other mention +
+    //checks if the overlapping argument is connected to the trigger of another mention with an incoming edge
     for {
       i <- 0 until ms.length
       m1 = ms(i)
@@ -67,9 +68,18 @@ object MentionFilter {
       val synPath = m.paths("theme").get(theme)
       // Does the synPath contain the trigger
       val tokensOnPath = synPath.get.flatMap(path => Seq(path._1, path._2)).toSet
-      trigger.tokenInterval.exists(tok => tokensOnPath.contains(tok))
+      val edges = mkPrev(theme.tokenInterval.start, m.sentenceObj)
+      trigger.tokenInterval.exists(tok => tokensOnPath.contains(tok) || edges.contains(tok))
     } else false
   }
+
+  //checks incoming rel for the given node
+  def mkPrev(node: Int, sent: Sentence): Seq[Int] = {
+    val graph = sent.dependencies.get
+    val edges = graph.incomingEdges(node)
+    edges.map(_._1).distinct
+  }
+
 
   // a simple, imperfect way of removing incomplete Mentions
   def pruneMentions(ms: Seq[CorefMention]): Seq[CorefMention] = {

--- a/main/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
+++ b/main/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
@@ -33,7 +33,7 @@ object MentionFilter {
     ms.filter(argumentsOverlap(m, _))
   }
 
-  def filterOverlappingMentions(ms: Seq[Mention]): Seq[Mention] = {
+  def filterOverlappingMentions(ms: Seq[CorefMention]): Seq[CorefMention] = {
     // For each mention, check to see if any other mention has argument overlap
     for {
       i <- 0 until ms.length - 1
@@ -324,8 +324,10 @@ object MentionFilter {
         moreComplete.filter(m => keepMention(m, State(moreComplete)))
           .map(_.toCorefMention)
       case Nil =>
-        val noTriggerOverlap = filterOverlappingMentions(other)
-        pruneMentions(noTriggerOverlap.map(_.toCorefMention))
+        pruneMentions(other.map(_.toCorefMention))
+
+      //        val noTriggerOverlap = filterOverlappingMentions(other)
+//        pruneMentions(noTriggerOverlap.map(_.toCorefMention))
     }
   }
 

--- a/main/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
+++ b/main/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
@@ -25,7 +25,8 @@ object MentionFilter {
 
 
   def filterOverlappingMentions(ms: Seq[CorefMention]): Seq[CorefMention] = {
-    // For each mention, check to see if any other mention has argument overlap
+    // For each mention, check to see if any other mention has argument overlap and if there is arg overlap,
+    // check if the path from the trigger to the overlapping argument contains a trigger of the other mention
     for {
       i <- 0 until ms.length
       m1 = ms(i)
@@ -55,7 +56,6 @@ object MentionFilter {
         val m2Themes = em.arguments.get("theme")
         val overlappingThemes = m1Themes.filter(theme => m2Themes.contains(theme))
         if (overlappingThemes.nonEmpty) {
-          //overlappingThemes.foreach(theme => println("theme: " + theme.toString()))
           overlappingThemes.get.exists(theme => synPathContainsTrigger(m1, theme, em.trigger))
         } else false
       case _ => false
@@ -67,18 +67,9 @@ object MentionFilter {
       val synPath = m.paths("theme").get(theme)
       // Does the synPath contain the trigger
       val tokensOnPath = synPath.get.flatMap(path => Seq(path._1, path._2)).toSet
-      val edges = mkPrev(theme.tokenInterval.start, m.sentenceObj)
-      trigger.tokenInterval.exists(tok => tokensOnPath.contains(tok) )
+      trigger.tokenInterval.exists(tok => tokensOnPath.contains(tok))
     } else false
   }
-
-  //checks incoming rel for the given node
-  def mkPrev(node: Int, sent: Sentence): Seq[Int] = {
-    val graph = sent.dependencies.get
-    val edges = graph.incomingEdges(node)
-    edges.map(_._1).distinct
-  }
-
 
   // a simple, imperfect way of removing incomplete Mentions
   def pruneMentions(ms: Seq[CorefMention]): Seq[CorefMention] = {

--- a/main/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
+++ b/main/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
@@ -23,7 +23,6 @@ object MentionFilter {
     ms.filter(argumentsOverlap(m, _))
   }
 
-
   def filterOverlappingMentions(ms: Seq[CorefMention]): Seq[CorefMention] = {
     // For each mention, check to see if any other mention has argument overlap and if there is arg overlap,
     // check if the path from the trigger to the overlapping argument contains a trigger of the other mention +
@@ -31,11 +30,11 @@ object MentionFilter {
     for {
       i <- 0 until ms.length
       m1 = ms(i)
-      msToCheck = ms.slice(0, i) ++ ms.slice(i+1, ms.length) // fixme: I'm pretty darn inefficient
-      overlapping = getOverlappingMentions(m1, msToCheck)
+      overlapping = getOverlappingMentions(m1, ms)
       if !triggerOverlap(m1, overlapping)
     } yield m1
   }
+
 
   // fixme: make a better name
   // If argument overlap is found, check to see if it's a problem: i.e., if the synPath between the trigger
@@ -51,7 +50,7 @@ object MentionFilter {
 
   def triggerOverlap(m1: Mention, m2: Mention): Boolean = {
     m2 match {
-      case em: EventMention if ( em.trigger.tokenInterval != m1.asInstanceOf[CorefEventMention].trigger.tokenInterval && em != m1 && m1.arguments.get("theme").nonEmpty && m2.arguments.get("theme").nonEmpty && em.labels.contains("SimpleEvent")) =>
+      case em: EventMention if ( em.trigger.tokenInterval != m1.asInstanceOf[CorefEventMention].trigger.tokenInterval && m1.arguments.get("theme").nonEmpty && m2.arguments.get("theme").nonEmpty && em.labels.contains("SimpleEvent")) =>
         // Does the synPath to the argument of m1 contain the trigger of m2?
         val m1Themes = m1.arguments.get("theme")
         val m2Themes = em.arguments.get("theme")

--- a/main/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
+++ b/main/src/main/scala/org/clulab/reach/darpa/MentionFilter.scala
@@ -25,7 +25,23 @@ object MentionFilter {
     ms.filter(argumentsOverlap(m, _))
   }
 
-  def filterOverlappingMentions(ms: Seq[CorefMention]): Seq[CorefMention] = {
+  def applyFilterOverlappingMentionsPerSent (ms: Seq[CorefMention], doc: Document): Seq[CorefMention] = {
+    val mentionsBySentence = ms groupBy (_.sentence) mapValues (_.sortBy(_.start)) withDefaultValue Nil
+    mentionsBySentence.foreach(m => println("whatever each mention by sentence is" + m._2))
+    val mentions = for ((m, i) <- mentionsBySentence.zipWithIndex) yield {
+      println("mention by sent m " + m)
+      filterOverlappingMentions(m._2, doc.sentences(i))
+    }
+     val mentionSeq = for {
+       i <- mentions
+       m <- i
+     } yield m
+
+    return mentionSeq.toSeq
+  }
+  //TODO check if an just return mentions.toSeq
+
+  def filterOverlappingMentions(ms: Seq[CorefMention], sent: Sentence): Seq[CorefMention] = {
     // For each mention, check to see if any other mention has argument overlap
     for {
       i <- 0 until ms.length


### PR DESCRIPTION
The filter removes (some of) the mentions that incorrectly grab arguments from other mentions
E.g., in "Insulin stimulated tyrosine phosphorylation of IRS-1, PI 3-kinase activity, and Akt phosphorylation.", the filter eliminates the following incorrect relations: phosphorylation1-Akt and phosphorylation2-IRS1

@MihaiSurdeanu, before opening a pull request, I merged master into my branch. There was one conflict, but I think I resolved it correctly--- the conflict was in ReachSystem.scala around line 140, where I am calling the new filter (filterOverlappingMentions). Is the protocol normally to open a pull request first and then resolve conflicts or merge master into your branch before opening a pull request? Thanks!