### PR TITLE
Increase some timeouts for the API server

### DIFF
--- a/export/src/main/resources/reference.conf
+++ b/export/src/main/resources/reference.conf
@@ -17,6 +17,7 @@ ApiServer {
     loggers = [ "akka.event.slf4j.Slf4jLogger" ]
     logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
     loglevel = INFO                          # OFF, DEBUG, INFO, WARN, ERROR
+    logger-startup-timeout = 30s
     #stdout-loglevel = OFF
     log-dead-letters = OFF
     #io.TcpListener = DEBUG
@@ -33,7 +34,7 @@ ApiServer {
         # The time period within which the TCP binding process must be completed.
         # Set to `infinite` to disable.
         bind-timeout = 1s
-        request-timeout = 5 minutes
+        request-timeout = 10 minutes
       }
 
       client {


### PR DESCRIPTION
I sometimes get timeouts from the logger starting up, and some full-text documents take longer than 5 minutes to process so in this PR I increased the default timeouts in the config.