### PR TITLE
Add Secretion event

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/events/secretion_events.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/events/secretion_events.yml
@@ -1,0 +1,11 @@
+vars: org/clulab/reach/biogrammar/vars.yml
+
+rules:
+
+- name: secretion_1
+  priority: ${ priority }
+  example: "INF-gamma secretion"
+  label: Secretion
+  pattern: |
+    trigger = [lemma=/${ triggerLemma }/]
+    theme:BioChemicalEntity = ${genitive_case_marker} /${noun_modifiers}/? | ${noun_modifiers}

--- a/main/src/main/resources/org/clulab/reach/biogrammar/events_master.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/events_master.yml
@@ -33,6 +33,11 @@ rules:
       triggerLemma: "amount|level|quantity"
       priority: "7"
 
+  - import: org/clulab/reach/biogrammar/events/secretion_events.yml
+    vars:
+      triggerLemma: "secret|release|exocyt"
+      priority: "7"
+
   - import: org/clulab/reach/biogrammar/events/hydrolysis_events.yml
     vars:
       priority: "7"

--- a/main/src/main/resources/org/clulab/reach/biogrammar/taxonomy.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/taxonomy.yml
@@ -31,6 +31,7 @@
             - Amount:
               - IncreaseAmount:
                 - Transcription
+                - Secretion
               - DecreaseAmount
             - AdditionEvent:
                 - Acetylation

--- a/main/src/test/scala/org/clulab/reach/TestRegulationEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestRegulationEvents.scala
@@ -571,4 +571,10 @@ class TestRegulationEvents extends FlatSpec with Matchers {
     mentions.filter(_.label == "Negative_activation") should have size (1)
   }
 
+  val sent63 = "glucose triggers insulin release"
+  sent63 should "recognize as a secretion" in {
+    val mentions = getBioMentions(sent63)
+    mentions.filter(_.label == "Secretion") should have size (1)
+  }
+
 }


### PR DESCRIPTION
This PR adds Secretion as a subtype under IncreaseAmount, and recognize secretion/exocytosis/release as triggers in sentences such as "glucose induces insulin release". Prior to the PR, these sentences would be extracted as positive activation.