### PR TITLE
Updated Lucene Indexers

### DIFF
--- a/main/src/main/scala/org/clulab/reach/indexer/NxmlIndexer.scala
+++ b/main/src/main/scala/org/clulab/reach/indexer/NxmlIndexer.scala
@@ -3,7 +3,6 @@ package org.clulab.reach.indexer
 import java.io.File
 import java.nio.file.Paths
 import java.util.regex.Pattern
-
 import scala.collection.mutable
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
@@ -14,10 +13,11 @@ import org.apache.lucene.index.{IndexWriter, IndexWriterConfig}
 import org.apache.lucene.store.FSDirectory
 import org.slf4j.LoggerFactory
 import org.clulab.struct.MutableNumber
-import org.clulab.utils.{Files, StringUtils}
+import org.clulab.utils.{FileUtils, Files, StringUtils}
 import NxmlIndexer._
 import org.clulab.processors.bionlp.BioNLPProcessor
 import org.clulab.reach.utils.Preprocess
+import sun.jvm.hotspot.oops.BooleanField
 
 
 /**
@@ -27,17 +27,18 @@ import org.clulab.reach.utils.Preprocess
   * Last Modified: Refactor processor client to processor annotator.
   */
 class NxmlIndexer {
-  def index(docsDir:String, mapFile:String, indexDir:String): Unit = {
-    val files = Files.findFiles(docsDir, "nxml")
+  def index(docsDir:String, mapFiles:Iterable[String], indexDir:String): Unit = {
+//    val files = Files.findFiles(docsDir, "nxml")
+    val files = FileUtils.findFiles(docsDir, "xml") // Since Dec 2021, pubmed files use xml extensions
     logger.info(s"Preparing to index ${files.length} files...")
     val nxmlReader = new NxmlReader(IGNORE_SECTIONS.toSet)
-    val fileToPmc = readMapFile(mapFile)
+    val fileToPmc = readMapFiles(mapFiles)
 
     // check that all files exist in the map
     var failed = false
     var count = 0
     for(file <- files) {
-      val fn = getFileName(file, "nxml")
+      val fn = getFileName(file, "xml") // Since Dec 2021, pubmed files use xml extensions
       if(! fileToPmc.contains(fn)) {
         logger.info(s"Did not find map for file $fn!")
         failed = true
@@ -73,9 +74,9 @@ class NxmlIndexer {
           Nil
       }
 
-      if(nxmlDoc != Nil && fileToPmc.contains(getFileName(file, "nxml"))) {
+      if(nxmlDoc != Nil && fileToPmc.contains(getFileName(file, "xml"))) {
         val doc = nxmlDoc.asInstanceOf[NxmlDocument]
-        val meta = fileToPmc.get(getFileName(file, "nxml")).get
+        val meta = fileToPmc.get(getFileName(file, "xml")).get
         val text = doc.text
         val nxml = readNxml(file)
         addDoc(writer, meta, text, nxml)
@@ -99,6 +100,7 @@ class NxmlIndexer {
     d.add(new StringField("id", meta.pmcId, Field.Store.YES))
     d.add(new StringField("year", meta.year, Field.Store.YES)) // TODO: index as DateField or NumericField?
     d.add(new StoredField("nxml", nxml))
+    d.add(new StringField("retracted", meta.retracted, Field.Store.YES))
     writer.addDocument(d)
   }
 
@@ -113,19 +115,29 @@ class NxmlIndexer {
     os.toString()
   }
 
+  /**
+    * Reads multiple map files and merges them into a single map
+    * @param mapFiles list of paths to map files
+    * @return merged map of individual files from readMapFile
+    */
+  def readMapFiles(mapFiles:Iterable[String]):Map[String, PMCMetaData] = {
+    (mapFiles map readMapFile flatMap (_.toSeq)).toMap
+  }
+
   def readMapFile(mapFile:String):Map[String, PMCMetaData] = {
     // map from file name (wo/ extension) to pmc id
     val map = new mutable.HashMap[String, PMCMetaData]()
     val errorCount = new MutableNumber[Int](0)
     val source = Source.fromFile(mapFile)
-    for(line <- source.getLines()) {
+    for(line <- source.getLines().drop(1)) { // Drop the first line to ignore the headers
       val tokens = line.split("\\t")
       if(tokens.length > 2) { // skip headers
-      val fn = getFileName(tokens(0), "tar.gz")
+      val fn = getFileName(tokens(0), "xml")
         val pmcId = tokens(2)
         val journalName = tokens(1)
+        val retracted = tokens(6)
         val year = extractPubYear(journalName, errorCount)
-        map += fn -> new PMCMetaData(pmcId, year)
+        map += fn -> PMCMetaData(pmcId, year, retracted)
         // logger.debug(s"$fn -> $pmcId, $year")
       }
     }
@@ -156,8 +168,9 @@ class NxmlIndexer {
 }
 
 case class PMCMetaData(
-  val pmcId:String,
-  val year:String)
+  pmcId:String,
+  year:String,
+  retracted:String)
 
 object NxmlIndexer {
   val logger = LoggerFactory.getLogger(classOf[NxmlIndexer])
@@ -171,7 +184,9 @@ object NxmlIndexer {
     val docsDir = props.getProperty("docs")
     val mapFile = props.getProperty("map")
 
+    println(props)
+
     val indexer = new NxmlIndexer
-    indexer.index(docsDir, mapFile, indexDir)
+    indexer.index(docsDir, mapFile.split(","), indexDir)
   }
 }

--- a/main/src/main/scala/org/clulab/reach/indexer/NxmlIndexer.scala
+++ b/main/src/main/scala/org/clulab/reach/indexer/NxmlIndexer.scala
@@ -43,7 +43,7 @@ class NxmlIndexer {
     var count = 0
     var nxmlErrors = 0
     for (meta <- fileToPmc.values) {
-      val file = new File(meta.path)
+      val file = meta.path
       // Preprocess bio text
       val source = Source.fromFile(file)
       val rawText = source.getLines.mkString("\n")
@@ -113,6 +113,7 @@ class NxmlIndexer {
     val map = new mutable.HashMap[String, PMCMetaData]()
     val errorCount = new MutableNumber[Int](0)
     val source = Source.fromFile(mapFile)
+    val directory = new File(mapFile).getAbsoluteFile.getParentFile
     for(line <- source.getLines().drop(1)) { // Drop the first line to ignore the headers
       val tokens = line.split("\\t")
       if(tokens.length > 2) { // skip headers
@@ -122,7 +123,7 @@ class NxmlIndexer {
         val journalName = tokens(1)
         val retracted = tokens(6)
         val year = extractPubYear(journalName, errorCount)
-        map += fn -> PMCMetaData(pmcId, year, retracted, path)
+        map += fn -> PMCMetaData(pmcId, year, retracted, new File(directory, path))
         // logger.debug(s"$fn -> $pmcId, $year")
       }
     }
@@ -156,7 +157,7 @@ case class PMCMetaData(
   pmcId:String,
   year:String,
   retracted:String,
-  path:String)
+  path:File)
 
 object NxmlIndexer {
   val logger = LoggerFactory.getLogger(classOf[NxmlIndexer])

--- a/main/src/main/scala/org/clulab/reach/indexer/NxmlIndexer.scala
+++ b/main/src/main/scala/org/clulab/reach/indexer/NxmlIndexer.scala
@@ -28,7 +28,7 @@ import org.clulab.reach.utils.Preprocess
 class NxmlIndexer {
   def index(docsDir:String, mapFiles:Iterable[String], indexDir:String): Unit = {
 //    val files = Files.findFiles(docsDir, "nxml")
-    val files = FileUtils.findFiles(docsDir, "xml") // Since Dec 2021, pubmed files use xml extensions
+    val files = FileUtils.walkTree(docsDir).filter(f => f.getName.endsWith(".xml")).toList // Since Dec 2021, pubmed files use xml extensions
     logger.info(s"Preparing to index ${files.length} files...")
     val nxmlReader = new NxmlReader(IGNORE_SECTIONS.toSet)
     val fileToPmc = readMapFiles(mapFiles)
@@ -36,7 +36,7 @@ class NxmlIndexer {
     // check that all files exist in the map
     var failed = false
     var count = 0
-    for(file <- files) {
+    for{file <- files} {
       val fn = getFileName(file, "xml") // Since Dec 2021, pubmed files use xml extensions
       if(! fileToPmc.contains(fn)) {
         logger.info(s"Did not find map for file $fn!")

--- a/main/src/main/scala/org/clulab/reach/indexer/NxmlIndexer.scala
+++ b/main/src/main/scala/org/clulab/reach/indexer/NxmlIndexer.scala
@@ -17,7 +17,6 @@ import org.clulab.utils.{FileUtils, Files, StringUtils}
 import NxmlIndexer._
 import org.clulab.processors.bionlp.BioNLPProcessor
 import org.clulab.reach.utils.Preprocess
-import sun.jvm.hotspot.oops.BooleanField
 
 
 /**

--- a/main/src/main/scala/org/clulab/reach/indexer/PubmedAbstractIndexer.scala
+++ b/main/src/main/scala/org/clulab/reach/indexer/PubmedAbstractIndexer.scala
@@ -72,7 +72,7 @@ class PubmedAbstractIndexer {
   }
 
   def addDocs(writer:IndexWriter, abstracts:Iterable[PubmedAbstract]): Int = {
-    abstracts map (abs => Try(addDoc(writer, abs))) count { case Success(_) => true}
+    abstracts map (abs => Try(addDoc(writer, abs))) count { case Success(_) => true ; case Failure(_) => false }
   }
 
   def addDoc(writer:IndexWriter, abs:PubmedAbstract): Unit = {

--- a/main/src/main/scala/org/clulab/reach/indexer/PubmedAbstractIndexer.scala
+++ b/main/src/main/scala/org/clulab/reach/indexer/PubmedAbstractIndexer.scala
@@ -1,0 +1,158 @@
+package org.clulab.reach.indexer
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer
+import org.apache.lucene.document._
+import org.apache.lucene.index.{IndexWriter, IndexWriterConfig}
+import org.apache.lucene.store.FSDirectory
+import org.clulab.reach.indexer.NxmlIndexer.logger
+import org.clulab.reach.utils.Preprocess
+import org.clulab.utils.{FileUtils, StringUtils}
+
+import java.nio.file.Paths
+import scala.io.Source
+import scala.util.{Failure, Success, Try}
+import scala.xml.XML
+
+case class JournalMetadata(name:String,
+                           issn:String,
+                           volume:Int,
+                           issue:Int,
+                           published:String)
+
+case class PubmedAbstract(pmid:String,
+                          title:String,
+                          text:String,
+                          doi:Option[String],
+                          journal:Option[JournalMetadata])
+
+class PubmedAbstractIndexer {
+
+  def index(docsDir:String, indexDir:String): Unit = {
+
+    val files = FileUtils.walkTree(docsDir).filter(f => f.getName.endsWith(".xml")).toList // Since Dec 2021, pubmed files use xml extensions
+    logger.info(s"Preparing to index ${files.length} files...")
+    val parser = PubmedReader()
+
+
+    // index
+    val analyzer = new StandardAnalyzer
+    val config = new IndexWriterConfig(analyzer)
+    val index = FSDirectory.open(Paths.get(indexDir))
+    val writer = new IndexWriter(index, config)
+
+
+    var count = 0
+
+    for (file <- files) {
+      // Preprocess bio text
+      val source = Source.fromFile(file)
+      val rawText = source.getLines.mkString("\n")
+      source.close()
+
+      var totalIndexed = 0
+
+      Try(parser.parse(rawText)) match {
+        case Success(abstracts) =>
+          logger.info(s"${abstracts.size} contained in file")
+          val indexed = addDocs(writer, abstracts)
+          totalIndexed += indexed
+        case Failure(e) =>
+          logger.error(s"WARNING: NxmlReader failed on file $file")
+      }
+
+      logger.info(s"Indexed $totalIndexed abstracts")
+
+      count += 1
+      if(count % 100 == 0)
+        logger.info(s"Indexed $count/${files.size} files.")
+
+    }
+    writer.close()
+    logger.info(s"Indexing complete. Indexed $count/${files.size} files.")
+  }
+
+  def addDocs(writer:IndexWriter, abstracts:Iterable[PubmedAbstract]): Int = {
+    abstracts map (abs => Try(addDoc(writer, abs))) count { case Success(_) => true}
+  }
+
+  def addDoc(writer:IndexWriter, abs:PubmedAbstract): Unit = {
+    val d = new Document
+    d.add(new TextField("text", abs.text, Field.Store.YES))
+    d.add(new TextField("title", abs.title, Field.Store.YES))
+    d.add(new StringField("pmid", abs.pmid, Field.Store.YES))
+
+    for(doi <- abs.doi)
+        d.add(new StringField("doi", doi, Field.Store.YES))
+
+    for(meta <-  abs.journal) {
+        d.add(new StringField("published", meta.published, Field.Store.YES))
+        d.add(new TextField("journal", meta.name, Field.Store.YES))
+        d.add(new StringField("issn", meta.issn, Field.Store.YES))
+        d.add(new IntField("volume", meta.volume, Field.Store.YES))
+        d.add(new IntField("issue", meta.volume, Field.Store.YES))
+    }
+
+    writer.addDocument(d)
+  }
+
+}
+
+object PubmedAbstractIndexer extends App {
+
+  val props = StringUtils.argsToProperties(args)
+  val indexDir = props.getProperty("index")
+  val docsDir = props.getProperty("docs")
+
+  val indexer = new PubmedAbstractIndexer
+  indexer.index(docsDir, indexDir)
+
+}
+
+case class PubmedReader() {
+  val preproc = new Preprocess
+  def parse(contents:String):Iterable[PubmedAbstract] = {
+    val xml = XML.loadString(contents)
+    for(article <- xml \ "PubmedArticle") yield {
+      val pmid = (article \ "MedlineCitation" \ "PMID").text
+      val title = (article \ "MedlineCitation" \ "Article" \ "ArticleTitle").text
+      val text = (article \ "MedlineCitation" \ "Article" \ "Abstract" \ "AbstractText").text
+      val articleIds =
+        for {
+          id <- article \ "PubmedData" \ "ArticleIdList" \ "ArticleId"
+          if (id \ "@IdType").text == "doi"
+        } yield id.text
+
+      val doi = articleIds match {
+        case id :: _ => Some(id)
+        case Nil => None
+      }
+
+      val metadata = (article \ "MedlineCitation" \ "Article" \ "Journal").toList match {
+        case mt::__ =>
+          val issn = (mt \ "ISSN").text
+          val name = (mt \ "Title").text
+          val volume =  Try((mt \ "JournalIssue" \ "Volume").text.toInt) match {
+            case Success(v) => v
+            case Failure(_) => -1
+          }
+          val issue = Try((mt \ "JournalIssue" \ "Issue").text.toInt)  match {
+            case Success(v) => v
+            case Failure(_) => -1
+          }
+
+          val pubdate = mt \ "JournalIssue" \ "PubDate"
+
+          val year = (pubdate \ "Year").text
+          val month = (pubdate \ "Month").text
+          val day = (pubdate \ "Day").text
+          val published = s"$year-$month-$day".toLowerCase
+
+          Some(JournalMetadata(name, issn, volume, issue, published))
+
+        case Nil => None
+      }
+
+      PubmedAbstract(pmid, preproc.preprocessText(title), preproc.preprocessText(text), doi, metadata)
+    }
+  }
+}


### PR DESCRIPTION
The file structure of PMC OA changed on Dec 21st 2021. The xml files are split into different directories. This PR updates the NxmlIndexer class to handle this new structure.
Added a new class named PubmedAbstractIndexer to create an index of pubmed abstracts akin to the full-text OA index