### PR TITLE
Remove deprecated output formats from conf and export

### DIFF
--- a/export/src/main/resources/org/clulab/reach/export/server/static/api.html
+++ b/export/src/main/resources/org/clulab/reach/export/server/static/api.html
@@ -111,7 +111,7 @@
                   <label class="kvKey">Options:</label>
                   <span class="kvValue">
                     The optional <b>form</b> argument <code>output</code> selects an output format:
-                    arizona, cmu, csv, indexcard, serial-json, or fries (the default).
+                    indexcard, serial-json, or fries (the default).
                   </span>
                 </div>
                 <div>
@@ -129,7 +129,7 @@
                       curl 'http://localhost:8080/api/text?text=Akt1+phosphorylates+mek1&output=serial-json'
                     </div>
                     <div class="example">
-                      curl 'http://localhost:8080/api/text?text=Akt1%20phosphorylates%20mek1&output=csv'
+                      curl 'http://localhost:8080/api/text?text=Akt1%20phosphorylates%20mek1&output=fries'
                     </div>
                   </span>
                   </div>
@@ -157,7 +157,7 @@
                   <label class="kvKey">Options:</label>
                   <span class="kvValue">
                     The optional <b>body</b> argument <code>output</code> selects an output format:
-                    arizona, cmu, csv, indexcard, serial-json, or fries (the default).
+                    indexcard, serial-json, or fries (the default).
                   </span>
                 </div>
                 <div>
@@ -172,16 +172,16 @@
                       curl -XPOST -d 'text=Akt1%20phosphorylates%20mek1' 'http://localhost:8080/api/textBody'
                     </div>
                     <div class="example">
-                      curl -XPOST -d 'text=akt1+phosphorylates+mek1&output=csv' 'http://localhost:8080/api/textBody'
+                      curl -XPOST -d 'text=akt1+phosphorylates+mek1&output=fries' 'http://localhost:8080/api/textBody'
                     </div>
                     <div class="example">
-                      curl -XPOST -d 'text=akt1+phosphorylates+mek1' -d 'output=csv' 'http://localhost:8080/api/textBody'
+                      curl -XPOST -d 'text=akt1+phosphorylates+mek1' -d 'output=fries' 'http://localhost:8080/api/textBody'
                     </div>
                     <div class="example">
-                      curl -XPOST -d 'output=cmu' --data 'text=The+inhibition+of+AICAR+suppresses+the+phosphorylation+of+TBC1D1.' 'http://localhost:8080/api/textBody'
+                      curl -XPOST -d 'output=fries' --data 'text=The+inhibition+of+AICAR+suppresses+the+phosphorylation+of+TBC1D1.' 'http://localhost:8080/api/textBody'
                     </div>
                     <div class="example">
-                      curl -XPOST -d 'output=cmu' --data-urlencode 'text=The inhibition of AICAR suppresses the phosphorylation of TBC1D1.' 'http://localhost:8080/api/textBody'
+                      curl -XPOST -d 'output=fries' --data-urlencode 'text=The inhibition of AICAR suppresses the phosphorylation of TBC1D1.' 'http://localhost:8080/api/textBody'
                     </div>
                     <div class="example">
                       curl -XPOST --data-urlencode 'text=TopBP1 promotes the phosphorylation of cyclin-D1 by ATR.' 'http://localhost:8080/api/textBody'
@@ -212,7 +212,7 @@
                   <label class="kvKey">Options:</label>
                   <span class="kvValue">
                     The optional <b>query</b> argument <code>output</code> selects an output format:
-                    arizona, cmu, csv, indexcard, serial-json, or fries (the default).
+                    indexcard, serial-json, or fries (the default).
                   </span>
                 </div>
                 <div>
@@ -224,10 +224,10 @@
                       curl -XPOST -F 'file=@infile.txt' 'http://localhost:8080/api/uploadFile'
                     </div>
                     <div class="example">
-                      curl -XPOST -F 'file=@myFile -F 'output=cmu' 'http://localhost:8080/api/uploadFile'
+                      curl -XPOST -F 'file=@myFile -F 'output=fries' 'http://localhost:8080/api/uploadFile'
                     </div>
                     <div class="example">
