### PR TITLE
Use HashCode from processors

### DIFF
--- a/assembly/src/main/scala/org/clulab/reach/assembly/representations/Complex.scala
+++ b/assembly/src/main/scala/org/clulab/reach/assembly/representations/Complex.scala
@@ -3,7 +3,7 @@ package org.clulab.reach.assembly.representations
 import org.clulab.odin.Mention
 import org.clulab.reach.assembly.AssemblyManager
 import org.clulab.reach.assembly._
-import scala.util.hashing.MurmurHash3._
+import org.clulab.utils.Hash
 
 
 /**
@@ -58,10 +58,12 @@ class Complex(
    * @return an Int hash based on the [[Entity.equivalenceHash]] of each member
    */
   def membersHash(ignoreMods: Boolean): Int = {
-    val h0 = stringHash(s"$eerString.members")
     val hs = members.map(_.equivalenceHash(ignoreMods))
-    val h = mixLast(h0, unorderedHash(hs))
-    finalizeHash(h, members.size)
+
+    Hash.withLast(members.size)(
+      Hash(s"$eerString.members"),
+      Hash.unordered(hs)
+    )
   }
 
   /**
@@ -69,16 +71,11 @@ class Complex(
    * @param ignoreMods whether or not to ignore modifications when calculating the equivalenceHash
    * @return a hash (Int) based primarily on the [[membersHash]]
    */
-  def equivalenceHash(ignoreMods: Boolean): Int = {
-    // the seed (not counted in the length of finalizeHash)
-    // decided to use the class name
-    val h0 = stringHash(eerString)
-    // comprised of the equiv. hash of members
-    val h1 = mix(h0, membersHash(ignoreMods))
-    // whether or not the representation is negated
-    val h2 = mixLast(h1, negated.hashCode)
-    finalizeHash(h2, 2)
-  }
+  def equivalenceHash(ignoreMods: Boolean): Int = Hash.withLast(
+    Hash(eerString),
+    membersHash(ignoreMods),
+    negated.hashCode
+  )
 
   /**
    * Used to compare against another [[Complex]]. <br>

--- a/assembly/src/test/scala/org/clulab/reach/assembly/TestAssemblyManager.scala
+++ b/assembly/src/test/scala/org/clulab/reach/assembly/TestAssemblyManager.scala
@@ -39,6 +39,8 @@ class TestAssemblyManager extends FlatSpec with Matchers {
     val se = am.getSimpleEntity(ras)
 
     se.getPTMs should have size(0)
+    se.equivalenceHash(ignoreMods = false) should be (-1879068248) // SimpleEntity
+    se.equivalenceHash(ignoreMods = true) should be (-11559465) // SimpleEntity
   }
 
   it should "have 3 mentions as evidence" in {
@@ -87,6 +89,8 @@ class TestAssemblyManager extends FlatSpec with Matchers {
     val phos = am.getSimpleEvent(p)
 
     phos.evidence should have size(1)
+    phos.equivalenceHash(ignoreMods = true) should be (-90854158) // SimpleEvent
+    phos.equivalenceHash(ignoreMods = false) should be (-24500179) // SimpleEvent
 
     phos.output should have size(1)
 
@@ -157,6 +161,8 @@ class TestAssemblyManager extends FlatSpec with Matchers {
     val (c1, c2) = (complexes.head, complexes.last)
     c1.isEquivalentTo(c2, ignoreMods = false) should be(true)
     c1.isEquivalentTo(c2, ignoreMods = true) should be(true)
+    c1.equivalenceHash(ignoreMods = false) should be (-1357391490) // Complex
+    c1.equivalenceHash(ignoreMods = true) should be (686730731) // Complex
   }
 
   it should "have 2 mentions as evidence" in {
@@ -226,6 +232,8 @@ class TestAssemblyManager extends FlatSpec with Matchers {
 
     am.getRegulations should have size (1)
     am.distinctRegulations should have size (1)
+    am.getRegulations.head.equivalenceHash(ignoreMods = false) should be (832895248) // ComplexEvent
+    am.getRegulations.head.equivalenceHash(ignoreMods = true) should be (738272956) // ComplexEvent
   }
 
   val regText2 = "Akt inhibits the phosphorylation of AFT by BEF."

--- a/assembly/src/test/scala/org/clulab/reach/assembly/TestHash.scala
+++ b/assembly/src/test/scala/org/clulab/reach/assembly/TestHash.scala
@@ -1,0 +1,30 @@
+package org.clulab.reach.assembly
+
+import org.clulab.reach.PaperReader
+import org.clulab.reach.assembly.relations.corpus.EventPair
+import org.clulab.reach.mentions.CorefMention
+import org.clulab.reach.utils.MentionManager
+import org.scalatest.{FlatSpec, Matchers}
+
+class TestHash  extends FlatSpec with Matchers {
+  val mentionManager = new MentionManager()
+  val testReach = PaperReader.reachSystem
+  val text = "Tbet Rag2 mice (Garrett et al., 2010) as well as Bacteroides spp. (Bloom et al., 2011), Helicobacter spp. (Fox et al., 2011), and Bilophila wadsworthia (Devkota et al., 2012) in Il10 have been shown to enhance intestinal inflammation.The acute dextran sulfate sodium"
+  val allMentions = testReach.extractFrom(text, "serialization-test", "1", None)
+  val sortedMentions = allMentions.sortBy { mention => (mention.startOffset, mention.endOffset) }
+
+  val assemblyManager = AssemblyManager()
+
+  behavior of "Hash"
+
+  it should "compute the expected value for an EventPair" in {
+    val expectedHash = 316669350
+    val corefMentions = sortedMentions.collect { case corefMention: CorefMention => corefMention }
+    val e1 = corefMentions.head
+    val e2 = corefMentions.last
+    val eventPair = new EventPair(e1, e2, "relation", 42d, "annotatorID", None)
+    val actualHash = eventPair.equivalenceHash
+
+    actualHash should be (expectedHash)
+  }
+}

--- a/main/src/main/scala/org/clulab/reach/grounding/InMemoryKB.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/InMemoryKB.scala
@@ -1,15 +1,15 @@
 package org.clulab.reach.grounding
 
 import scala.Serializable
-import scala.util.hashing.MurmurHash3._
 import collection.mutable.{ HashMap, HashSet, Map, MultiMap, Set }
 
+import org.clulab.reach.grounding.InMemoryKB._
 import org.clulab.reach.grounding.ReachKBConstants._
 import org.clulab.reach.grounding.ReachKBKeyTransforms._
 import org.clulab.reach.grounding.ReachKBUtils._
 import org.clulab.reach.grounding.Speciated._
+import org.clulab.utils.Hash
 
-import org.clulab.reach.grounding.InMemoryKB._
 
 /**
   * Class implementing an in-memory knowledge base indexed by key and species.
@@ -243,14 +243,13 @@ object InMemoryKB {
     }
 
     /** Redefine hashCode. */
