### PR TITLE
Add bioresources to build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ lazy val commonSettings = Seq(
 
 lazy val root = (project in file("."))
   .settings(commonSettings: _*)
-  .aggregate(processors, main, causalAssembly, export)
+  .aggregate(processors, main, causalAssembly, export, bioresources)
   .dependsOn(main % "test->test;compile", causalAssembly, export) // so that we can import from the console
   .settings(
     name := "reach-exe",


### PR DESCRIPTION
This PR makes a small change to build.sbt which allows bioresources to be made available when doing `publishLocal`. This is necessary for #802.