### PR TITLE
Context Module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -96,10 +96,16 @@ lazy val processors = project
 lazy val main = project
   .settings(commonSettings:_*)
   .dependsOn(processors % "test->test;compile->compile")
+//  .dependsOn(context  % "test->test;compile->compile")
 
 lazy val causalAssembly = project.in(file("assembly"))
   .settings(commonSettings:_*)
   .dependsOn(main % "test->test;compile->compile")
+
+lazy val context = project.in(file("context"))
+  .settings(commonSettings:_*)
+  .dependsOn(main % "test->test;compile->compile")
+
 
 lazy val export = project
   .settings(commonSettings:_*)

--- a/context/build.sbt
+++ b/context/build.sbt
@@ -1,0 +1,1 @@
+name := "reach-context"

--- a/context/src/main/scala/org/clulab/reach/context/engine/SVMContextEngine.scala
+++ b/context/src/main/scala/org/clulab/reach/context/engine/SVMContextEngine.scala
@@ -1,0 +1,30 @@
+package org.clulab.reach.context.engine
+
+import org.clulab.reach.context.ContextEngine
+import org.clulab.reach.mentions.BioMention
+
+import java.io.File
+
+/**
+  * Create SVM based context engine from model file
+  * @param modelFile File object with the model's parameters
+  */
+class SVMContextEngine(modelFile: File) extends ContextEngine {
+
+  /**
+    * Create context engine from model path
+    * @param modelPath path to the file with the model's parameters
+    */
+  def this(modelPath: String) = this(new File(modelPath))
+
+  // TODO: Load the contents of modelFile into whatever wrapper/facade structure to the svm classifier
+
+  /** initializes any data structure that needs to be initialized */
+  override def infer(mentions: Seq[BioMention]): Unit = ???
+
+  /** updates those data structures with any new info */
+  override def update(mentions: Seq[BioMention]): Unit = ???
+
+  /** assigns context to mentions given current state of the engine */
+  override def assign(mentions: Seq[BioMention]): Seq[BioMention] = ???
+}

--- a/context/src/main/scala/org/clulab/reach/context/train/TrainSVMClassifier.scala
+++ b/context/src/main/scala/org/clulab/reach/context/train/TrainSVMClassifier.scala
@@ -1,0 +1,8 @@
+package org.clulab.reach.context.train
+
+/**
+  * Trains an SVM to be used by an SVMContext engine
+  */
+object TrainSVMClassifier extends App {
+  // TODO: Implement this
+}

--- a/context/src/main/scala/org/clulab/reach/context/train/dataset/FindIntersection.scala
+++ b/context/src/main/scala/org/clulab/reach/context/train/dataset/FindIntersection.scala
@@ -1,0 +1,70 @@
+package org.clulab.reach.context.train.dataset
+
+import com.typesafe.config.ConfigFactory
+import org.clulab.reach.context.utils
+import org.clulab.reach.context.utils.PaperExtraction
+import org.clulab.struct.Interval
+
+import scala.collection.mutable.ListBuffer
+
+/**
+  * Utility to compute the intersection of the annotated events and the paper extractions
+  */
+object FindIntersection extends App {
+
+  val config = ConfigFactory.load().getConfig("findIntersection")
+
+  val inputPaperData = config.getString("inputPaperData")
+  val inputExtractions = config.getString("inputExtractions")
+
+  def getIntersection(left: Seq[PaperExtraction], right: Seq[PaperExtraction]): Seq[PaperExtraction] = {
+    // Small helper function
+    def intersects(a: Interval, b: Interval): Boolean = {
+      val (shorter, longer) = if (a.size <= b.size) (a, b) else (b, a)
+      if (longer contains shorter)
+        true
+      else if (shorter.intersect(longer).nonEmpty)
+        true
+      else
+        false
+    }
+
+    val sentences =
+      ((left map (_.sent)) ++
+        (right map (_.sent))).distinct
+
+    val gpBySentLeft = left.groupBy(_.sent)
+    val gpBySentRight = right.groupBy(_.sent)
+
+    val intersection = ListBuffer[PaperExtraction]()
+
+    for (sentIx <- sentences) {
+      if ((gpBySentLeft contains sentIx) && (gpBySentRight contains sentIx)) {
+        for {
+          l <- gpBySentLeft(sentIx)
+          r <- gpBySentRight(sentIx)
+        } {
+          if (intersects(l.interval, r.interval))
+            intersection += l
+        }
+      }
+    }
+
+    intersection.toList.distinct
+  }
+
+  val parsedAnnotations = utils.readSerializedPaperAnnotations(inputPaperData)
+  val reachExtractions = utils.readSerializedExtractions(inputExtractions)
+
+  val parsedEvents = parsedAnnotations.mapValues(t => utils.getEvents(t.extractions))
+  val reachEvents = reachExtractions.mapValues(utils.getEvents)
+
+  for (pmcid <- parsedEvents.keys) yield {
+    val parsed = parsedEvents(pmcid)
+    val extracted = reachEvents(pmcid)
+    val intersection = getIntersection(parsed, extracted)
+
+
+    println(s"$pmcid Original size: ${parsed.size}, Extracted size: ${extracted.distinct.size}, Intersection: ${intersection.size}")
+  }
+}

