### PR TITLE
This is another way to add section names without changes to processors

### DIFF
--- a/export/src/main/scala/org/clulab/reach/export/fries/FriesOutput.scala
+++ b/export/src/main/scala/org/clulab/reach/export/fries/FriesOutput.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable.{HashMap, ListBuffer, Set => MSet}
 import org.json4s.jackson.Serialization
 import org.clulab.odin._
 import org.clulab.processors.Document
-import org.clulab.reach.FriesEntry
+import org.clulab.reach.{FriesEntry, ReachDocument}
 import org.clulab.reach.context._
 import org.clulab.reach.display._
 import org.clulab.reach.export._
@@ -730,7 +730,7 @@ class FriesOutput extends JsonOutputter with LazyLogging {
   private def makeSentence (model: PropMap,
     paperId: String,
     passageMeta: FriesEntry,
-    passageDoc: Document,
+    passageDoc: ReachDocument,
     offset: Int): PropMap = {
     val f = startFrame(Some("BioNLPProcessor"))
     f("frame-type") = "sentence"
@@ -739,7 +739,7 @@ class FriesOutput extends JsonOutputter with LazyLogging {
     f("start-pos") = makeRelativePosition(paperId, passageMeta, sentenceStartCharacterOffset(passageDoc, offset))
     f("end-pos") = makeRelativePosition(paperId, passageMeta, sentenceEndCharacterOffset(passageDoc, offset))
     f("text") = passageDoc.sentences(offset).getSentenceText
-    passageDoc.sentences(offset).sections match {
+    passageDoc.reachSentences(offset).sections match {
       case Some(sections) =>
         f("sections") = sections
       case None => ()
@@ -752,7 +752,7 @@ class FriesOutput extends JsonOutputter with LazyLogging {
   private def makeSentences (model: PropMap,
     paperId: String,
     passageMeta: FriesEntry,
-    passageDoc: Document): Seq[PropMap] = {
+    passageDoc: ReachDocument): Seq[PropMap] = {
     val sents = new ListBuffer[PropMap]
     for (i <- passageDoc.sentences.indices) {
       sents += makeSentence(model, paperId, passageMeta, passageDoc, i)
@@ -799,11 +799,11 @@ class FriesOutput extends JsonOutputter with LazyLogging {
     addMetaInfo(model, paperId, startTime, endTime, otherMetaData)
 
     // keeps track of all documents created for each entry
-    val passageDocs = new HashMap[String, Document]()
+    val passageDocs = new HashMap[String, ReachDocument]()
     for (m <- mentions)  {
       val chunkId = getChunkId(m)
       if (!passageDocs.contains(chunkId)) {
-        passageDocs += chunkId -> m.document
+        passageDocs += chunkId -> m.document.asInstanceOf[ReachDocument] // This conversion is important!
       }
     }
 

--- a/main/src/main/scala/org/clulab/reach/ReachDocument.scala
+++ b/main/src/main/scala/org/clulab/reach/ReachDocument.scala
@@ -1,0 +1,26 @@
+package org.clulab.reach
+
+import org.clulab.processors.{Document, Sentence}
+
+class ReachDocument(doc: Document, val reachSentences: Array[ReachSentence])
+    extends Document(reachSentences.asInstanceOf[Array[Sentence]]) {
+  this.id = doc.id
+  this.coreferenceChains = doc.coreferenceChains
+  this.text = doc.text
+
+  doc.getAttachmentKeys.foreach { key =>
+    this.addAttachment(key, doc.getAttachment(key).get)
+  }
+  doc.getDCT.foreach(this.setDCT)
+
+  def serialize(): Unit = ???
+}
+
+object ReachDocument {
+
+  def apply(doc: Document): ReachDocument = {
+    val reachSentences = doc.sentences.map(new ReachSentence(_))
+
+    new ReachDocument(doc, reachSentences)
+  }
+}

--- a/main/src/main/scala/org/clulab/reach/ReachSentence.scala
+++ b/main/src/main/scala/org/clulab/reach/ReachSentence.scala
@@ -1,0 +1,20 @@
+package org.clulab.reach
+
+import org.clulab.processors.Sentence
+
+// It would be really nice to have a copy constructor for Sentence!
+class ReachSentence(sentence: Sentence, var sections: Option[Array[String]] = None) extends Sentence(
+  sentence.raw,
+  sentence.startOffsets,
+  sentence.endOffsets,
+  sentence.words
+) {
+  this.tags = sentence.tags
+  this.lemmas = sentence.lemmas
+  this.entities = sentence.entities
+  this.norms = sentence.norms
+  this.chunks = sentence.chunks
+  this.syntacticTree = sentence.syntacticTree
+  this.graphs = sentence.graphs
+  this.relations = sentence.relations
+}

--- a/main/src/main/scala/org/clulab/reach/ReachSystem.scala
+++ b/main/src/main/scala/org/clulab/reach/ReachSystem.scala
@@ -59,7 +59,8 @@ class ReachSystem(
     // note that this messes with the character offsets in the text...
     val preprocessedText = textPreProc.preprocessText(text)
     // annotate() now preserves chatracter offsets in text, but it is too late due to preprocessText() above
-    val doc = procAnnotator.annotate(text, keepText = true)
+    val doc = ReachDocument(procAnnotator.annotate(text, keepText = true))
+
     val id = if (chunkId.isEmpty) docId else s"${docId}_${chunkId}"
     doc.id = Some(id)
     // If section names are given, add them to the doc object
@@ -68,7 +69,7 @@ class ReachSystem(
         // Order the intervals
         val sectionIntervals = sectionNames.keys.toSeq.sorted
         // Iterate through each sentence to get its section name
-        doc.sentences foreach {
+        doc.reachSentences foreach {
           sent =>
             val interval = Interval.open(sent.startOffsets.head, sent.endOffsets.last)
             val containingInterval = sectionIntervals.filter(si => si.intersects(interval))

--- a/processors/build.sbt
+++ b/processors/build.sbt
@@ -5,7 +5,7 @@ resolvers += ("Artifactory" at "http://artifactory.cs.arizona.edu:8081/artifacto
 
 
 libraryDependencies ++= {
-  val procVer = "8.5.0-SNAPSHOT"//"8.3.3"
+  val procVer = "8.5.0"//"8.3.3"
 
   Seq(
     "com.typesafe"         %  "config"      % "1.3.1",


### PR DESCRIPTION
Convert the Document to a ReachDocument wherever necessary, namely, whenever the section will need to be accessed.