### PR TITLE
Integrating ChEBI, GO and new stopwords from bioresources

### DIFF
--- a/export/src/test/scala/org/clulab/reach/export/TestApi.scala
+++ b/export/src/test/scala/org/clulab/reach/export/TestApi.scala
@@ -119,9 +119,9 @@ class TestApi extends FlatSpec with Matchers {
     hasEntity("ASPP2", results) should be (true)
   }
 
-  it should "return 4 positive activation and 3 phosphorylation results from NXML test" in {
+  it should "return 9 positive activation and 3 phosphorylation results from NXML test" in {
     val results = Api.runOnNxml(nxmlText)
-    results.filter(_.label == "Positive_activation") should have size (4)
+    results.filter(_.label == "Positive_activation") should have size (9)
     results.filter(_.label == "Phosphorylation") should have size (3)
   }
 

--- a/main/src/main/scala/org/clulab/reach/grounding/EntityChecker.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/EntityChecker.scala
@@ -27,7 +27,9 @@ object EntityChecker extends App with LazyLogging {
                                        staticProteinKBLookup )
 
   /** Search sequence for small molecules. */
-  protected val chemSearcher = Seq( staticChemicalKBLookup, staticDrugKBLookup )
+  protected val chemSearcher = Seq( staticChemicalKBLookupChebi,
+                                    staticChemicalKBLookup,
+                                    staticDrugKBLookup )
 
   /** Search sequence for sub cellular locations terms. */
   protected val cellLocationSearcher = Seq( staticCellLocationKBLookup )

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
@@ -99,6 +99,7 @@ class ReachEntityLookup {
   )
 
   val chemicalSeq: KBSearchSequence = extraKBs ++ Seq(
+    StaticChemicalChebi,                    // Chebi
     StaticChemical,                         // PubChem
     StaticDrug,                             // HMS LINCS drugs
     // StaticMetabolite,                    // REPLACED by PubChem

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBLookups.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBLookups.scala
@@ -70,17 +70,15 @@ object ReachIMKBLookups {
   }
 
   /** KB lookup to resolve small molecule (chemical) names via static KB. */
-  // def staticChemicalKBLookup: IMKBLookup = {
-  //   val metaInfo = new IMKBMetaInfo(
-  //     namespace = "chebi",
-  //     kbFilename = Some(StaticChemicalFilename),
-  //     baseURI = "http://identifiers.org/chebi/",
-  //     resourceId = "MIR:00100009"
-  //   )
-  //   new IMKBLookup(TsvIMKBFactory.make(metaInfo))
-  // }
-
-
+  def staticChemicalKBLookupChebi: IMKBLookup = {
+     val metaInfo = new IMKBMetaInfo(
+       namespace = "chebi",
+       kbFilename = Some(StaticChemicalFilename),
+       baseURI = "http://identifiers.org/chebi/",
+       resourceId = "MIR:00100009"
+     )
+     new IMKBLookup(TsvIMKBFactory.make(metaInfo))
+   }
 
   /** KB accessor to resolve protein names via static KB. */
   def staticProteinKBLookup: IMKBLookup = {

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBLookups.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBLookups.scala
@@ -73,7 +73,7 @@ object ReachIMKBLookups {
   def staticChemicalKBLookupChebi: IMKBLookup = {
      val metaInfo = new IMKBMetaInfo(
        namespace = "chebi",
-       kbFilename = Some(StaticChemicalFilename),
+       kbFilename = Some(StaticChemicalFilenameChebi),
        baseURI = "http://identifiers.org/chebi/",
        resourceId = "MIR:00100009"
      )

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
@@ -29,6 +29,7 @@ object ReachIMKBMentionLookups {
   val StaticCellLocation = staticCellLocationKBML   // GO subcellular KB
   val StaticCellLocation2 = staticCellLocation2KBML // Uniprot subcellular KB
   val StaticChemical = staticChemicalKBML
+  val StaticChemicalChebi = staticChemicalKBMLChebi
   val StaticDrug = staticDrugKBML
   // val StaticMetabolite = staticMetaboliteKBML    // Replaced by PubChem
   val StaticProtein = staticProteinKBML
@@ -129,15 +130,15 @@ object ReachIMKBMentionLookups {
   }
 
   /** KB accessor to resolve small molecule (chemical) names via static KB. */
-  // def staticChemicalKBML: IMKBMentionLookup = {
-  //   val metaInfo = new IMKBMetaInfo(
-  //     namespace = "chebi",
-  //     kbFilename = Some(StaticChemicalFilename),
-  //     baseURI = "http://identifiers.org/chebi/",
-  //     resourceId = "MIR:00100009"
-  //   )
-  //   new IMKBMentionLookup(TsvIMKBFactory.make(metaInfo))
-  // }
+  def staticChemicalKBMLChebi: IMKBMentionLookup = {
+     val metaInfo = new IMKBMetaInfo(
+       namespace = "chebi",
+       kbFilename = Some(StaticChemicalFilename),
+       baseURI = "http://identifiers.org/chebi/",
+       resourceId = "MIR:00100009"
+     )
+     new IMKBMentionLookup(TsvIMKBFactory.make(metaInfo))
+   }
 
 
   //

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
@@ -133,7 +133,7 @@ object ReachIMKBMentionLookups {
   def staticChemicalKBMLChebi: IMKBMentionLookup = {
      val metaInfo = new IMKBMetaInfo(
        namespace = "chebi",
-       kbFilename = Some(StaticChemicalFilename),
+       kbFilename = Some(StaticChemicalFilenameChebi),
        baseURI = "http://identifiers.org/chebi/",
        resourceId = "MIR:00100009"
      )

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
@@ -55,6 +55,9 @@ object ReachKBConstants {
   /** Filename of the static small molecule (chemical) file. */
   val StaticChemicalFilename = "PubChem.tsv.gz"
 
+  /** Filename of the static small molecule (chemical) file from ChEBI. */
+  val StaticChemicalFilenameChebi = "chebi.tsv.gz"
+
   /** Filename of the static small molecule (drug) file. */
   val StaticDrugFilename = "hms-drugs.tsv.gz"
 

--- a/main/src/test/scala/org/clulab/reach/TestBindingEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestBindingEvents.scala
@@ -315,13 +315,15 @@ class TestBindingEvents extends FlatSpec with Matchers {
   }
   */
 
-  val sent27 = "Once bound to the DSB, the DNA-PK holoenzyme facilitates the recruitment..."
+
+  val sent27 = "Once bound to RAD51, the DNA-PK holoenzyme facilitates the recruitment..."
   sent27 should "contain 1 binding event (MARCO)" in {
     val mentions = getBioMentions(sent27)
     // TODO: this should be matched by the binding_oncebound rule, but it doesn't...
-    hasEventWithArguments("Binding", List("DNA-PK holoenzyme", "DSB"), mentions) should be (true)
+    hasEventWithArguments("Binding", List("DNA-PK holoenzyme", "RAD51"), mentions) should be (true)
   }
 
+   */
   val sent28 = "To confirm whether XRCC1 and DNA-PK coexist in a common complex, we carried out co-immunoprecipitation experiments in HeLa nuclear extracts."
   sent28 should "contain 1 binding event" in {
     val mentions = getBioMentions(sent28)

--- a/main/src/test/scala/org/clulab/reach/TestBindingEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestBindingEvents.scala
@@ -323,7 +323,7 @@ class TestBindingEvents extends FlatSpec with Matchers {
     hasEventWithArguments("Binding", List("DNA-PK holoenzyme", "RAD51"), mentions) should be (true)
   }
 
-   */
+
   val sent28 = "To confirm whether XRCC1 and DNA-PK coexist in a common complex, we carried out co-immunoprecipitation experiments in HeLa nuclear extracts."
   sent28 should "contain 1 binding event" in {
     val mentions = getBioMentions(sent28)

--- a/main/src/test/scala/org/clulab/reach/TestCoreference.scala
+++ b/main/src/test/scala/org/clulab/reach/TestCoreference.scala
@@ -542,7 +542,7 @@ class TestCoreference extends FlatSpec with Matchers {
   sent51 should "not apply S135 grounding to diacylglycerol or vice versa" in {
     val mentions = getBioMentions(sent51)
     val entities = mentions filter (m => (m matches "Entity") || (m matches "Site"))
-    entities should have size 2
+    entities should have size 3
     entities.head.grounding.get.equals(entities.last.grounding.get) should be (false)
   }
 

--- a/main/src/test/scala/org/clulab/reach/TestCoreference.scala
+++ b/main/src/test/scala/org/clulab/reach/TestCoreference.scala
@@ -542,7 +542,7 @@ class TestCoreference extends FlatSpec with Matchers {
   sent51 should "not apply S135 grounding to diacylglycerol or vice versa" in {
     val mentions = getBioMentions(sent51)
     val entities = mentions filter (m => (m matches "Entity") || (m matches "Site"))
-    entities should have size 3
+    entities should have size 2
     entities.head.grounding.get.equals(entities.last.grounding.get) should be (false)
   }
 

--- a/main/src/test/scala/org/clulab/reach/TestEntities.scala
+++ b/main/src/test/scala/org/clulab/reach/TestEntities.scala
@@ -145,7 +145,7 @@ class TestEntities extends FlatSpec with Matchers {
   // "X
   val sent9a = "Ras inhibitor was added to the solution." // family + inhibitor
   val sent9b = "Akt inhibitor was added to the solution." // protein + inhibitor
-  val sent9c = "Adenylate cyclase inhibitor was added to the solution." // multi-word protein + inhibitor
+  val sent9c = "Adenylate cyclase inhibitor was added to the solution." // Entire phrase available as GO synonym
   val sent9d = "Vascular endothelial cell growth inhibitor was added to solution." // protein (not a simple chemical)
   sent9a should "contain a Simple_chemical and nothing else" in {
     val mentions = getBioMentions(sent9a)
@@ -157,10 +157,10 @@ class TestEntities extends FlatSpec with Matchers {
     mentions.length should be (1)
     mentions.head matches "Simple_chemical" should be (true)
   }
-  sent9c should "contain a Simple_chemical and nothing else" in {
+  sent9c should "contain a BioProcess and nothing else" in {
     val mentions = getBioMentions(sent9c)
     mentions.length should be (1)
-    mentions.head matches "Simple_chemical" should be (true)
+    mentions.head matches "BioProcess" should be (true)
   }
   sent9d should "contain a Gene_or_gene_product and nothing else" in {
     val mentions = getBioMentions(sent9d)

--- a/main/src/test/scala/org/clulab/reach/TestNERLabeling.scala
+++ b/main/src/test/scala/org/clulab/reach/TestNERLabeling.scala
@@ -25,12 +25,12 @@ class TestNERLabeling extends FlatSpec with Matchers {
   // this tests overrides simple chemical identifications:
   val manual_chemicals = "Estrone E1, estradiol E2, and estriol E3 do not cause cancer."
   val organ = "Acetabulum, Visceral Pericardium, malleolar bone, Vena cava sinus, and zygopodium cause cancer"
-  val chemical = "endoxifen sulfate, Juvamine, Adenosine-phosphate, Xitix, and Monic acid cause cancer"
+  val chemical = "endoxifen sulfate, Juvamine, Adenosine-phosphate, Xitix, and okadaic acid cause cancer"
   val sites = "ALOG domain, AMIN domain, KIP1-like, KEN domain, and HAS subgroup cause cancer"
   val species = "Potato, wheat, Yerba-mate, Danio rerio, zebrafish, Rats, Gallus gallus, and chickens cause cancer"
 
   val drug = "Alvocidib, Anacardic acid, L-779450, Masitinib, and  Withaferin A are known drugs. "
-  val drug_ids = Seq("CHEBI:47344", "167551", "9950176", "CHEBI:63450", "CHEBI:10040")
+  val drug_ids = Seq("CHEBI:47344", "CHEBI:2696", "9950176", "CHEBI:63450", "CHEBI:69120")
 
 
   bioProcess should "have BioProcess label" in {

--- a/main/src/test/scala/org/clulab/reach/TestNERLabeling.scala
+++ b/main/src/test/scala/org/clulab/reach/TestNERLabeling.scala
@@ -30,7 +30,7 @@ class TestNERLabeling extends FlatSpec with Matchers {
   val species = "Potato, wheat, Yerba-mate, Danio rerio, zebrafish, Rats, Gallus gallus, and chickens cause cancer"
 
   val drug = "Alvocidib, Anacardic acid, L-779450, Masitinib, and  Withaferin A are known drugs. "
-  val drug_ids = Seq("5287969", "167551", "9950176", "10074640", "265237")
+  val drug_ids = Seq("CHEBI:47344", "167551", "9950176", "CHEBI:63450", "CHEBI:10040")
 
 
   bioProcess should "have BioProcess label" in {

--- a/processors/build.sbt
+++ b/processors/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= {
     "org.clulab"          %%  "processors-main"          % procVer,
     "org.clulab"          %%  "processors-corenlp"       % procVer,
     "org.clulab"          %%  "processors-odin"          % procVer,
-    "org.clulab"           %  "bioresources"             % "1.1.32-SNAPSHOT",
+    "org.clulab"           %  "bioresources"             % "1.1.32",
     "org.clulab"          %%  "fatdynet"                 % "0.2.5",
 
     // logging

--- a/processors/build.sbt
+++ b/processors/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= {
     "org.clulab"          %%  "processors-main"          % procVer,
     "org.clulab"          %%  "processors-corenlp"       % procVer,
     "org.clulab"          %%  "processors-odin"          % procVer,
-    "org.clulab"           %  "bioresources"             % "1.1.31",
+    "org.clulab"           %  "bioresources"             % "1.1.32-SNAPSHOT",
     "org.clulab"          %%  "fatdynet"                 % "0.2.5",
 
     // logging


### PR DESCRIPTION
This PR builds on https://github.com/clulab/bioresources/pull/31, https://github.com/clulab/bioresources/pull/32 and https://github.com/clulab/bioresources/pull/33 to add ChEBI as a source of chemical names in addition to PubChem, GO synonyms and names for biological processes, and a new list of stopwords.