--- a/context/src/main/scala/org/clulab/reach/context/train/dataset/GeneratePairs.scala
+++ b/context/src/main/scala/org/clulab/reach/context/train/dataset/GeneratePairs.scala
@@ -1,0 +1,63 @@
+package org.clulab.reach.context.train.dataset
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
+import org.clulab.reach.context.utils
+import org.clulab.reach.context.utils.{Pair, PaperExtraction}
+import org.clulab.utils.Serializer
+
+/**
+  * Create the raw entity pairs to be used for feature extraction down the pipeline
+  */
+object GeneratePairs extends App with LazyLogging {
+
+  val config = ConfigFactory.load().getConfig("generatePairs")
+  val inputPaperData = config.getString("inputPaperData")
+  val inputExtractions = config.getString("inputExtractions")
+  val outputPairsPath = config.getString("outputFile")
+
+  def generatePairs(paperData: ManuallyAnnotatedData, extractions: Seq[PaperExtraction], validContextIds: Set[String]): Iterable[Pair] = {
+    val annotations = paperData.annotations
+    val textBoundMentions = extractions filter (m => m.grounding != "Event")
+
+    for {
+      (event, positiveClasses) <- annotations
+      mention <- textBoundMentions
+      if validContextIds contains mention.grounding
+    } yield {
+      if (positiveClasses contains mention.grounding)
+        Pair(event, mention, isContext = true)
+      else
+        Pair(event, mention, isContext = false)
+    }
+  }
+
+  // First read the annotations
+  logger.info(s"Loading annotations from $inputPaperData")
+  val paperAnnotations = utils.readSerializedPaperAnnotations(inputPaperData)
+
+  // Then generate the set of candidate context mentions acceptable
+  val validContexts =
+    utils.generateValidContextIds(paperAnnotations)
+
+  // Then read the extractions
+  logger.info(s"Loading extractions from $inputExtractions")
+  val paperExtractions = utils.readSerializedExtractions(inputExtractions)
+
+  // Now generate the pairs
+  val pairs =
+    for ((pmcid, annotations) <- paperAnnotations)
+      yield {
+        logger.info(s"Generating pairs for $pmcid")
+        val extractions = paperExtractions(pmcid)
+        val pairs = generatePairs(annotations, extractions, validContexts)
+
+        // Count the distribution of labels for the current paper
+        logger.info(s"$pmcid has ${pairs.count(_.isContext)} out of ${pairs.size}")
+        pmcid -> pairs
+      }
+
+  // Finally serialize the results
+  logger.info(s"Saving pairs to $outputPairsPath")
+  Serializer.save(pairs, outputPairsPath)
+}