-                      curl -XPOST -F 'file=@some.text' -F 'output=csv' 'http://localhost:8080/api/uploadFile'
+                      curl -XPOST -F 'file=@some.text' -F 'output=fries' 'http://localhost:8080/api/uploadFile'
                     </div>
                     <div class="example">
                       curl -XPOST -F 'file=@PMC1240239.nxml' 'http://localhost:8080/api/uploadFile'
@@ -236,7 +236,7 @@
                       curl -XPOST -F 'file=@myFile.xml -F 'output=serial-json' 'http://localhost:8080/api/uploadFile'
                     </div>
                     <div class="example">
-                      curl -XPOST -F 'file=@some.nxml -F 'output=csv' 'http://localhost:8080/api/uploadFile'
+                      curl -XPOST -F 'file=@some.nxml -F 'output=fries' 'http://localhost:8080/api/uploadFile'
                     </div>
                     <div class="example">
                       curl -XPOST -F 'file=@PMCfake.nxml -F 'output=fries' 'http://localhost:8080/api/uploadFile'

--- a/export/src/main/resources/org/clulab/reach/export/server/static/fileUpload.html
+++ b/export/src/main/resources/org/clulab/reach/export/server/static/fileUpload.html
@@ -81,9 +81,6 @@
           Next, select the desired output format for the results:
           <ul>
             <li><b>fries</b>, for FRIES Consortium JSON (the default),</li>
-            <li><b>csv</b>, for the Arizona tab-separated output format,</li>
-            <li><b>tsv</b>, for the Arizona tab-separated output format,</li>
-            <li><b>cmu</b>, for another tab-separated output format,</li>
             <li><b>indexcard</b>, for MITRE IndexCard JSON,</li>
             <li>
               <b>serial-json</b>, for a JSON serialization of the entire Reach internal document
@@ -136,8 +133,6 @@
               <label class="bigLabel" for="outputFormat">Output Format:
                 <select class="form-control col-xs-4 indented down10" name="output" id="output">
                   <option value="fries">FRIES Consortium JSON format</option>
-                  <option value="csv">Arizona (tab-separated columnar format)</option>
-                  <option value="cmu">CMU (tab-separated columnar format)</option>
                   <option value="indexcard">MITRE Indexcard JSON format</option>
                   <option value="serial-json">Serial-JSON (serialization of document structures)</option>
                 </select>

--- a/export/src/main/scala/org/clulab/reach/export/server/ApiServer.scala
+++ b/export/src/main/scala/org/clulab/reach/export/server/ApiServer.scala
@@ -71,10 +71,6 @@ trait ApiImpl {
     case "fries"       => ContentTypes.`application/json`
     case "indexcard"   => ContentTypes.`application/json`
     case "serial-json" => ContentTypes.`application/json`
-    case "arizona"     => ContentTypes.`text/csv(UTF-8)`
-    case "cmu"         => ContentTypes.`text/csv(UTF-8)`
-    case "csv"         => ContentTypes.`text/csv(UTF-8)`
-    case "tsv"         => ContentTypes.`text/csv(UTF-8)`
     case _             => ContentTypes.`text/plain(UTF-8)`
   }
 
@@ -83,10 +79,6 @@ trait ApiImpl {
     case "fries"       => "json"
     case "indexcard"   => "json"
     case "serial-json" => "json"
-    case "arizona"     => "tsv"
-    case "cmu"         => "tsv"
-    case "csv"         => "tsv"
-    case "tsv"         => "tsv"
     case _             => "json"
   }
 

--- a/main/src/main/resources/application.conf
+++ b/main/src/main/resources/application.conf
@@ -30,12 +30,10 @@ encoding = "utf-8"
 ignoreSections = ["references", "materials", "materials|methods", "methods", "supplementary-material"]
 
 # the output formats for mentions:
-# "arizona" (column-based, one file per paper)
-# "cmu" (column-based, one file per paper)
 # "fries" (multiple JSON files per paper)
 # "serial-json" (JSON serialization of mentions data structures. LARGE output!)
 # "text" (non-JSON textual format)
-outputTypes = ["fries", "arizona", "cmu"]
+outputTypes = ["fries"]
 
 # number of simultaneous threads to use for parallelization
 threadLimit = 2


### PR DESCRIPTION
In #667, the cmu, arizona, csv and tsv formats were removed but application.conf still listed these meaning the CLI would fail unless they were removed manually. This PR removes these from application.conf and also from various files in the export module where they appear.