### PR TITLE
Maintain naming consistency in the IndexCards Output

### DIFF
--- a/export/src/main/scala/org/clulab/reach/export/indexcards/IndexCardOutput.scala
+++ b/export/src/main/scala/org/clulab/reach/export/indexcards/IndexCardOutput.scala
@@ -468,7 +468,7 @@ class IndexCardOutput extends JsonOutputter with LazyLogging {
     ev += mention.text
     f("evidence") = ev
     // TODO: we do not compare against the model; assume everything is new
-    f("verbose-text") = display.cleanVerbose(mention.sentenceObj.getSentenceText)
+    f("verbose_text") = display.cleanVerbose(mention.sentenceObj.getSentenceText)
     f("model_relation") = "extension"
   }
 


### PR DESCRIPTION
`verbose-text` has been changed to `verbose_test` to maintain consistency in naming convention across all keys in the JSON output.