--- a/context/src/main/scala/org/clulab/reach/context/train/dataset/GenerateReachAnnotations.scala
+++ b/context/src/main/scala/org/clulab/reach/context/train/dataset/GenerateReachAnnotations.scala
@@ -1,0 +1,70 @@
+package org.clulab.reach.context.train.dataset
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
+import org.clulab.processors.Document
+import org.clulab.processors.bionlp.BioNLPProcessor
+import org.clulab.reach.context.utils.PaperExtraction
+import org.clulab.reach.mentions.{BioEventMention, BioMention, BioTextBoundMention}
+import org.clulab.utils.Serializer
+
+import java.io.File
+import scala.io.Source
+
+/**
+  * Generates REACH annotations for the papers given the version configured in build.sbt
+  */
+object GenerateReachAnnotations extends App with LazyLogging {
+
+  val config = ConfigFactory.load().getConfig("generateReachAnnotations")
+
+  val paperFilesDir = config.getString("filesDirectory")
+  val outputPath = config.getString("outputFile")
+
+  def readTokens(path: String): Seq[Seq[String]] = {
+    val lines = Source.fromFile(path).getLines().toList
+    val tokens = lines map (_.split(" ").toList)
+    tokens
+  }
+
+  def extractFrom(path: String): (Seq[BioMention], Document) = {
+    val tokens = readTokens(path + "/sentences.txt")
+
+    val doc = procAnnotator.mkDocumentFromTokens(tokens)
+    doc.id = Some(path)
+    doc.text = Some(tokens.map(_.mkString(" ")).mkString("\n"))
+    procAnnotator.annotate(doc)
+
+    (reachSystem extractFrom doc, doc)
+  }
+
+  // initialize ReachSystem
+  logger.info(s"Loading BioNLPProcessor and REACH")
+  val procAnnotator = new BioNLPProcessor()
+  procAnnotator.annotate("test")
+  val reachSystem = new ReachSystem(processorAnnotator = Some(procAnnotator)) // This line for REACH 2020
+
+  val directories = for {f <- new File(paperFilesDir).listFiles(); if f.isDirectory} yield f
+
+  val data =
+    (for {dir <- directories.par} yield {
+      val path = dir.getAbsolutePath
+      val pmcid = dir.getName
+      logger.info(s"Processing $pmcid ...")
+      val (extractions, doc) = extractFrom(path)
+      logger.info(s"Finished $pmcid")
+      val tups =
+        extractions collect {
+          case e: BioEventMention =>
+            PaperExtraction(e.sentence, e.tokenInterval, e.text, "Event")
+          case m: BioTextBoundMention =>
+            PaperExtraction(m.sentence, m.tokenInterval, m.text, m.grounding match { case Some(kb) => kb.nsId; case None => "" })
+        }
+      pmcid -> (tups, doc)
+    }).seq
+
+
+  logger.info(s"Saving output into $outputPath")
+  Serializer.save(data, outputPath)
+
+}

