### PR TITLE
Bumped SBT's minor version to make it compatible with the latest Mac

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0
+sbt.version=1.4.9


### PR DESCRIPTION
This change to SBT's declared version fixes an incompatibility with the latest version of MacOS in Apple Silicon. I open this PR for your consideration.