### PR TITLE
Fix ubuntu version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:bionic
 
 # Install basic packages
 RUN apt-get update && apt-get install -y git vim wget build-essential \


### PR DESCRIPTION
This PR just fixes the Docker build's Ubuntu version to `bionic` since the build doesn't work with the current `latest`.