--- a/context/src/main/scala/org/clulab/reach/context/train/dataset/ParsePaperFiles.scala
+++ b/context/src/main/scala/org/clulab/reach/context/train/dataset/ParsePaperFiles.scala
@@ -1,0 +1,161 @@
+package org.clulab.reach.context.train.dataset
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
+import org.clulab.reach.context.utils.PaperExtraction
+import org.clulab.struct.Interval
+import org.clulab.utils.Serializer
+
+import java.io.File
+import scala.io.Source
+
+case class ManuallyAnnotatedData(extractions: Seq[PaperExtraction], annotations: Map[PaperExtraction, Seq[String]])
+
+/**
+ * Parses the original paper files into data structures suitable for the rest of the pipeline
+ */
+object ParsePaperFiles extends App with LazyLogging {
+
+  val config = ConfigFactory.load().getConfig("parsePaperFiles")
+
+  val dir = config.getString("filesDirectory")
+  val outputPath = config.getString("outputFile")
+
+  def parsePaperFiles(dirPath: String): ManuallyAnnotatedData = {
+    // First the event intervals
+    val dir = new File(dirPath)
+    val eventsFile = new File(dir, "event_intervals.txt")
+    val annotatedEventsFile = new File(dir, "annotated_event_intervals.tsv")
+    val mentionsFile = new File(dir, "mention_intervals.txt")
+    val manualMentionsFile = new File(dir, "manual_context_mentions.tsv")
+    val textFile = new File(dir, "sentences.txt")
+
+    val docTokens = readText(textFile)
+
+    val (annotatedEventsIntervals, eventAnnotations) = parsedAnnotatedEvents(annotatedEventsFile, docTokens)
+
+    ManuallyAnnotatedData(
+      (parseEvents(eventsFile, docTokens) ++
+        annotatedEventsIntervals ++
+        parseMentions(mentionsFile, docTokens) ++
+        parseManualMentions(manualMentionsFile, docTokens)).distinct,
+      eventAnnotations)
+  }
+
+  def parseEvents(file: File, docTokens: Array[Array[String]]): Seq[PaperExtraction] = {
+    val src = Source.fromFile(file)
+    val lines = src.getLines().toList
+    src.close()
+
+    lines flatMap {
+      line =>
+        val tokens = line.split(" ")
+        val sent = tokens(0).toInt
+        val intervals = tokens.tail map {
+          tok =>
+            val nums = tok.split("-")
+            val (start, end) = (nums(0), nums(1))
+            Interval(start.toInt, end.toInt + 1)
+        }
+
+        for (interval <- intervals) yield {
+          val text = docTokens(sent).slice(interval.start, interval.end).mkString(" ")
+          PaperExtraction(sent, interval, text, "Event")
+        }
+    }
+  }
+
+  def parsedAnnotatedEvents(file:File,docTokens:Array[Array[String]]):(Seq[PaperExtraction], Map[PaperExtraction, Seq[String]]) = {
+    val src = Source.fromFile(file)
+    val lines = src.getLines().toList
+    src.close()
+
+
+    val (extractions, rawAnnotations) =
+      (lines map {
+        line =>
+          val tokens = line.split("\t")
+          val sent = tokens(0).toInt
+
+          val nums = tokens(1).split("-")
+          val (start, end) = (nums(0), nums(1))
+          val ids =
+            if (tokens.length == 3)
+              tokens(2).split(",").toSeq
+            else
+              Seq()
+          val interval = Interval(start.toInt, end.toInt + 1)
+          val text = docTokens(sent).slice(interval.start, interval.end).mkString(" ")
+
+
+          (PaperExtraction(sent, interval, text, "Event"), ids)
+
+      }).unzip
+
+    val annotations = (extractions zip rawAnnotations).toMap
+
+    (extractions, annotations)
+  }
+
+  def parseMentions(mentionsFile: File, docTokens:Array[Array[String]]) = {
+    val src = Source.fromFile(mentionsFile)
+    val lines = src.getLines().toList
+    src.close()
+
+    lines flatMap {
+      line =>
+        val tokens = line.split(" ")
+        val sent = tokens(0).trim().toInt
+
+        tokens.tail map {
+          elem =>
+            val tokens = elem.split("%")
+            val (start, end) = (tokens(0), tokens(1))
+            val id = tokens(3)
+            val interval = Interval(start.toInt, end.toInt + 1)
+            val text = docTokens(sent).slice(interval.start, interval.end).mkString(" ")
+
+
+            PaperExtraction(sent, interval, text, id)
+        }
+    }
+  }
+
+  def readText(textFile: File): Array[Array[String]] = {
+    val src = Source.fromFile(textFile)
+    val lines = src.getLines().toArray
+    src.close()
+
+    lines map (_.split(" "))
+  }
+
+  def parseManualMentions(manualMentionsFile: File, docTokens: Array[Array[String]]) = {
+    val src = Source.fromFile(manualMentionsFile)
+    val lines = src.getLines().toList
+    src.close()
+
+    lines map {
+      line =>
+        val tokens = line.split("\t")
+        val sent = tokens(0).toInt
+
+        val nums = tokens(1).split("-")
+        val (start, end) = (nums(0), nums(1))
+        val id = tokens(2)
+        val interval = Interval(start.toInt, end.toInt + 1)
+        val text = docTokens(sent).slice(interval.start, interval.end).mkString(" ")
+
+
+        PaperExtraction(sent, interval, text, id)
+
+    }
+  }
+
+  logger.info(s"Reading data form $dir")
+  val paperDirs = for (f <- new File(dir).listFiles(); if f.isDirectory) yield f.getAbsolutePath
+  val extractions = paperDirs.map(p => new File(p).getName -> parsePaperFiles(p)).toMap
+
+  logger.info(s"Saving output to $outputPath")
+  Serializer.save(extractions, outputPath)
+
+}

