### PR TITLE
Fix incorrect event from "the A activator B" phrases

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/events/pos-reg_template.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/events/pos-reg_template.yml
@@ -24,7 +24,6 @@ rules:
       (/${conjunctions}|${dep}|${objects}|${noun_modifiers}|${genitive_case_marker}|${preps_in$_singleton}/){,2}
     controller:${ controllerType } = </${complements}/? (${agents} | ${passive_voice_subject} | /${passive_agents}/ | </${adjective_clause}|${adverbial_clause}/) /${noun_modifiers}|${conjunctions}|${genitive_case_marker}|${preps_in$_singleton}/{,2}
 
-
 - name: Positive_${ ruleType }_syntax_1a_verb #Added by jmculnan
   priority: ${ priority }
   example: "X restores Y"
@@ -253,7 +252,7 @@ rules:
   example: "monoubiquitinated K-Ras is less sensitive than the unmodified protein to GAP-mediated GTP hydrolysis"
   action: ${ actionFlow }
   pattern: |
-    @controller:${ controllerType } (?<trigger> [word=/(?i)^(${ triggers })/ & !tag=/^JJ/]) @controlled:${ controlledType }
+    @controller:${ controllerType } (?<trigger> [word=/(?i)^(${ triggers })/ & !tag=/^JJ|^NN/]) @controlled:${ controlledType }
 
 - name: Positive_${ ruleType }_token_1b_verb
   priority: ${ priority }

--- a/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestActivationEvents.scala
@@ -340,4 +340,11 @@ class TestActivationEvents extends FlatSpec with Matchers {
     val mentions = getBioMentions(sent47)
     hasPositiveActivation("vemurafenib", " BRAF", mentions) should be (false)
   }
+
+  val sent50 = "the Rac1 activator TIAM1"
+  sent50 should "contain 1 positive activation event" in {
+    val mentions = getBioMentions(sent50)
+    hasPositiveActivation("Rac1", "TIAM1", mentions) should be(false)
+    hasPositiveActivation("TIAM1", "Rac1", mentions) should be(true)
+  }
 }


### PR DESCRIPTION
Before this PR, the phrase "Rac1 activator TIAM1" yielded two positive activation events, including one in which the controller was Rac1 and the controlled TIAM1. This PR patches `Positive_activation_token_1_verb` to disallow NN triggers. Sorry if this is not the right approach to fixing this issue!