### PR TITLE
Added missing ai.lum.common dependency

### DIFF
--- a/processors/build.sbt
+++ b/processors/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= {
 
   Seq(
     "com.typesafe"         %  "config"      % "1.3.1",
-
+        "ai.lum"          %% "common"                    % "0.1.2",
     "org.clulab"          %%  "processors-main"          % procVer,
     "org.clulab"          %%  "processors-corenlp"       % procVer,
     "org.clulab"          %%  "processors-odin"          % procVer,


### PR DESCRIPTION
`ai.lum.common` is used in several places in a couple of subprojects, but it isn't included as an explicit dependency anywhere.

This can lead to compatibility issues in other projects that depend on reach, but use different versions of `ai.lum.common`.