--- a/context/src/main/scala/org/clulab/reach/context/utils/FeatureExtractor.scala
+++ b/context/src/main/scala/org/clulab/reach/context/utils/FeatureExtractor.scala
@@ -1,0 +1,262 @@
+package org.clulab.reach.context.utils
+
+import com.typesafe.scalalogging.LazyLogging
+import org.clulab.processors.Document
+import org.clulab.struct.Interval
+
+// Internal data structures used for ML classification
+
+/**
+  * Represents a text-bound mention in a light-weight fashion
+  * @param sent Sentence index w.r.t. document object
+  * @param interval Token interval of the mention
+  * @param text Text representation of the extraction
+  * @param grounding Grounding id of the extraction
+  */
+case class PaperExtraction(sent:Int, interval:Interval, text:String, grounding:String)
+
+/**
+  * Represents an event mention - context mention pair
+  * @param event Pair that represents the event mention
+  * @param contextMention Pair instance that represents the context mention
+  * @param isContext Flag that indicates whether this is a positive example. <i>Only relevant at training time</i>
+  */
+case class Pair(event:PaperExtraction, contextMention:PaperExtraction, isContext:Boolean = false)
+
+/**
+  * Data structure that represents the features used by the context classifier
+  * @param eventSentence
+  * @param eventInterval
+  * @param contextSentence
+  * @param contextInterval
+  * @param sentenceDistance
+  * @param contextFrequency
+  * @param contextGrounding
+  * @param isClosestContextClass
+  * @param contextSentencePresentTense
+  * @param eventSentencePresentTense
+  * @param contextSentencePastTense
+  * @param eventSentencePastTense
+  * @param contextSentenceFirstPerson
+  * @param eventSentenceFirstPerson
+  * @param dependencyDistance
+  * @param contextHasNegation
+  * @param eventHasNegation
+  * @param isContext Flag that indicates whether this is a positive example. <i>Only relevant at training time</i>
+  */
+case class PairFeatures(eventSentence:Int,
+                        eventInterval:Interval,
+                        contextSentence:Int,
+                        contextInterval:Interval,
+                        sentenceDistance:Int,
+                        contextFrequency:Int,
+                        contextGrounding:String,
+                        isClosestContextClass:Boolean,
+                        contextSentencePresentTense:Boolean,
+                        eventSentencePresentTense:Boolean,
+                        contextSentencePastTense:Boolean,
+                        eventSentencePastTense:Boolean,
+                        contextSentenceFirstPerson:Boolean,
+                        eventSentenceFirstPerson:Boolean,
+                        dependencyDistance:Int,
+                        contextHasNegation:Boolean,
+                        eventHasNegation:Boolean,
+                        isContext:Boolean) { // True for the positive case during training
+
+  override def toString: String = {
+    Seq(s"$isContext",
+      s"E${eventSentence}_${eventInterval.start}_${eventInterval.end}",
+      s"$contextGrounding",
+      s"$isClosestContextClass",
+      s"$contextFrequency",
+      s"$contextHasNegation",
+      s"$contextSentenceFirstPerson",
+      s"$contextSentencePastTense",
+      s"$contextSentencePresentTense",
+      s"$dependencyDistance",
+      s"$eventHasNegation",
+      s"$eventSentenceFirstPerson",
+      s"$eventSentencePastTense",
+      s"$eventSentencePresentTense",
+      s"$sentenceDistance"
+    ).mkString("\t")
+  }
+}
+
+//object PairFeatures {
+//  val headerRow: String = {
+//    Seq(
+//      "label",
+//      "EvtID",
+//      "CtxID",
+//      "closesCtxOfClass",
+//      "context_frequency",
+//      "ctxNegationIntTail",
+//      "ctxSentenceFirstPerson",
+//      "ctxSentencePastTense",
+//      "ctxSentencePresentTense",
+//      "dependencyDistance",
+//      "evtNegationInTail",
+//      "evtSentenceFirstPerson",
+//      "evtSentencePastTense",
+//      "evtSentencePresentTense",
+//      "sentenceDistance").mkString("\t")
+//  }
+//
+//  def mkTsv(rows: Iterable[PairFeatures]): String =
+//    (headerRow :: rows.map(_.toString).toList).mkString("\n")
+//}n
+
+
+/**
+  * Extracts features for ML-based context classification
+  */
+object FeatureExtractor extends App with LazyLogging {
+
+
+  /**
+    * Extracts features from a pair instance and it's accompaining doc, counts and locations data structures
+    * @param pair Represents the event mention - context mention pair
+    * @param doc Doc instance with the relevant NLP information of the current document
+    * @param counts Counts of the frequencies of every context mention
+    * @param locations Tracking information of the locations of context mentions throughout the document
+    * @return <b>PairFeatures</b> instance with the extracted features of the input pair
+    */
+  def extractFeaturePairs(pair: Pair, doc: Document,
+                          counts: Map[String, Int],
+                          locations: Map[String, Seq[Int]]): PairFeatures = {
+    val event = pair.event
+    val context = pair.contextMention
+
+    // Helper functions to extract features
+    def isSentencePresentTense(sent: Int, doc: Document): Boolean = {
+      val sentence = doc.sentences(sent)
+      val deps = sentence.dependencies.get
+      val rootTags = deps.roots map sentence.tags.get
+
+      // Return true if a root is a verb conjugated in present tense
+      (rootTags contains "VB") ||
+        (rootTags contains "VBP") ||
+        (rootTags contains "VBZ") ||
+        (rootTags contains "VBG")
+
+    }
+
+    def isSentencePastTense(sent: Int, doc: Document): Boolean = {
+      val sentence = doc.sentences(sent)
+      val deps = sentence.dependencies.get
+      val rootTags = deps.roots map sentence.tags.get
+
+      // Return true if a root is a verb conjugated in present tense
+      (rootTags contains "VBD") ||
+        (rootTags contains "VBN")
+    }
+
+    def isSentenceFirstPerson(sent: Int, doc: Document): Boolean = {
+      val sentence = doc.sentences(sent)
+      val tags = sentence.tags.get
+
+      // Get the indices noun phrases
+      val chunks = sentence.chunks.get
+      val npIndices =
+        chunks.zipWithIndex.collect { case (tag, ix) if tag.endsWith("-NP") => ix }
+
+      // Get the POS tag in the noun phrases
+      val npTags = npIndices map (ix => (ix, tags(ix)))
+
+      // Find the personal pronouns and fetch their words
+      val prps =
+        npTags collect {
+          case (ix, tag) if tag == "PRP" =>
+            sentence.words(ix).toLowerCase
+        }
+
+      // If the personal pronoun is first person, return true
+      (prps contains "i") || (prps contains "we") || (prps contains "us") || (prps contains "our")
+    }
+
+    def calculateDependencyDistance(ctx: PaperExtraction, evt: PaperExtraction): Int = {
+      // If they appear in the same sentence, then compute the distance in dependency hops between them
+      if (ctx.sent == evt.sent) {
+        val deps = doc.sentences(event.sent).dependencies.get
+        val allDistances =
+          (for {
+            i <- event.interval
+            j <- ctx.interval
+          }
+            yield deps.shortestPath(i, j, ignoreDirection = true).size).filter(_ > 0)
+
+        if (allDistances.nonEmpty)
+          allDistances.min
+        else
+          doc.sentences(event.sent).size // If there is no path (I can't see why not) then return the theoretical max
+      }
+      // Otherwise the number of "roots" traversed plus the distance from each root to the head of the entity
+      else {
+        val depsEvt = doc.sentences(event.sent).dependencies.get
+        val rootToEvt =
+          (for {
+            i <- event.interval
+            j <- depsEvt.roots
+          }
+            yield depsEvt.shortestPath(i, j, ignoreDirection = true).size).filter(_ > 0)
+
+        val ctxEvt = doc.sentences(context.sent).dependencies.get
+        val rootToCtx =
+          (for {
+            i <- context.interval
+            j <- ctxEvt.roots
+          }
+            yield ctxEvt.shortestPath(i, j, ignoreDirection = true).size).filter(_ > 0)
+
+        val sentDistance = Math.abs(event.sent - context.sent)
+
+        sentDistance + rootToEvt.min + rootToCtx.min
+      }
+    }
+
+    def findNegationInTails(mention: PaperExtraction): Boolean = {
+      val deps = doc.sentences(mention.sent).dependencies.get
+      val labels =
+        for {
+          ix <- mention.interval
+          (target, label) <- deps.getOutgoingEdges(ix)
+          if !(mention.interval contains target)
+        }
+          yield label
+
+      labels contains "neg"
+    }
+
+    // Here I compute the features
+    val sentenceDistance = Math.abs(event.sent - context.sent)
+    val contextCount = counts(context.grounding)
+    val closestContextOf = {
+      val minimumDistances =
+        locations mapValues (sentences => sentences.map(s => Math.abs(s - event.sent)).min)
+      val contextsByDistance = minimumDistances.toSeq.groupBy(_._2).mapValues(_.map(_._1).toSet)
+      val shortestDistance = contextsByDistance.keys.min
+      contextsByDistance(shortestDistance) contains context.grounding
+    }
+    val contextSentencePresentTense = isSentencePresentTense(context.sent, doc)
+    val eventSentencePresentTense = isSentencePresentTense(event.sent, doc)
+
+    val contextSentencePastTense = isSentencePastTense(context.sent, doc)
+    val eventSentencePastTense = isSentencePastTense(event.sent, doc)
+
+    val contextSentenceFirstPerson = isSentenceFirstPerson(context.sent, doc)
+    val eventSentenceFirstPerson = isSentenceFirstPerson(event.sent, doc)
+
+    val dependencyDistance = calculateDependencyDistance(context, event)
+
+    val contextHasNegation = findNegationInTails(context)
+    val eventHasNegation = findNegationInTails(event)
+
+    PairFeatures(event.sent, event.interval, context.sent, context.interval,
+      sentenceDistance, contextCount, context.grounding, closestContextOf,
+      contextSentencePresentTense, eventSentencePresentTense,
+      contextSentencePastTense, eventSentencePastTense, contextSentenceFirstPerson, eventSentenceFirstPerson,
+      dependencyDistance, contextHasNegation, eventHasNegation,
+      pair.isContext)
+  }
+}

