### PR TITLE
Remove references to separate HGNC resource

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 #Changes
 =======
++ **1.6.2** - Update bioresources to 1.1.38
 + **1.6.2** - Update bioresources to 1.1.36 and processors to 8.2.4.
 + **1.6.2** - Fix bugs related to OS and library dependency compatibility, bounds checking, serialization of newer Modifications, and output consistency
 + **1.6.2** - Added the `assembly` subproject back. The `arizona` and `cmu` formats are supported again.

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachEntityLookup.scala
@@ -120,7 +120,6 @@ class ReachEntityLookup {
   val proteinSeq: KBSearchSequence = extraKBs ++ Seq(
     StaticProteinFragment, // TODO: for now fragments have higher priority
     StaticProtein,                          // Uniprot proteins
-    StaticGene,
     ModelGendProteinAndFamily
   )
 

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBLookups.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBLookups.scala
@@ -93,20 +93,7 @@ object ReachIMKBLookups {
     val keyTransforms = new KBKeyTransformsGroup(DefaultKeyTransforms, ProteinAuxKeyTransforms, DefaultKeyTransforms)
     new IMKBLookup(TsvIMKBFactory.make(metaInfo, keyTransforms))
   }
-  
-  /** KB accessor to resolve human gene names via static KB. */
-  def staticGeneKBLookup: IMKBLookup = {
-    val metaInfo = new IMKBMetaInfo(
-      namespace = "uniprot",
-      kbFilename = Some(StaticGeneFilename),
-      baseURI = "http://identifiers.org/uniprot/",
-      resourceId = "MIR:00100164",
-      hasSpeciesInfo = true,
-      isProteinKB = true
-    )
-    val keyTransforms = new KBKeyTransformsGroup(DefaultKeyTransforms, ProteinAuxKeyTransforms, DefaultKeyTransforms)
-    new IMKBLookup(TsvIMKBFactory.make(metaInfo, keyTransforms))
-  }
+
 
   /** KB accessor to resolve protein family and complex names via static KBs with alternate lookups. */
   def staticFamilyOrComplexKBLookup: IMKBLookup = {

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachIMKBMentionLookups.scala
@@ -35,7 +35,6 @@ object ReachIMKBMentionLookups {
   // val StaticMetabolite = staticMetaboliteKBML    // Replaced by PubChem
   val StaticProtein = staticProteinKBML
   val StaticProteinFragment = staticProteinFragmentKBML
-  val StaticGene = staticGeneKBML
   val staticProteinFamilyOrComplex = staticProteinFamilyOrComplexKBML
 
   val StaticProteinFamily = staticProteinFamilyKBML
@@ -175,20 +174,6 @@ object ReachIMKBMentionLookups {
     val metaInfo = new IMKBMetaInfo(
       namespace = "proonto", // the Protein Ontology
       kbFilename = Some(StaticProteinFragmentFilename),
-      isProteinKB = true
-    )
-    val keyTransforms = new KBKeyTransformsGroup(DefaultKeyTransforms, ProteinAuxKeyTransforms, DefaultKeyTransforms)
-    new IMKBMentionLookup(TsvIMKBFactory.make(metaInfo, keyTransforms))
-  }
-
-  /** KB accessor to resolve human gene names via static KB. */
-  def staticGeneKBML: IMKBMentionLookup = {
-    val metaInfo = new IMKBMetaInfo(
-      namespace = "uniprot",
-      kbFilename = Some(StaticGeneFilename),
-      baseURI = "http://identifiers.org/uniprot/",
-      resourceId = "MIR:00100164",
-      hasSpeciesInfo = true,
       isProteinKB = true
     )
     val keyTransforms = new KBKeyTransformsGroup(DefaultKeyTransforms, ProteinAuxKeyTransforms, DefaultKeyTransforms)

--- a/main/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/ReachKBConstants.scala
@@ -69,9 +69,6 @@ object ReachKBConstants {
 
   /** Filename containing protein fragments from the Protein Ontology */
   val StaticProteinFragmentFilename = "protein-ontology-fragments.tsv.gz"
-  
-  /** Filename for the static human gene fine. */
-  val StaticGeneFilename = "hgnc.tsv.gz"
 
   /** Filename of the static protein family file. */
   val StaticProteinFamilyFilename = "PFAM-families.tsv.gz"

--- a/processors/build.sbt
+++ b/processors/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= {
     "org.clulab"          %%  "processors-main"          % procVer,
     "org.clulab"          %%  "processors-corenlp"       % procVer,
     "org.clulab"          %%  "processors-odin"          % procVer,
-    "org.clulab"           %  "bioresources"             % "1.1.37",
+    "org.clulab"           %  "bioresources"             % "1.1.38",
     "org.clulab"          %%  "fatdynet"                 % "0.2.5",
 
     "ai.lum" %% "common" % "0.1.4",


### PR DESCRIPTION
This corresponds to https://github.com/clulab/bioresources/pull/56 and should be tested/merged once https://github.com/clulab/bioresources/pull/56 is merged and released. It removes references to a separate HGNC resource file.