### PR TITLE
Change deprecated be to fplx

### DIFF
--- a/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
@@ -224,7 +224,7 @@ object ReachIMKBMentionLookups {
   /** KB accessor to resolve protein family names via static KB. */
   def staticProteinFamilyOrComplexKBML: IMKBMentionLookup = {
     val metaInfo = new IMKBMetaInfo(
-      namespace = "be",
+      namespace = "fplx",
       kbFilename = Some(StaticProteinFamilyOrComplexFilename),
       baseURI = "https://identifiers.org/fplx/",
       isFamilyKB = true


### PR DESCRIPTION
We forgot to change be to fplx in one important place, this PR fixes that.