--- a/context/src/main/scala/org/clulab/reach/context/utils/package.scala
+++ b/context/src/main/scala/org/clulab/reach/context/utils/package.scala
@@ -1,0 +1,35 @@
+package org.clulab.reach.context
+
+import org.clulab.processors.Document
+import org.clulab.reach.context.train.dataset.ManuallyAnnotatedData
+import org.clulab.utils.Serializer
+
+/**
+  * Utility functions shared by the scripts
+  */
+package object utils {
+  def readSerializedPaperAnnotations(path:String):Map[String, ManuallyAnnotatedData] = {
+    val data = Serializer.load[Map[String, ManuallyAnnotatedData]](path)
+    data
+  }
+
+  def readSerializedDocument(path:String):Map[String, Document] = {
+    val data = Serializer.load[Seq[(String, (Seq[PaperExtraction], Document))]](path)
+    data.toMap.mapValues(_._2)
+  }
+
+  def readSerializedExtractions(path:String):Map[String, Seq[PaperExtraction]] = {
+    val data = Serializer.load[Seq[(String, (Seq[PaperExtraction], Document))]](path)
+    data.toMap.mapValues(_._1)
+  }
+
+  def readSerializedPairs(path:String):Map[String, Iterable[Pair]] = {
+    Serializer.load[Map[String, Iterable[Pair]]](path)
+  }
+
+  def getEvents(data:Seq[PaperExtraction]):Seq[PaperExtraction] = data filter (_.grounding == "Event")
+
+  def generateValidContextIds(annotations:Map[String, ManuallyAnnotatedData]):Set[String] = {
+    annotations.values.flatMap(_.annotations.values).flatten.toSet
+  }
+}


### PR DESCRIPTION
This is the first PR related to adding the SVM context engine as a sub-module to REACH.

It has the following elements:

- Created a context submodule for the SVM implementation of the context engine. This includes all the auxiliary code to extract features for ML, parse the dataset files and training scripts. The original context engine trait and the deterministic context engine still live in the main module to avoid a circular dependency problem.
- Added the feature extraction code to the context sub-module
- Added the dataset parsers to the context sub-module
- Added a skeleton implementation to the SVM context engine to the context sub-module


Still TODO:

- Implement the training script using processors' SVM wrapper
- Implement the SVM context engine
- Write unit tests