### PR TITLE
Integrate Disease entity type and grounding

### DIFF
--- a/main/src/main/resources/org/clulab/reach/biogrammar/entities/entities.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/entities/entities.yml
@@ -241,6 +241,15 @@
   pattern: |
     [entity='B-BioProcess'] [entity='I-BioProcess']*
 
+- name: ner-disease-entities
+  label: Disease
+  action: mkNERMentions
+  example: "cystic fibrosis"
+  priority: 3
+  type: token
+  pattern: |
+    [entity='B-Disease'] [entity='I-Disease']*
+
 # TODO: Ideally, this should somehow be added to the KB
 - name: missing-simple_chemical
   label: Simple_chemical

--- a/main/src/main/resources/org/clulab/reach/biogrammar/taxonomy.yml
+++ b/main/src/main/resources/org/clulab/reach/biogrammar/taxonomy.yml
@@ -67,6 +67,7 @@
     - Entity:
       # Any BioEntity may appear as the controlled in an Activation
       - BioEntity:
+          - Disease
           - BioProcess   # ex. "apoptosis"
           - BioChemicalEntity:
               - Generic_entity

--- a/main/src/main/scala/org/clulab/reach/grounding/EntityChecker.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/EntityChecker.scala
@@ -34,6 +34,9 @@ object EntityChecker extends App with LazyLogging {
   /** Search sequence for sub cellular locations terms. */
   protected val cellLocationSearcher = Seq( staticCellLocationKBLookup )
 
+  /** Search sequence for disease terms. */
+  protected val diseaseSearcher = Seq( staticDiseaseKBLookup )
+
 
   /** Read the BioPAX model from the given input stream and check the entities. */
   def readAndCheckBioPax (fis:InputStream) = {

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
@@ -85,6 +85,7 @@ class ReachEntityLookup {
 
   // instantiate the various search sequences, each sequence for a different label:
   val bioProcessSeq: KBSearchSequence = extraKBs ++ Seq( StaticBioProcess )
+  val diseaseSeq: KBSearchSequence = extraKBs ++ Seq( StaticDisease )
   val cellTypeSeq: KBSearchSequence = extraKBs ++ Seq( ContextCellType )
 
   val cellLineSeq: KBSearchSequence = extraKBs ++ Seq(

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
@@ -45,6 +45,7 @@ class ReachEntityLookup {
       case "Cellular_component" => augmentMention(mention, cellComponentSeq)
       case "Complex" | "GENE" | "Gene_or_gene_product" | "Protein" =>
         augmentMention(mention, proteinSeq)
+      case "Disease" =>  augmentMention(mention, diseaseSeq)
       case "Family" =>  augmentMention(mention, familySeq)
       case "Organ" => augmentMention(mention, organSeq)
       case "Simple_chemical" => augmentMention(mention, chemicalSeq)

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBLookups.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBLookups.scala
@@ -146,4 +146,15 @@ object ReachIMKBLookups {
     val keyTransforms = new KBKeyTransformsGroup(DefaultKeyTransforms, FamilyAuxKeyTransforms, DefaultKeyTransforms)
     new IMKBLookup(TsvIMKBFactory.make(metaInfo, keyTransforms))
   }
+
+  /** KB lookup to resolve disease names via static KB. */
+  def staticDiseaseKBLookup: IMKBLookup = {
+    val metaInfo = new IMKBMetaInfo(
+      kbFilename = Some(StaticDiseaseFilename),
+      namespace = "mesh",
+      baseURI = "http://identifiers.org/mesh/",
+      resourceId = "MIR:00000560"
+    )
+    new IMKBLookup(TsvIMKBFactory.make(metaInfo))
+  }
 }

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
@@ -26,6 +26,7 @@ object ReachIMKBMentionLookups {
   val ContextTissueType = contextTissueTypeKBML
 
   val StaticBioProcess = staticBioProcessKBML
+  val StaticDisease = staticDiseaseKBML
   val StaticCellLocation = staticCellLocationKBML   // GO subcellular KB
   val StaticCellLocation2 = staticCellLocation2KBML // Uniprot subcellular KB
   val StaticChemical = staticChemicalKBML
@@ -35,6 +36,7 @@ object ReachIMKBMentionLookups {
   val StaticProtein = staticProteinKBML
   val StaticGene = staticGeneKBML
   val staticProteinFamilyOrComplex = staticProteinFamilyOrComplexKBML
+  val staticDisease = staticDiseaseKBML
 
   val StaticProteinFamily = staticProteinFamilyKBML
   val StaticProteinFamily2 = staticProteinFamily2KBML
@@ -232,6 +234,17 @@ object ReachIMKBMentionLookups {
     )
     val keyTransforms = new KBKeyTransformsGroup(DefaultKeyTransforms, FamilyAuxKeyTransforms, DefaultKeyTransforms)
     new IMKBMentionLookup(TsvIMKBFactory.make(metaInfo, keyTransforms))
+  }
+
+  /** KB accessor to resolve disease names via static KB. */
+  def staticDiseaseKBML: IMKBMentionLookup = {
+    val metaInfo = new IMKBMetaInfo(
+      namespace = "mesh",
+      kbFilename = Some(StaticDiseaseFilename),
+      baseURI = "http://identifiers.org/mesh/",
+      resourceId = "MIR:00000560"
+    )
+    new IMKBMentionLookup(TsvIMKBFactory.make(metaInfo))
   }
 
 

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
@@ -36,7 +36,6 @@ object ReachIMKBMentionLookups {
   val StaticProtein = staticProteinKBML
   val StaticGene = staticGeneKBML
   val staticProteinFamilyOrComplex = staticProteinFamilyOrComplexKBML
-  val staticDisease = staticDiseaseKBML
 
   val StaticProteinFamily = staticProteinFamilyKBML
   val StaticProteinFamily2 = staticProteinFamily2KBML

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
@@ -79,6 +79,9 @@ object ReachKBConstants {
   /** Filename of the static protein family or complex file. */
   val StaticProteinFamilyOrComplexFilename = "famplex.tsv.gz"
 
+  /** Filename of the static disease file. */
+  val StaticDiseaseFilename = "mesh_disease.tsv.gz"
+
   /** Filename of the context species file */
   val ContextSpeciesFilename = "Species.tsv.gz"
 

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
@@ -80,7 +80,7 @@ object ReachKBConstants {
   val StaticProteinFamilyOrComplexFilename = "famplex.tsv.gz"
 
   /** Filename of the static disease file. */
-  val StaticDiseaseFilename = "mesh_disease.tsv.gz"
+  val StaticDiseaseFilename = "mesh-disease.tsv.gz"
 
   /** Filename of the context species file */
   val ContextSpeciesFilename = "Species.tsv.gz"

--- a/main/src/test/scala/org/clulab/reach/TestAmountEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestAmountEvents.scala
@@ -16,10 +16,4 @@ class TestAmountEvents extends FlatSpec with Matchers {
     val mentions = getBioMentions(sent2)
     hasEventWithArguments("DecreaseAmount", Seq("MMP-9"), mentions) should be (true)
   }
-
-  val sent3 = "The knockdown of p65 impaired the induction of CXCL10"
-  sent2 should "have a Increase_amount event of CXCL10" in {
-    val mentions = getBioMentions(sent2)
-    hasEventWithArguments("IncreaseAmount", Seq("CXCL10"), mentions) should be (true)
-  }
 }

--- a/main/src/test/scala/org/clulab/reach/TestAmountEvents.scala
+++ b/main/src/test/scala/org/clulab/reach/TestAmountEvents.scala
@@ -16,4 +16,10 @@ class TestAmountEvents extends FlatSpec with Matchers {
     val mentions = getBioMentions(sent2)
     hasEventWithArguments("DecreaseAmount", Seq("MMP-9"), mentions) should be (true)
   }
+
+  val sent3 = "The knockdown of p65 impaired the induction of CXCL10"
+  sent2 should "have a Increase_amount event of CXCL10" in {
+    val mentions = getBioMentions(sent2)
+    hasEventWithArguments("IncreaseAmount", Seq("CXCL10"), mentions) should be (true)
+  }
 }

--- a/processors/build.sbt
+++ b/processors/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= {
     "org.clulab"          %%  "processors-main"          % procVer,
     "org.clulab"          %%  "processors-corenlp"       % procVer,
     "org.clulab"          %%  "processors-odin"          % procVer,
-    "org.clulab"           %  "bioresources"             % "1.1.32",
+    "org.clulab"           %  "bioresources"             % "1.1.33-SNAPSHOT",
     "org.clulab"          %%  "fatdynet"                 % "0.2.5",
 
     // logging

--- a/processors/build.sbt
+++ b/processors/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= {
     "org.clulab"          %%  "processors-main"          % procVer,
     "org.clulab"          %%  "processors-corenlp"       % procVer,
     "org.clulab"          %%  "processors-odin"          % procVer,
-    "org.clulab"           %  "bioresources"             % "1.1.33-SNAPSHOT",
+    "org.clulab"           %  "bioresources"             % "1.1.33",
     "org.clulab"          %%  "fatdynet"                 % "0.2.5",
 
     // logging

--- a/processors/src/main/resources/reference.conf
+++ b/processors/src/main/resources/reference.conf
@@ -13,6 +13,7 @@ kbloader: {
     "org/clulab/reach/kb/ner/Simple_chemical.tsv.gz",
     "org/clulab/reach/kb/ner/Site.tsv.gz",
     "org/clulab/reach/kb/ner/BioProcess.tsv.gz",
+    "org/clulab/reach/kb/ner/Disease.tsv.gz",
     "org/clulab/reach/kb/ner/Species.tsv.gz",
     "org/clulab/reach/kb/ner/CellLine.tsv.gz",
     "org/clulab/reach/kb/ner/TissueType.tsv.gz",


### PR DESCRIPTION
This PR adds a new entity type called Disease, and integrates MeSH groundings for diseases from bioresources (https://github.com/clulab/bioresources/pull/34).