-    override def hashCode: Int = {
-      val h0 = stringHash("org.clulab.reach.grounding.KBEntry")
-      val h1 = mix(h0, text.toLowerCase.hashCode)
-      val h2 = mix(h1, namespace.hashCode)
-      val h3 = mix(h2, id.hashCode)
-      val h4 = mixLast(h3, species.hashCode)
-      finalizeHash(h4, 4)
-    }
+    override def hashCode: Int = Hash.withLast(
+      Hash("org.clulab.reach.grounding.KBEntry"),
+      text.toLowerCase.hashCode,
+      namespace.hashCode,
+      id.hashCode,
+      species.hashCode
+    )
 
     /** Tell whether this entry has an associated species or not. */
     def hasSpecies: Boolean = (species != NoSpeciesValue)

--- a/main/src/main/scala/org/clulab/reach/grounding/InMemoryKB.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/InMemoryKB.scala
@@ -211,7 +211,7 @@ object InMemoryKB {
     *   Written by: Tom Hicks. 10/25/2015.
     *   Last Modified: Limit the scope of the KBEntry class by embedding it in IMKB.
     */
-  private class KBEntry (
+  class KBEntry (
 
     /** Text for this entry, loaded from the external KB. */
     val text: String,

--- a/main/src/main/scala/org/clulab/reach/grounding/KBResolution.scala
+++ b/main/src/main/scala/org/clulab/reach/grounding/KBResolution.scala
@@ -1,10 +1,12 @@
 package org.clulab.reach.grounding
 
-import scala.Serializable
-import scala.util.hashing.MurmurHash3._
-
+import org.clulab.utils.Hash
+import org.clulab.reach.context.BoundedPaddingContext.species
 import org.clulab.reach.grounding.ReachKBConstants._
 import org.clulab.reach.grounding.Speciated._
+import org.clulab.utils.Hash
+
+import scala.Serializable
 
 /**
   * Class holding information about a specific resolution from the in-memory Knowledge Base.
@@ -46,14 +48,13 @@ class KBResolution (
   }
 
   /** Redefine hashCode. */
-  override def hashCode: Int = {
-    val h0 = stringHash("org.clulab.reach.grounding.KBResolution")
-    val h1 = mix(h0, text.toLowerCase.hashCode)
-    val h2 = mix(h1, namespace.hashCode)
-    val h3 = mix(h2, id.hashCode)
-    val h4 = mixLast(h3, species.hashCode)
-    finalizeHash(h4, 4)
-  }
+  override def hashCode: Int = Hash.withLast(
+    Hash("org.clulab.reach.grounding.KBResolution"),
+    text.toLowerCase.hashCode,
+    namespace.hashCode,
+    id.hashCode,
+    species.hashCode
+  )
 
   /** Tell whether this entry has an associated species or not. */
   def hasSpecies: Boolean = (species != NoSpeciesValue)

--- a/main/src/main/scala/org/clulab/reach/utils/MentionManager.scala
+++ b/main/src/main/scala/org/clulab/reach/utils/MentionManager.scala
@@ -82,7 +82,7 @@ class MentionManager {
   // Private Methods
   //
 
-  private def computeHash (mention:Mention): Int = {
+  def computeHash(mention: Mention): Int = {
     // val hash = computeHash(mention, symmetricSeed)
     // return finalize(hash)
     computeHash(mention, symmetricSeed)

--- a/main/src/test/scala/org/clulab/reach/TestHash.scala
+++ b/main/src/test/scala/org/clulab/reach/TestHash.scala
@@ -1,0 +1,45 @@
+package org.clulab.reach
+
+import org.clulab.reach.grounding.InMemoryKB.KBEntry
+import org.clulab.reach.grounding.{InMemoryKB, KBResolution}
+import org.clulab.reach.utils.MentionManager
+import org.scalatest.{FlatSpec, Matchers}
+
+class TestHash  extends FlatSpec with Matchers {
+  val mentionManager = new MentionManager()
+  val testReach = PaperReader.reachSystem
+  val text1 = "Mek was not phosphorylized by AKT1"
+  val text2 = "Mouse AKT2 phosphorylates PTHR2 in chicken adenoid."
+  val text3 = "Tbet Rag2 mice (Garrett et al., 2010) as well as Bacteroides spp. (Bloom et al., 2011), Helicobacter spp. (Fox et al., 2011), and Bilophila wadsworthia (Devkota et al., 2012) in Il10 have been shown to enhance intestinal inflammation.The acute dextran sulfate sodium"
+  val allTexts = Seq(text1, text2, text3)
+  val sortedMentions = allTexts.flatMap { text =>
+    val mentions = testReach.extractFrom(text, "serialization-test", "1", None)
+
+    mentions.sortBy { mention => (mention.startOffset, mention.endOffset) }
+  }
+
+  behavior of "Hash"
+
+  it should "compute the expected value for a Mention" in {
+    val expectedHashes = Array(27986141, -396507223, 1590560579, -1891512069, -914654348, 408527033, -1487373899, -2017652764, 1558808406, 2017209834, -1279750485, -37832763, 200095485, 2020390684, 1876313014, 795103862, 220919393)
+    val actualHashes = sortedMentions.map(mentionManager.computeHash)
+
+    actualHashes should be (expectedHashes)
+  }
+
+  it should "compute the expected value for a KBResolution" in {
+    val expectedHash = 1782466108
+    val kbResolution = new KBResolution("text", "namespace", "id", "species")
+    val actualHash = kbResolution.hashCode
+
+    actualHash should be (expectedHash)
+  }
+
+  it should "compute the expected value for a KBEntry" in {
+    val expectedHash = 578280303
+    val kbEntry = new KBEntry("text", "namespace", "id", "species")
+    val actualHash = kbEntry.hashCode
+
+    actualHash should be (expectedHash)
+  }
+}

--- a/processors/build.sbt
+++ b/processors/build.sbt
@@ -5,7 +5,7 @@ resolvers += "clulab" at "https://artifactory.clulab.org/artifactory/sbt-release
 
 
 libraryDependencies ++= {
-  val procVer = "8.5.3"
+  val procVer = "8.5.4-SNAPSHOT"
 
   Seq(
     "com.typesafe"         %  "config"      % "1.3.1",

--- a/processors/src/main/scala/org/clulab/processors/bionlp/ner/ReachStandardKbSource.scala
+++ b/processors/src/main/scala/org/clulab/processors/bionlp/ner/ReachStandardKbSource.scala
@@ -6,6 +6,7 @@ import org.clulab.processors.bionlp.ner.KBGenerator.logger
 import org.clulab.processors.bionlp.ner.KBGenerator.tokenizeResourceLine
 import org.clulab.processors.clu.tokenizer.Tokenizer
 import org.clulab.sequences.StandardKbSource
+import org.clulab.utils.Closer.AutoCloser
 import org.clulab.utils.Files
 import org.clulab.utils.Serializer
 
@@ -54,7 +55,7 @@ class ReachSingleStandardKbSource(kbEntry: KBEntry, caseInsensitiveMatching: Boo
         )
       )
 
-    Serializer.using(bufferedReader) { bufferedReader =>
+    bufferedReader.autoClose { bufferedReader =>
       bufferedReader.lines.forEach(consumer)
     }
     logger.info(s"Done. Read ${consumer.lineCount} lines from ${new File(kbEntry.path).getName}")


### PR DESCRIPTION
This is a draft because it depends on a SNAPSHOT version of processors.
Don't hand-code the hash codes each time, but borrow functionality from processors.  We'll want to clean up the hash codes in a different pass.