### PR TITLE
Remove duplicates from overrides

### DIFF
--- a/bioresources/src/main/resources/org/clulab/reach/kb/NER-Grounding-Override.tsv
+++ b/bioresources/src/main/resources/org/clulab/reach/kb/NER-Grounding-Override.tsv
@@ -30,7 +30,6 @@ cyclododecane	18529		pubchem	Simple_chemical
 farnesylthiosalicylic	5469318		pubchem	Simple_chemical
 E1	5870		pubchem	Simple_chemical
 E2	5757		pubchem	Simple_chemical
-E3	5756		pubchem	Simple_chemical
 EHT 1864	9938202		pubchem	Simple_chemical
 EHT-1864	9938202		pubchem	Simple_chemical
 EHT1864	9938202		pubchem	Simple_chemical
@@ -268,7 +267,6 @@ GNG	G_gamma		fplx	Family
 HDAC Class I	HDAC_I		fplx	Family
 HDAC Class II	HDAC_II		fplx	Family
 Histone H1	Histone_H1		fplx	Family
-Histone H2A	Histone_H2A		fplx	Family
 Histone H2B	Histone_H2B		fplx	Family
 Histone H3	Histone_H3		fplx	Family
 Histone H4	Histone_H4		fplx	Family
@@ -285,13 +283,11 @@ PIK3R Class IA	PIK3R_I		fplx	Family
 PPP2R Subunit A	PPP2R_A		fplx	Family
 PPP2R Subunit B	PPP2R_B		fplx	Family
 PRKA	PRKAC		fplx	Family
-PRKAA	AMPK_alpha		fplx	Family
 PRKAB	AMPK_beta		fplx	Family
 PRKAG	AMPK_gamma		fplx	Family
 RB domain	PF02196		pfam	Family
 RB-domain	PF02196		pfam	Family
 RBD	PF02196		pfam	Family
-RPS6KA	P90RSK		fplx	Family
 RPS6KB	P70S6K		fplx	Family
 Sulfonylurea Receptor	Sulfonylurea_receptor		fplx	Family
 TCF/LEF	TCF_LEF		fplx	Family
@@ -487,7 +483,6 @@ Cox8	COX8		fplx	Family
 Cyclin	Cyclin		fplx	Family
 Cyclin D	Cyclin_D		fplx	Family
 Cyclin-A	Cyclin_A		fplx	Family
-Cyclin-A	Cyclin_A		fplx	Family
 Cyclin-D	Cyclin_D		fplx	Family
 Cyclophilin	Cyclophilin		fplx	Family
 DAG kinase	DGK		fplx	Family
@@ -528,7 +523,6 @@ Fibrinogen	Fibrinogen		fplx	Family
 Fos	FOS_family		fplx	Family
 Fz	FZD		fplx	Family
 G protein	G_protein		fplx	Family
-G-alpha	G_alpha		fplx	Family
 G-alpha	G_alpha		fplx	Family
 G-gamma	G_gamma		fplx	Family
 G12	G_12		fplx	Family
@@ -832,7 +826,6 @@ tilorone	5475		pubchem	Simple_chemical
 CD4+	D015496		mesh	CellType
 CD4 +	D015496		mesh	CellType
 CD4+ T cell	D015496		mesh	CellType
-CD4+ T cells	D015496		mesh	CellType
 CD4 + T cell	D015496		mesh	CellType
 CD4 þ T cells	D015496		mesh	CellType
 CD4 ϩ T cells	D015496		mesh	CellType
@@ -843,7 +836,6 @@ CD4+ T helper cells	D006377		mesh	CellType
 CD8+	D018414		mesh	CellType
 CD8 +	D018414		mesh	CellType
 CD8+ T cell	D018414		mesh	CellType
-CD8+ T cells	D018414		mesh	CellType
 CD8 + T cell	D018414		mesh	CellType
 CD8 þ T cells	D018414		mesh	CellType
 CD8 ϩ T cells	D018414		mesh	CellType

--- a/main/src/test/scala/org/clulab/reach/TestNERLabeling.scala
+++ b/main/src/test/scala/org/clulab/reach/TestNERLabeling.scala
@@ -23,7 +23,8 @@ class TestNERLabeling extends FlatSpec with Matchers {
   val families = "CDC73_N, RcsD-ABL domain, zinc-ribbon domain, Rho_RNA_bind, RasGAP_C, zwf, PTHR10856:SF10, GLHYDRLASE27, Ras guanyl-releasing protein 1, and Jiraiya cause cancer."
   val ggp = "CK-40, ZZANK2, MCH-1R, RAS1, and hemAT cause cancer."
   // this tests overrides simple chemical identifications:
-  val manual_chemicals = "Estrone E1, estradiol E2, and estriol E3 do not cause cancer."
+//  val manual_chemicals = "Estrone E1, estradiol E2, and estriol E3 do not cause cancer."
+  val manual_chemicals = "Estrone E1 and estradiol E2 do not cause cancer."
   val organ = "Acetabulum, Visceral Pericardium, malleolar bone, Vena cava sinus, and zygopodium cause cancer"
   val chemical = "endoxifen sulfate, Juvamine, Adenosine-phosphate, Xitix, and okadaic acid cause cancer"
   val sites = "ALOG domain, AMIN domain, KIP1-like, KEN domain, and HAS subgroup cause cancer"
@@ -138,8 +139,8 @@ class TestNERLabeling extends FlatSpec with Matchers {
     val mentions = getBioMentions(manual_chemicals)
     mentions should not be (empty)
     // printMentions(Try(mentions), true)      // DEBUGGING
-    mentions should have size 6
-    mentions.count(_ matches "Simple_chemical") should be (6)
+    mentions should have size 4
+    mentions.count(_ matches "Simple_chemical") should be (4)
   }
 
 

--- a/main/src/test/scala/org/clulab/reach/TestOverrides.scala
+++ b/main/src/test/scala/org/clulab/reach/TestOverrides.scala
@@ -133,7 +133,8 @@ class TestOverrides extends FlatSpec with Matchers {
   val chem = "GTP, GDP, cyclododecane, TAK-165, and estrone are important molecules. "
   val chem_ids = Seq("6830", "8977", "18529", "644692", "5870")
 
-  val estros = "Estrone E1, estradiol E2, and estriol E3 do not cause cancer."
+//  val estros = "Estrone E1, estradiol E2, and estriol E3 do not cause cancer."
+  val estros = "Estrone E1 and estradiol E2 do not cause cancer."
 
   val aminos = "Alanine, arginine, asparagine, aspartic acid, aspartate, cysteine, glutamic acid, glutamate, glutamine, glycine, histidine, isoleucine, leucine, lysine, methionine, phenylalanine, proline, serine, threonine, tryptophan, tyrosine, and valine are amino acids"
 
@@ -215,8 +216,8 @@ class TestOverrides extends FlatSpec with Matchers {
     val mentions = getBioMentions(estros)
     mentions should not be (empty)
     // printMentions(Try(mentions), true)      // DEBUGGING
-    mentions should have size 6
-    mentions.count(_ matches "Simple_chemical") should be (6)
+    mentions should have size 4
+    mentions.count(_ matches "Simple_chemical") should be (4)
   }
 
   // Amino Acid abbreviations relabeled as Sites (but only 20/22 because of protein conflicts)


### PR DESCRIPTION
Fixes #746. Except for `E3` where there is a genuine ambiguity that had to be resolved (I chose the protein family sense there), all the other duplicates were just redundant rows that could be deleted.