### PR TITLE
Change to runMain

### DIFF
--- a/parse_papers
+++ b/parse_papers
@@ -7,5 +7,5 @@ fi
 
 CONF=$1
 
-sbt -Dconfig.file=$CONF "run-main org.clulab.reach.RunReachCLI"
+sbt -Dconfig.file=$CONF "runMain org.clulab.reach.RunReachCLI"
 

--- a/runReachCLI.sh
+++ b/runReachCLI.sh
@@ -6,7 +6,7 @@
 #sleep 20
 
 echo 'Running Reach CLI...'
-sbt 'run-main org.clulab.reach.RunReachCLI'
+sbt 'runMain org.clulab.reach.RunReachCLI'
 
 # An explicit call to shutdown the server is not necessary
 # because ReachCLI shuts down both client and server.


### PR DESCRIPTION
Two scripts in the repo were using the deprecated `run-main`, this PR changes these to `runMain`. 