### PR TITLE
Dockerfiles for base build and test build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,6 @@ RUN apt-get install -y openjdk-8-jdk && \
 RUN git clone https://github.com/clulab/bioresources.git && \
     cd bioresources && sbt publishLocal && cd .. && \
     git clone https://github.com/clulab/processors.git && \
-    cd processors && sbt publishLocal && cd .. && \
+    cd processors && sbt +publishLocal && cd .. && \
     git clone https://github.com/clulab/reach.git && \
     cd reach && sbt publishLocal

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:latest
+
+# Install basic packages
+RUN apt-get update && apt-get install -y git vim wget build-essential \
+    software-properties-common
+
+# Add some extensions to apt sources and update
+RUN add-apt-repository -y ppa:openjdk-r/ppa && \
+    echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \
+    apt-get update
+
+# Install Java, Scala and SBT
+RUN apt-get install -y openjdk-8-jdk && \
+    wget -nv https://www.scala-lang.org/files/archive/scala-2.11.12.deb && \
+    dpkg -i scala-2.11.12.deb && \
+    rm scala-2.11.12.deb && \
+    apt-get install -y sbt
+
+# Clone bioresources, processors and reach
+RUN git clone https://github.com/clulab/bioresources.git && \
+    cd bioresources && sbt publishLocal && cd .. && \
+    git clone https://github.com/clulab/processors.git && \
+    cd processors && sbt publishLocal && cd .. && \
+    git clone https://github.com/clulab/reach.git && \
+    cd reach && sbt publishLocal

--- a/docker/Dockerfile_test
+++ b/docker/Dockerfile_test
@@ -1,0 +1,33 @@
+FROM reach:latest
+
+# Handle arguments for repo branches, with master as default
+ARG bioresources_branch=master
+ARG processors_branch=master
+ARG reach_branch=master
+
+# Build bioresources off a custom branch
+RUN cd bioresources && \
+    git fetch --all && \
+    git checkout origin/$bioresources_branch && \
+    sbt publishLocal
+
+# Build processors off a custom branch
+RUN export BIORESOURCES_VERSION=$(grep -o '".*"' bioresources/version.sbt | sed 's/"//g') && \
+    cd processors && \
+    git fetch --all && \
+    git checkout origin/$processors_branch && \
+    sed -i 's/"bioresources" % ".*"/"bioresources" % "'$BIORESOURCES_VERSION'"/' corenlp/build.sbt && \
+    sbt +publishLocal
+
+# Build reach off a custom branch
+RUN export BIORESOURCES_VERSION=$(grep -o '".*"' bioresources/version.sbt | sed 's/"//g') && \
+    export PROCESSORS_VERSION=$(grep -o '".*"' processors/version.sbt | sed 's/"//g') && \
+    cd reach && \
+    git fetch --all && \
+    git checkout --track origin/$reach_branch && \
+    sed -i 's/procVer = ".*"/procVer = "'$PROCESSORS_VERSION'"/' main/build.sbt && \
+    sed -i 's/"bioresources".*% ".*"/"bioresources" % "'$BIORESOURCES_VERSION'"/' main/build.sbt #&& \
+    sbt publishLocal
+
+WORKDIR reach
+ENTRYPOINT ./runAllTests.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,37 @@
+Building the base image
+-----------------------
+The `Dockerfile` installs all necessary dependencies and compiles the latest
+master of `bioresources`, `processors`, and `reach` from source. To build the
+image, run
+
+```
+docker build --tag reach:latest .
+```
+
+Building a test image
+---------------------
+The `Dockerfile_test` builds on the `reach:latest` base image, and using
+build arguments, allows specifying which branch of `bioresources`,
+`processors` and `reach` to check out and build. It fetches and checks out
+the chosen branches, and sets build configurations to
+build each system against the correct version of its dependencies. The
+rationale behind separating the two Dockerfiles is that the base image can
+take a long time to build but each test build is typically much faster.
+
+To build the test image, run
+```
+docker build -f Dockerfile_test --tag reach:test .
+```
+The build command takes three optional arguments: `bioresources_branch`,
+`processors_branch`, and `reach_branch`. These can be specified as, for
+example,
+```
+docker build -f Dockerfile_test --build-arg bioresources_branch=test_branch
+--tag reach:test .
+```
+
+The image also defines a default entrypoint for running all REACH tests as
+follows:
+```
+docker run reach:test
+```


### PR DESCRIPTION
This PR adds a `Dockerfile` for building bioresources, processors and reach off of the latest master  branches to create a base development environment. A `Dockerfile_test` build can then be done on top of that which automates checking out selected branches, changing build configs to use the right local snapshot versions, and compiling bioresources, processors, and reach. Finally, the container can be run to run all tests. This is the most convenient approach that I could come up with to test reach against changes in bioresources in an automated way, and with a self-contained development environment.